### PR TITLE
Adding VM Download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,8 @@
 		<a id="welcome-to-github-pages" class="anchor" href="#welcome-to-github-pages" aria-hidden="true"><span class="octicon octicon-link"></span></a>Java Application API</h3>
 	      
 	      <p>The Java Application API enables a developer to create streaming applications entirely in Java for IBM Streams. The API employs a functional style of programming -- a developer may define a graph's flow and data manipulation simultaneously.
-      <p>Please refer to the <a href="gettingstarted.html">getting started guide</a>, <a href="FAQ.html">FAQ</a> page, and <a href="doc.html">documentation</a> for help.</p>
+          <p>Please refer to the <a href="gettingstarted.html">getting started guide</a>, <a href="FAQ.html">FAQ</a> page, and <a href="doc.html">documentation</a> for help.</p>
+      
 	      	<h3>Java Application API Quick Start VM</h3>
 	      
 	      <p>Get started now by downloading the free <a href="https://www-01.ibm.com/marketing/iwm/iwm/web/preLogin.do?source=swg-ibmistvi">Java Application API Quick Start VMware image</a>. Then follow the <a href="gettingstarted.html">getting started guide</a>.</p>      

--- a/index.html
+++ b/index.html
@@ -25,7 +25,9 @@
 	      
 	      <p>The Java Application API enables a developer to create streaming applications entirely in Java for IBM Streams. The API employs a functional style of programming -- a developer may define a graph's flow and data manipulation simultaneously.
       <p>Please refer to the <a href="gettingstarted.html">getting started guide</a>, <a href="FAQ.html">FAQ</a> page, and <a href="doc.html">documentation</a> for help.</p>
-	      	      
+	      	<h3>Java Application API Quick Start VM</h3>
+	      
+	      <p>Get started now by downloading the free <a href="https://www-01.ibm.com/marketing/iwm/iwm/web/preLogin.do?source=swg-ibmistvi">Java Application API Quick Start VMware image</a>. Then follow the <a href="gettingstarted.html">getting started guide</a>.</p>      
 	    </section>
 	    
 	    


### PR DESCRIPTION
Adding VMware Image Download link directly to landing page for Java Application API project. For now, this points to the form people need to fill out to begin downloading. If our pages change, this link may need to be updated. This is per Joanna's request. Thanks! 