### PR TITLE
Handle streams of XML, Blob as native SPL streams

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology/types.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology/types.spl
@@ -1,0 +1,49 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+namespace com.ibm.streamsx.topology;
+
+/**
+* Tuple type for representing JSON in SPL.
+*/
+type Json = rstring jsonString;
+
+/**
+* Tuple type representing string tuples published
+* by an application from the Java Application API.
+* Using this schema in an SPL application with
+* [com.ibm.streamsx.topology.topic::Publish]
+* and [com.ibm.streamsx.topology.topic::Subscribe]
+* allows exchange of tuples between SPL and Java.
+* 
+* Any Java stream of type `TStream&lt;String>`
+* published by a Java application will have this schema.
+*/
+type String = rstring __spl_js;
+
+/**
+* Tuple type representing XML tuples published
+* by an application from the Java Application API.
+* Using this schema in an SPL application with
+* [com.ibm.streamsx.topology.topic::Publish]
+* and [com.ibm.streamsx.topology.topic::Subscribe]
+* allows exchange of tuples between SPL and Java.
+* 
+* Any Java stream of type `TStream&lt;com.ibm.streams.operator.types.XML>`
+* published by a Java application will have this schema.
+*/
+type XML = xml __spl_jx;
+
+/**
+* Tuple type representing Blob tuples published
+* by an application from the Java Application API.
+* Using this schema in an SPL application with
+* [com.ibm.streamsx.topology.topic::Publish]
+* and [com.ibm.streamsx.topology.topic::Subscribe]
+* allows exchange of tuples between SPL and Java.
+* 
+* Any Java stream of type `TStream&lt;com.ibm.streams.operator.types.Blob>`
+* published by a Java application will have this schema.
+*/
+type Blob = blob __spl_jb;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology/types.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology/types.spl
@@ -17,7 +17,7 @@ type Json = rstring jsonString;
 * and [com.ibm.streamsx.topology.topic::Subscribe]
 * allows exchange of tuples between SPL and Java.
 * 
-* Any Java stream of type `TStream&lt;String>`
+* Any Java stream of type `TStream<String>`
 * published by a Java application will have this schema.
 */
 type String = rstring __spl_js;
@@ -30,7 +30,7 @@ type String = rstring __spl_js;
 * and [com.ibm.streamsx.topology.topic::Subscribe]
 * allows exchange of tuples between SPL and Java.
 * 
-* Any Java stream of type `TStream&lt;com.ibm.streams.operator.types.XML>`
+* Any Java stream of type `TStream<com.ibm.streams.operator.types.XML>`
 * published by a Java application will have this schema.
 */
 type XML = xml __spl_jx;
@@ -43,7 +43,7 @@ type XML = xml __spl_jx;
 * and [com.ibm.streamsx.topology.topic::Subscribe]
 * allows exchange of tuples between SPL and Java.
 * 
-* Any Java stream of type `TStream&lt;com.ibm.streams.operator.types.Blob>`
+* Any Java stream of type `TStream<com.ibm.streams.operator.types.Blob>`
 * published by a Java application will have this schema.
 */
 type Blob = blob __spl_jb;

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/BlobMapping.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/BlobMapping.java
@@ -1,0 +1,33 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.internal.spljava;
+
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streams.operator.types.Blob;
+
+/**
+ * SPL tuple for a TStream<Blob> Uses the SPL schema Schemas.BLOB.
+ * 
+ */
+class BlobMapping extends SPLMapping<Blob> {
+
+    // Singleton, as stateless.
+    BlobMapping() {
+        super(Schemas.BLOB, Blob.class);
+    }
+
+    @Override
+    public Tuple convertTo(Blob tuple) {
+        if (tuple.getLength() == 0)
+            return getSchema().getTuple();
+
+        return getSchema().getTuple(new Object[] { tuple });
+    }
+
+    @Override
+    public Blob convertFrom(Tuple tuple) {
+        return tuple.getBlob(0);
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/SPLMapping.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/SPLMapping.java
@@ -17,6 +17,8 @@ import com.ibm.streams.operator.Tuple;
 public abstract class SPLMapping<T> {
 
     static final StringMapping JavaString = new StringMapping();
+    static final BlobMapping JavaBlob = new BlobMapping();
+    static final XMLMapping JavaXML = new XMLMapping();
 
     private final StreamSchema schema;
     private final Class<T> tupleClass;

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/Schemas.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/Schemas.java
@@ -9,19 +9,24 @@ import static com.ibm.streams.operator.Type.Factory.getStreamSchema;
 import com.ibm.streams.operator.Attribute;
 import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streams.operator.Type;
+import com.ibm.streams.operator.types.Blob;
+import com.ibm.streams.operator.types.XML;
 
 public class Schemas {
 
     public static final StreamSchema STRING = getStreamSchema("tuple<rstring __spl_js>");
-
-    public static final StreamSchema INT32 = getStreamSchema("tuple<int32 __spl_ji>");
-
-    public static final StreamSchema INT64 = getStreamSchema("tuple<int64 __spl_jl>");
+    public static final StreamSchema BLOB = getStreamSchema("tuple<blob __spl_jb>");
+    public static final StreamSchema XML = getStreamSchema("tuple<xml __spl_jx>");
+    
 
     public StreamSchema getSPLSchema(Class<?> tupleClass) {
 
         if (String.class.equals(tupleClass))
             return STRING;
+        if (Blob.class.equals(tupleClass))
+            return BLOB;
+        if (XML.class.equals(tupleClass))
+            return XML;
 
         throw new IllegalArgumentException(tupleClass.getName());
     }
@@ -32,6 +37,12 @@ public class Schemas {
         if (String.class.equals(tupleClass)) {
             return (SPLMapping<T>) SPLMapping.JavaString;
         }
+        if (Blob.class.equals(tupleClass)) {
+            return (SPLMapping<T>) SPLMapping.JavaBlob;
+        }
+        if (XML.class.equals(tupleClass)) {
+            return (SPLMapping<T>) SPLMapping.JavaXML;
+        }
 
         return SPLJavaObject.createMappping(tupleClass);
     }
@@ -40,6 +51,12 @@ public class Schemas {
 
         if (STRING.equals(schema)) {
             return SPLMapping.JavaString;
+        }
+        if (BLOB.equals(schema)) {
+            return SPLMapping.JavaBlob;
+        }
+        if (XML.equals(schema)) {
+            return SPLMapping.JavaXML;
         }
 
         Attribute attr0 = schema.getAttribute(0);

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/XMLMapping.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/XMLMapping.java
@@ -1,0 +1,33 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.internal.spljava;
+
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streams.operator.types.XML;
+
+/**
+ * SPL tuple for a TStream<XML> Uses the SPL schema Schemas.XML.
+ * 
+ */
+class XMLMapping extends SPLMapping<XML> {
+
+    // Singleton, as stateless.
+    XMLMapping() {
+        super(Schemas.XML, XML.class);
+    }
+
+    @Override
+    public Tuple convertTo(XML tuple) {
+        if (tuple.isDefaultValue())
+            return getSchema().getTuple();
+
+        return getSchema().getTuple(new Object[] { tuple });
+    }
+
+    @Override
+    public XML convertFrom(Tuple tuple) {
+        return tuple.getXML(0);
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/json/JSONSchemas.java
+++ b/java/src/com/ibm/streamsx/topology/json/JSONSchemas.java
@@ -8,6 +8,10 @@ import static com.ibm.streams.operator.Type.Factory.getStreamSchema;
 
 import com.ibm.streams.operator.StreamSchema;
 
+/**
+ * SPL schema for JSON.
+ *
+ */
 public class JSONSchemas {
 
     private JSONSchemas() {

--- a/java/src/com/ibm/streamsx/topology/json/JSONSchemas.java
+++ b/java/src/com/ibm/streamsx/topology/json/JSONSchemas.java
@@ -14,8 +14,8 @@ public class JSONSchemas {
     }
 
     /**
-     * SPL schema used by Tuple&lt;String> streams. Consists of a single
-     * attribute of type {@code rstring __spl_js}.
+     * SPL schema used for JSON data. Consists of a single
+     * attribute of type {@code rstring jsonString}.
      */
     public static StreamSchema JSON = getStreamSchema("tuple<rstring jsonString>");
 }

--- a/java/src/com/ibm/streamsx/topology/json/JSONSchemas.java
+++ b/java/src/com/ibm/streamsx/topology/json/JSONSchemas.java
@@ -14,7 +14,7 @@ public class JSONSchemas {
     }
 
     /**
-     * SPL schema used for JSON data. Consists of a single
+     * SPL schema used for SPL streams with JSON data. Consists of a single
      * attribute of type {@code rstring jsonString}.
      */
     public static StreamSchema JSON = getStreamSchema("tuple<rstring jsonString>");

--- a/java/src/com/ibm/streamsx/topology/json/JSONStreams.java
+++ b/java/src/com/ibm/streamsx/topology/json/JSONStreams.java
@@ -122,7 +122,7 @@ public class JSONStreams {
     }
 
     /**
-     * Create a stream of JSON objects from a stream of serialized JSON tuples.
+     * Declare a stream of JSON objects from a stream of serialized JSON tuples.
      * If the serialized JSON is a simple value or an array,
      * then a JSON object is created, with
      * a single attribute {@code payload} containing the deserialized
@@ -136,9 +136,10 @@ public class JSONStreams {
     }
     
     /**
-     * Create 
-     * @param stream
-     * @return
+     * Declare a stream of JSON objects from a stream
+     * of Java objects that implement {@link JSONAble}.  
+     * @param stream Stream containing {@code JSONAble} tuples.
+     * @return Stream that will contain the JSON objects.
      */
     public static <T extends JSONAble> TStream<JSONObject> toJSON(TStream<T> stream) {
         return stream.transform(new ToJSON<T>(), JSONObject.class);

--- a/java/src/com/ibm/streamsx/topology/json/package-info.java
+++ b/java/src/com/ibm/streamsx/topology/json/package-info.java
@@ -3,9 +3,42 @@
 # Copyright IBM Corp. 2015  
  */
 /**
- * 
- * JSON related streams.
- *
+ * JSON streams.
+ * JSON (<a href="http://www.json.org/">JavaScript Object Notation</a>)
+ * is a lightweight data-interchange format that can be used to exchange
+ * streams between different languages.
+ * <h3>Java</h3>
+ * Within Java the recommended stream type for JSON data
+ * is {@code TStream<JSONObject>}.
+ * <BR>
+ * When a tuple is a JSON array
+ * the approach is to use an {@code JSONObject} with
+ * a single attribute {@link com.ibm.streamsx.topology.json.JSONStreams#PAYLOAD payload}
+ * containing the value (for example, an array of JSON objects}.
+ * <h3>SPL</h3>
+ * Within SPL the recommended stream type for JSON data
+ * is {@code tuple<rstring jsonString>}, representing
+ * serialized JSON.
+ * (see {@link com.ibm.streamsx.topology.json.JSONSchemas#JSON JSON}).
+ * This is the convention used by the SPL toolkits
+ * {@code com.ibm.streamsx.json} and {@code com.ibm.streamsx.inet}.
+ * <h3>Conversions</h3>
+ * <TABLE border="1">
+ * <TR><TH colspan="2"></TH><TH colspan="2">To</TH></TR>
+ * <TR><TH colspan="2">From</TH><TH>Java<BR>(TStream&lt;JSONObject>)</TH><TH>SPL<BR>({@code rstring jsonString})</TH></TR>
+ * <TR><TH rowspan="3">Java</TH><TD>TStream&lt;JSONObject></TD>
+ * <TD></TD><TD>{@link com.ibm.streamsx.topology.json.JSONStreams#toSPL(com.ibm.streamsx.topology.TStream) JSONStreams.toSPL()}</TD></TR>
+ * <TR><TD>TStream&lt;? extends JSONAble></TD>
+ * <TD>{@link com.ibm.streamsx.topology.json.JSONStreams#toJSON(com.ibm.streamsx.topology.TStream) JSONStreams.toJSON()}</TD>
+ * <TD></TD></TR>
+ * <TR><TD>TStream&lt;String></TD>
+ * <TD>{@link com.ibm.streamsx.topology.json.JSONStreams#deserialize(com.ibm.streamsx.topology.TStream) JSONStreams.deserialize()}</TD>
+ * <TD></TD></TR>
+ * <TR><TH rowspan="2">SPL</TH><TD>SPLStream ({@code rstring jsonString})</TD>
+ * <TD rowspan="2">{@link com.ibm.streamsx.topology.spl.SPLStream#toJSON() SPLStream.toJSON()} </TD><TD></TD>
+ * </TR>
+ * <TR><TD>SPLStream (any other schema)</TD><TD></TD></TR>
+ * </TABLE>
  */
 package com.ibm.streamsx.topology.json;
 

--- a/java/src/com/ibm/streamsx/topology/json/package-info.java
+++ b/java/src/com/ibm/streamsx/topology/json/package-info.java
@@ -23,7 +23,7 @@
  * This is the convention used by the SPL toolkits
  * {@code com.ibm.streamsx.json} and {@code com.ibm.streamsx.inet}.
  * <h3>Conversions</h3>
- * <TABLE border="1">
+ * <TABLE border="1" style="width:50%">
  * <TR><TH colspan="2"></TH><TH colspan="2">To</TH></TR>
  * <TR><TH colspan="2">From</TH><TH>Java<BR>(TStream&lt;JSONObject>)</TH><TH>SPL<BR>({@code rstring jsonString})</TH></TR>
  * <TR><TH rowspan="3">Java</TH><TD>TStream&lt;JSONObject></TD>

--- a/java/src/com/ibm/streamsx/topology/spl/SPLStream.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLStream.java
@@ -27,7 +27,23 @@ public interface SPLStream extends TStream<Tuple>, SPLInput {
 
     /**
      * Transform SPL tuples into JSON. Each tuple from this stream is converted
-     * into its JSON representation.
+     * into a JSON representation.
+     * <UL>
+     * <LI>
+     * If {@link #getSchema()} returns
+     * {@link com.ibm.streamsx.topology.json.JSONSchemas#JSON}
+     * then each tuple is taken as a serialized JSON and deserialized.
+     * If the serialized JSON is an array,
+     * then a JSON object is created, with
+     * a single attribute {@code payload} containing the deserialized
+     * value.
+     * </LI>
+     * <LI>
+     * Otherwise the tuple is converted to JSON using the
+     * encoding provided by the SPL Java Operator API
+     * {@code com.ibm.streams.operator.encoding.JSONEncoding}.
+     * </LI>
+     * </UL>
      * 
      * @return A stream with each tuple as a {@code JSONObject}.
      */

--- a/test/java/src/com/ibm/streamsx/topology/test/api/BlobTupleTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/BlobTupleTest.java
@@ -1,0 +1,44 @@
+package com.ibm.streamsx.topology.test.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.ibm.streams.operator.types.Blob;
+import com.ibm.streams.operator.types.ValueFactory;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.function7.Function;
+import com.ibm.streamsx.topology.test.TestTopology;
+
+@SuppressWarnings("serial")
+public class BlobTupleTest extends TestTopology {
+   
+    @Test
+    public void testConstant() throws Exception {
+        final Topology topology = new Topology();
+        String sdata = "YY" + BlobTupleTest.class.getName();
+        byte[] data = sdata.getBytes(StandardCharsets.UTF_8);
+        Blob blob = ValueFactory.newBlob(data, 0, data.length);
+        TStream<Blob> source = topology.constants(Collections.singletonList(blob), Blob.class);
+        assertNotNull(source);
+        assertEquals(Blob.class, source.getTupleClass());
+        
+        TStream<String> out = convertBlobToString(source);
+        completeAndValidate(out, 10,  sdata);
+    }
+
+    private static TStream<String> convertBlobToString(TStream<Blob> source) {
+        TStream<String> out = source.transform(new Function<Blob,String>() {
+
+            @Override
+            public String apply(Blob v) {
+                return new String(v.getData(), StandardCharsets.UTF_8);
+            }}, String.class);
+        return out;
+    }
+}

--- a/test/java/src/com/ibm/streamsx/topology/test/api/XMLTupleTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/XMLTupleTest.java
@@ -1,0 +1,66 @@
+package com.ibm.streamsx.topology.test.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.junit.Test;
+
+import com.ibm.streams.operator.types.ValueFactory;
+import com.ibm.streams.operator.types.XML;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.function7.Function;
+import com.ibm.streamsx.topology.test.TestTopology;
+
+@SuppressWarnings("serial")
+public class XMLTupleTest extends TestTopology {
+   
+    @Test
+    public void testConstant() throws Exception {
+        
+        final Topology topology = new Topology();
+        String sdata = "<book><title>Dracula</title><author>Bram Stoker</author></book>";
+        byte[] data = sdata.getBytes(StandardCharsets.UTF_8);
+        XML xml = ValueFactory.newXML(new ByteArrayInputStream(data));
+        TStream<XML> source = topology.constants(Collections.singletonList(xml), XML.class);
+        assertNotNull(source);
+        assertEquals(XML.class, source.getTupleClass());
+        
+        TStream<String> out = convertXMLToString(source);
+        completeAndValidate(out, 10,  sdata);
+    }
+
+    private static TStream<String> convertXMLToString(TStream<XML> source) {
+        TStream<String> out = source.transform(new Function<XML,String>() {
+
+            @Override
+            public String apply(XML v) {
+                
+                StreamSource ss = v.getStreamSource();
+                
+                try {
+                    Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+                    
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    
+                    transformer.transform(ss, new StreamResult(out));
+                    return new String(out.toByteArray(), StandardCharsets.UTF_8);
+                } catch (Exception e) {
+                    return null;
+                }
+            }}, String.class);
+        return out;
+    }
+}

--- a/test/java/src/com/ibm/streamsx/topology/test/json/JSONStreamsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/json/JSONStreamsTest.java
@@ -23,6 +23,7 @@ import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.function7.UnaryOperator;
+import com.ibm.streamsx.topology.json.JSONSchemas;
 import com.ibm.streamsx.topology.json.JSONStreams;
 import com.ibm.streamsx.topology.spl.SPLStream;
 import com.ibm.streamsx.topology.spl.SPLStreams;
@@ -166,4 +167,21 @@ public class JSONStreamsTest extends TestTopology {
 
         checkJsonOutput(jo, jsonString);
     }
+    
+    @Test
+    public void testJsonSPL() throws Exception {
+        final Topology t = new Topology();
+        TStream<String> example = t.strings(JSON_EXAMPLE);
+
+        TStream<JSONObject> json = JSONStreams.deserialize(example);
+        
+        SPLStream spl = JSONStreams.toSPL(json);
+        assertEquals(JSONSchemas.JSON, spl.getSchema());
+        
+        TStream<JSONObject> jsonFromSPL = spl.toJSON();      
+        TStream<String> jsonString = JSONStreams.serialize(jsonFromSPL);
+
+        checkJsonOutput(JSON.parse(JSON_EXAMPLE), jsonString);
+    }
+    
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/json/JSONStreamsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/json/JSONStreamsTest.java
@@ -8,12 +8,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import com.ibm.json.java.JSON;
+import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONArtifact;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streams.flow.handlers.MostRecent;
@@ -26,8 +28,12 @@ import com.ibm.streamsx.topology.spl.SPLStream;
 import com.ibm.streamsx.topology.spl.SPLStreams;
 import com.ibm.streamsx.topology.test.TestTopology;
 import com.ibm.streamsx.topology.tester.Condition;
+import com.ibm.streamsx.topology.tuple.JSONAble;
 
 public class JSONStreamsTest extends TestTopology {
+    
+    private static final String QUESTION =
+            "What is the answer to life, the universe & everything?";
 
     private static final String JSON_EXAMPLE = "{\"menu\": {\n"
             + "  \"id\": \"file\",\n" + "  \"value\": \"File\",\n"
@@ -73,8 +79,7 @@ public class JSONStreamsTest extends TestTopology {
         final Topology t = new Topology("SimpleJson");
 
         final JSONObject value = new JSONObject();
-        value.put("question",
-                "What is the answer to life, the universe & everything?");
+        value.put("question",QUESTION);
         TStream<JSONObject> s = t.constants(Collections.singletonList(value),
                 JSONObject.class);
 
@@ -85,7 +90,7 @@ public class JSONStreamsTest extends TestTopology {
 
         assertFalse(value.containsKey("answer"));
         JSONObject ev = new JSONObject();
-        ev.put("question", value.get("question"));
+        ev.put("question", QUESTION);
         ev.put("answer", 42l);
 
         checkJsonOutput(ev, JSONStreams.serialize(jsonm));
@@ -102,5 +107,63 @@ public class JSONStreamsTest extends TestTopology {
             }
         });
     }
+    
+    @Test
+    public void testJSONAble() throws IOException, Exception {
+        Topology topology = new Topology();
+        
+        final TestJSONAble value = new TestJSONAble(42,QUESTION);
+        TStream<TestJSONAble> s = topology.constants(
+                Collections.singletonList(value),
+                TestJSONAble.class);
 
+        TStream<JSONObject> js = JSONStreams.toJSON(s);
+        
+        JSONObject ev = new JSONObject();
+        ev.put("b", QUESTION);
+        ev.put("a", 42l);
+
+        checkJsonOutput(ev, JSONStreams.serialize(js));
+    }
+    
+    @SuppressWarnings("serial")
+    public static class TestJSONAble implements Serializable, JSONAble {
+        
+        private final int a;
+        private final String b;
+        
+        public TestJSONAble(int a, String b) {
+            this.a = a;
+            this.b = b;
+        }
+
+        @Override
+        public JSONObject toJSON() {
+            JSONObject jo = new JSONObject();
+            jo.put("a", a);
+            jo.put("b", b);
+            return jo;
+        }
+        
+    }
+    
+    /**
+     * Test that if the serialized value is
+     * an array, it ends up wrapped in an object.
+     */
+    @Test
+    public void testDeserializeArray() throws Exception {
+        final String data = "[ 100, 500, false, 200, 400 ]";
+        final Topology t = new Topology();
+        TStream<String> array = t.strings(data);
+
+        TStream<JSONObject> json = JSONStreams.deserialize(array);
+        TStream<String> jsonString = JSONStreams.serialize(json);
+        
+        JSONArray ja = (JSONArray) JSON.parse(data);
+        JSONObject jo = new JSONObject();
+        jo.put("payload", ja);
+
+        checkJsonOutput(jo, jsonString);
+    }
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/spl/SPLStreamsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/spl/SPLStreamsTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -26,7 +25,6 @@ import com.ibm.streamsx.topology.spl.SPLStream;
 import com.ibm.streamsx.topology.spl.SPLStreams;
 import com.ibm.streamsx.topology.streams.BeaconStreams;
 import com.ibm.streamsx.topology.test.TestTopology;
-import com.ibm.streamsx.topology.test.api.TopologyTest;
 import com.ibm.streamsx.topology.tester.Condition;
 import com.ibm.streamsx.topology.tester.Tester;
 
@@ -113,6 +111,25 @@ public class SPLStreamsTest extends TestTopology {
 
         completeAndValidate(iands, 10,  "n:465 s:325", "n:597 s:457",
                 "n:9465 s:9325");
+    }
+    
+    @Test
+    public void testConversionFromSPLToString() throws Exception {
+        final Topology topology = new Topology();
+        SPLStream splStream = testTupleStream(topology);
+        TStream<String> strings = SPLStreams.toStringStream(splStream);
+        assertEquals(String.class, strings.getTupleClass());
+
+        completeAndValidate(strings, 10,  "0", "1", "2", "3");
+    }
+    @Test
+    public void testConversionFromSPLToStringAttribute() throws Exception {
+        final Topology topology = new Topology();
+        SPLStream splStream = testTupleStream(topology);
+        TStream<String> strings = SPLStreams.toStringStream(splStream, "vl");
+        assertEquals(String.class, strings.getTupleClass());
+
+        completeAndValidate(strings, 10,  "34535", "43675232", "654932", "82343");
     }
 
     private static TStream<IntAndString> createStreamFromSPLStream(


### PR DESCRIPTION
This enables easy exchange between SPL and Java (and other languages) for these data types, as they are types that can represent a multi-valued tuple (e.g. next bus data is returned as XML).

Also more clarity on JSON streams.