### PR TITLE
Change SPL schema for Java objects to be fixed.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topicsjava.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topicsjava.spl
@@ -1,0 +1,50 @@
+namespace com.ibm.streamsx.topology.topic ;
+
+/**
+ * Publish a stream to a topic. Allows other IBM Streams
+ * applications to subscribe to the input stream, including
+ * those written in different languages.
+ * See [namespace:com.ibm.streamsx.topology.topic] for details.
+ * @input In Stream to be published as a topic.
+ * @param topic Topic to publish stream to.
+ * @exclude
+*/
+public composite PublishJava(input In )
+{
+	param
+		expression<rstring> $topic ;
+		expression<rstring> $class ;
+	graph
+		() as ExportTopic = Export(In)
+		{
+			param
+				properties : { __spl_exportType = "topic.java", __spl_topic = $topic, __spl_class = $class } ;
+		}
+}
+
+/**
+ * Subscribe to a topic.
+ * Generates a stream that is subscribed, through
+ * IBM Streams dynamic connections, to all streams
+ * published to the same `topic` and `streamType`.
+ * See [namespace:com.ibm.streamsx.topology.topic] for details.
+ 
+ * @output Topic Subscription to `topic`.
+ * @param topic Topic to subscribe to.
+ * @param streamType Type of output stream `Topic`.
+ * @exclude
+*/
+public composite SubscribeJava(output Topic )
+{
+	param		
+		expression<rstring> $topic ;
+		expression<rstring> $class ;
+		type $streamType ;
+	graph
+		stream<$streamType> Topic = Import()
+		{
+			param
+				subscription : __spl_exportType == "topic.java" && __spl_topic == $topic && __spl_class == $class ;
+		}
+
+}

--- a/java/src/com/ibm/streamsx/topology/Topology.java
+++ b/java/src/com/ibm/streamsx/topology/Topology.java
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streams.flow.declare.OperatorGraph;
+import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streams.operator.types.Blob;
 import com.ibm.streams.operator.types.XML;
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
@@ -38,7 +39,6 @@ import com.ibm.streamsx.topology.internal.logic.EndlessSupplier;
 import com.ibm.streamsx.topology.internal.logic.LimitedSupplier;
 import com.ibm.streamsx.topology.internal.logic.LogicUtils;
 import com.ibm.streamsx.topology.internal.logic.SingleToIterableSupplier;
-import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 import com.ibm.streamsx.topology.internal.spljava.Schemas;
 import com.ibm.streamsx.topology.internal.tester.TupleCollection;
 import com.ibm.streamsx.topology.json.JSONSchemas;
@@ -423,7 +423,7 @@ public class Topology implements TopologyElement {
             return json;
         }
         
-        SPLMapping<T> mapping = Schemas.getSPLMapping(tupleTypeClass);
+        StreamSchema mappingSchema = Schemas.getSPLMappingSchema(tupleTypeClass);
         
         SPLStream splImport;
         
@@ -432,18 +432,18 @@ public class Topology implements TopologyElement {
                 Blob.class.equals(tupleTypeClass) ||
                  XML.class.equals(tupleTypeClass)) {
             splImport = SPLStreams.subscribe(this, topic,
-                    mapping.getSchema());
+                    mappingSchema);
 
         } else {      
             Map<String, Object> params = new HashMap<>();
 
             params.put("topic", topic);
             params.put("class", tupleTypeClass.getName());
-            params.put("streamType", mapping.getSchema());
+            params.put("streamType", mappingSchema);
 
             splImport = SPL.invokeSource(this,
                     "com.ibm.streamsx.topology.topic::SubscribeJava", params,
-                    mapping.getSchema());
+                    mappingSchema);
         }
 
         return new StreamImpl<T>(this, splImport.output(), tupleTypeClass);

--- a/java/src/com/ibm/streamsx/topology/context/ContextProperties.java
+++ b/java/src/com/ibm/streamsx/topology/context/ContextProperties.java
@@ -50,4 +50,11 @@ public interface ContextProperties {
      * {@code com.ibm.streams.operator.logging.TraceLevel}.
      */
     String TRACING_LEVEL = "topology.tracing";
+    
+    /**
+     * Override IBM Streams install directory for
+     * bundle compilation, defaults to $STREAMS_INSTALL.
+     * Argument is a String.
+     */
+    String COMPILE_INSTALL_DIR = "topology.install.compile";
 }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -39,6 +39,12 @@ class OperatorGenerator {
 
     private static void noteAnnotations(JSONObject op, StringBuilder sb)
             throws IOException {
+        
+        sourceLocationNote(op, sb);
+        portTypesNote(op, sb);
+    }
+    
+    private static void sourceLocationNote(JSONObject op, StringBuilder sb) throws IOException {
         JSONArray ja = (JSONArray) op.get("sourcelocation");
         if (ja == null || ja.isEmpty())
             return;
@@ -50,6 +56,22 @@ class OperatorGenerator {
         String sourceInfo = jsource.serialize();
         SPLGenerator.stringLiteral(sb, sourceInfo);
         sb.append(")\n");
+    }
+    
+    private static void portTypesNote(JSONObject op, StringBuilder sb) {
+        JSONArray ja = (JSONArray) op.get("outputs");
+        if (ja == null || ja.isEmpty())
+            return;
+        for (int i = 0 ; i < ja.size(); i++) {
+            JSONObject output = (JSONObject) ja.get(i);
+            String type = (String) output.get("type.native");
+            if (type == null || type.isEmpty())
+                continue;
+            sb.append("@spl_note(id=\"__spl_nativeType_output_" + i + "\"");
+            sb.append(", text=");
+            SPLGenerator.stringLiteral(sb, type);
+            sb.append(")\n");
+        }
     }
 
     private static void parallelAnnotation(JSONObject op, StringBuilder sb) {

--- a/java/src/com/ibm/streamsx/topology/internal/context/BundleStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/BundleStreamsContext.java
@@ -64,7 +64,7 @@ public class BundleStreamsContext extends ToolkitStreamsContext {
         String namespace = (String) jsonApp.get("namespace");
         String name = (String) jsonApp.get("name");
 
-        InvokeSc sc = new InvokeSc(standalone, namespace, name, appDir);
+        InvokeSc sc = new InvokeSc(config, standalone, namespace, name, appDir);
         
         // Add the toolkits
         JSONObject graphConfig  = (JSONObject) jsonApp.get("config");

--- a/java/src/com/ibm/streamsx/topology/internal/core/JavaFunctional.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/JavaFunctional.java
@@ -88,6 +88,7 @@ public class JavaFunctional {
             BOperatorInvocation bop, Class<T> tupleTypeClass) {
         SPLMapping<T> mapping = Schemas.getSPLMapping(tupleTypeClass);
         BOutputPort bstream = bop.addOutput(mapping.getSchema());
+        bstream.json().put("type.native", tupleTypeClass.getName());
         addDependency(te, bop, tupleTypeClass);
         
         // If the stream is just a Java object as a blob

--- a/java/src/com/ibm/streamsx/topology/internal/core/JavaFunctional.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/JavaFunctional.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.ibm.streams.operator.Operator;
+import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.TopologyElement;
@@ -24,10 +25,7 @@ import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.builder.BOutput;
 import com.ibm.streamsx.topology.builder.BOutputPort;
 import com.ibm.streamsx.topology.internal.functional.ObjectUtils;
-import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 import com.ibm.streamsx.topology.internal.spljava.Schemas;
-import com.ibm.streamsx.topology.spl.SPLStream;
-import com.ibm.streamsx.topology.spl.SPLStreams;
 
 /**
  * Maintains the core core for building a topology of Java streams.
@@ -86,8 +84,8 @@ public class JavaFunctional {
      */
     public static <T> TStream<T> addJavaOutput(TopologyElement te,
             BOperatorInvocation bop, Class<T> tupleTypeClass) {
-        SPLMapping<T> mapping = Schemas.getSPLMapping(tupleTypeClass);
-        BOutputPort bstream = bop.addOutput(mapping.getSchema());
+        StreamSchema mappingSchema = Schemas.getSPLMappingSchema(tupleTypeClass);
+        BOutputPort bstream = bop.addOutput(mappingSchema);
         bstream.json().put("type.native", tupleTypeClass.getName());
         addDependency(te, bop, tupleTypeClass);
         
@@ -98,15 +96,6 @@ public class JavaFunctional {
         }
 
         return new StreamImpl<T>(te, bstream, tupleTypeClass);
-    }
-
-    public static <T> TStream<T> addSubscribeOperator(TopologyElement te,
-            String topic, Class<T> tupleTypeClass) {
-        SPLMapping<T> mapping = Schemas.getSPLMapping(tupleTypeClass);
-        @SuppressWarnings("unused")
-        SPLStream splImport = SPLStreams.subscribe(te, topic,
-                mapping.getSchema());
-        return null; // TODO
     }
 
     /**

--- a/java/src/com/ibm/streamsx/topology/internal/core/JavaFunctional.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/JavaFunctional.java
@@ -107,12 +107,6 @@ public class JavaFunctional {
         SPLStream splImport = SPLStreams.subscribe(te, topic,
                 mapping.getSchema());
         return null; // TODO
-        /*
-         * return new OutputPortStream<T>(bop, te, splImport.getPort(),
-         * tupleTypeClass); return GraphUtils.portToStream(this,
-         * splImport.getPort(), tupleTypeClass);
-         */
-
     }
 
     /**

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionAggregate.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionAggregate.java
@@ -15,7 +15,7 @@ import com.ibm.streamsx.topology.internal.functional.window.PeriodicAggregator;
 
 @PrimitiveOperator
 @Icons(location16 = "opt/icons/aggregate_16.gif", location32 = "opt/icons/aggregate_32.gif")
-public class FunctionAggregate<T, A> extends FunctionWindow<T> {
+public class FunctionAggregate<T, A> extends FunctionWindow {
     @Override
     void createWindowListener(StreamWindow<Tuple> window)
             throws ClassNotFoundException {

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionConvertToSPL.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionConvertToSPL.java
@@ -23,10 +23,10 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 @InputPortSet(cardinality = 1)
 @OutputPortSet(cardinality = 1)
 @Icons(location16 = "opt/icons/functor_16.gif", location32 = "opt/icons/functor_32.gif")
-public class FunctionConvertToSPL<T> extends FunctionFunctor {
+public class FunctionConvertToSPL extends FunctionFunctor {
 
-    private BiFunction<T, OutputTuple, OutputTuple> convert;
-    private SPLMapping<T> inputMapping;
+    private BiFunction<Object, OutputTuple, OutputTuple> convert;
+    private SPLMapping<Object> inputMapping;
     private StreamingOutput<OutputTuple> output;
 
     @Override
@@ -42,7 +42,7 @@ public class FunctionConvertToSPL<T> extends FunctionFunctor {
     @Override
     public void process(StreamingInput<Tuple> stream, Tuple tuple)
             throws Exception {
-        T value = inputMapping.convertFrom(tuple);
+        Object value = inputMapping.convertFrom(tuple);
         OutputTuple outTuple = output.newTuple();
         synchronized (convert) {
             outTuple = convert.apply(value, outTuple);

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionFilter.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionFilter.java
@@ -23,10 +23,10 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 @InputPortSet(cardinality = 1)
 @OutputPortSet(cardinality = 1)
 @Icons(location16 = "opt/icons/filter_16.gif", location32 = "opt/icons/filter_32.gif")
-public class FunctionFilter<T> extends FunctionFunctor {
+public class FunctionFilter extends FunctionFunctor {
 
-    private Predicate<T> filter;
-    private SPLMapping<T> mapping;
+    private Predicate<Object> filter;
+    private SPLMapping<?> mapping;
     private StreamingOutput<OutputTuple> passed;
 
     @Override
@@ -42,7 +42,7 @@ public class FunctionFilter<T> extends FunctionFunctor {
     @Override
     public void process(StreamingInput<Tuple> stream, Tuple tuple)
             throws Exception {
-        T value = mapping.convertFrom(tuple);
+        Object value = mapping.convertFrom(tuple);
 
         boolean submitTuple;
         synchronized (filter) {
@@ -51,6 +51,4 @@ public class FunctionFilter<T> extends FunctionFunctor {
         if (submitTuple)
             passed.submit(tuple);
     }
-    
-    
 }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionJoin.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionJoin.java
@@ -20,14 +20,14 @@ import com.ibm.streamsx.topology.internal.functional.window.SlidingJoin;
         @InputPortSet(cardinality = 1, windowingMode = WindowMode.Windowed),
         @InputPortSet(cardinality = 1) })
 @Icons(location16 = "opt/icons/join_16.gif", location32 = "opt/icons/join_32.gif")
-public class FunctionJoin<T, U, J> extends FunctionWindow<T> {
-    private SlidingJoin<T, U, J> joiner;
+public class FunctionJoin extends FunctionWindow {
+    private SlidingJoin<Object, Object, Object> joiner;
 
     @Override
     void createWindowListener(StreamWindow<Tuple> window)
             throws ClassNotFoundException {
-        joiner = window.isPartitioned() ? new PartitionedSlidingJoin<T, U, J>(
-                this, window) : new SlidingJoin<T, U, J>(this, window);
+        joiner = window.isPartitioned() ? new PartitionedSlidingJoin<Object, Object, Object>(
+                this, window) : new SlidingJoin<Object, Object, Object>(this, window);
     }
 
     /**

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionMultiTransform.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionMultiTransform.java
@@ -22,10 +22,10 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 @InputPortSet(cardinality = 1)
 @OutputPortSet(cardinality = 1)
 @Icons(location16 = "opt/icons/functor_16.gif", location32 = "opt/icons/functor_32.gif")
-public class FunctionMultiTransform<T, U> extends FunctionQueueableFunctor<T> {
+public class FunctionMultiTransform extends FunctionQueueableFunctor {
 
-    private Function<T, Iterable<U>> transform;
-    private SPLMapping<U> outputMapping;
+    private Function<Object, Iterable<Object>> transform;
+    private SPLMapping<Object> outputMapping;
     private StreamingOutput<OutputTuple> output;
 
     @Override
@@ -39,14 +39,14 @@ public class FunctionMultiTransform<T, U> extends FunctionQueueableFunctor<T> {
     }
 
     @Override
-    public void tuple(T tuple)
+    public void tuple(Object tuple)
             throws Exception {
-        Iterable<U> modValues;
+        Iterable<Object> modValues;
         synchronized (transform) {
             modValues = transform.apply(tuple);
         }
         if (modValues != null) {
-            for (U modValue : modValues) {
+            for (Object modValue : modValues) {
                 if (modValue != null)
                     output.submit(outputMapping.convertTo(modValue));
             }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionPeriodicSource.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionPeriodicSource.java
@@ -22,10 +22,10 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 @PrimitiveOperator
 @OutputPortSet(cardinality = 1)
 @SharedLoader
-public class FunctionPeriodicSource<T> extends PollingTupleProducer implements Functional {
+public class FunctionPeriodicSource extends PollingTupleProducer implements Functional {
 
-    private Supplier<Iterable<T>> data;
-    private SPLMapping<T> mapping;
+    private Supplier<Iterable<Object>> data;
+    private SPLMapping<Object> mapping;
 
     private String functionalLogic;
     private String[] jar;
@@ -64,7 +64,7 @@ public class FunctionPeriodicSource<T> extends PollingTupleProducer implements F
     @Override
     protected void fetchTuples() throws Exception {
 
-        for (T tuple : data.get()) {
+        for (Object tuple : data.get()) {
             if (Thread.interrupted())
                 return;
             if (tuple == null)

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionQueueableFunctor.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionQueueableFunctor.java
@@ -18,12 +18,12 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
  * The input port is not connected to a PE port. In this case
  * there is already a thread for the processing.
  */
-abstract class FunctionQueueableFunctor<T> extends FunctionFunctor implements StreamHandler<T> {
+abstract class FunctionQueueableFunctor extends FunctionFunctor implements StreamHandler<Object> {
     
     private int queueSize;
     
-    private SPLMapping<T> inputMapping;
-    private StreamHandler<T> handler;
+    private SPLMapping<?> inputMapping;
+    private StreamHandler<Object> handler;
     
     @Override
     public synchronized void initialize(OperatorContext context)
@@ -33,13 +33,13 @@ abstract class FunctionQueueableFunctor<T> extends FunctionFunctor implements St
         if (getQueueSize() <=0 || getInput(0).isConnectedToPEPort())
             handler = this; // not queued
         else
-            handler = new FunctionalQueue<T>(context, getQueueSize(), this);
+            handler = new FunctionalQueue<Object>(context, getQueueSize(), this);
     }
     
     @Override
     public final void process(StreamingInput<Tuple> stream, Tuple tuple)
             throws Exception {
-        T value = inputMapping.convertFrom(tuple);
+        Object value = inputMapping.convertFrom(tuple);
         handler.tuple(value);
     }
     

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionSink.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionSink.java
@@ -17,9 +17,9 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 
 @PrimitiveOperator
 @InputPortSet(cardinality = 1)
-public class FunctionSink<T> extends FunctionFunctor {
-    private Consumer<T> sinker;
-    private SPLMapping<T> mapping;
+public class FunctionSink extends FunctionFunctor {
+    private Consumer<Object> sinker;
+    private SPLMapping<?> mapping;
 
     @Override
     public synchronized void initialize(OperatorContext context)
@@ -34,7 +34,7 @@ public class FunctionSink<T> extends FunctionFunctor {
     @Override
     public void process(StreamingInput<Tuple> stream, Tuple tuple)
             throws Exception {
-        T value = mapping.convertFrom(tuple);
+        Object value = mapping.convertFrom(tuple);
         synchronized (sinker) {
             sinker.accept(value);
         }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionSource.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionSource.java
@@ -23,10 +23,10 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 @PrimitiveOperator
 @OutputPortSet(cardinality = 1)
 @SharedLoader
-public class FunctionSource<T> extends ProcessTupleProducer implements Functional {
+public class FunctionSource extends ProcessTupleProducer implements Functional {
 
-    private Supplier<Iterable<T>> data;
-    private SPLMapping<T> mapping;
+    private Supplier<Iterable<Object>> data;
+    private SPLMapping<Object> mapping;
 
     private String functionalLogic;
     private String[] jar;
@@ -66,7 +66,7 @@ public class FunctionSource<T> extends ProcessTupleProducer implements Functiona
     protected void process() throws Exception {
 
         try {
-            for (T tuple : data.get()) {
+            for (Object tuple : data.get()) {
                 if (Thread.interrupted())
                     return;
                 if (tuple == null)

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionTransform.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionTransform.java
@@ -22,10 +22,10 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 @InputPortSet(cardinality = 1)
 @OutputPortSet(cardinality = 1)
 @Icons(location16 = "opt/icons/functor_16.gif", location32 = "opt/icons/functor_32.gif")
-public class FunctionTransform<T, U> extends FunctionQueueableFunctor<T> {
+public class FunctionTransform extends FunctionQueueableFunctor {
 
-    private Function<T, U> transform;
-    private SPLMapping<U> outputMapping;
+    private Function<Object, Object> transform;
+    private SPLMapping<Object> outputMapping;
     private StreamingOutput<OutputTuple> output;
 
     @Override
@@ -38,9 +38,9 @@ public class FunctionTransform<T, U> extends FunctionQueueableFunctor<T> {
         outputMapping = getOutputMapping(this, 0);
     }
     
-    public void tuple(T value) throws Exception {
+    public void tuple(Object value) throws Exception {
 
-        U modValue;
+        Object modValue;
         synchronized (transform) {
             modValue = transform.apply(value);
         }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionWindow.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/FunctionWindow.java
@@ -23,7 +23,7 @@ import com.ibm.streamsx.topology.tuple.Keyable;
 
 @InputPorts(@InputPortSet(cardinality = 1, windowingMode = WindowMode.Windowed))
 @OutputPorts(@OutputPortSet(cardinality = 1))
-public abstract class FunctionWindow<T> extends FunctionFunctor {
+public abstract class FunctionWindow extends FunctionFunctor {
 
     private Metric nPartitions;
 

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/HashAdder.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/HashAdder.java
@@ -23,10 +23,10 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
  */
 @InputPorts({@InputPortSet(cardinality = 1)})
 @OutputPorts({@OutputPortSet(cardinality = 1)})
-public abstract class HashAdder<T> extends
+public abstract class HashAdder extends
         FunctionFunctor {
 
-    protected SPLMapping<T> mapping;
+    protected SPLMapping<Object> mapping;
     protected StreamingOutput<OutputTuple> output;
 
     @Override
@@ -42,14 +42,14 @@ public abstract class HashAdder<T> extends
     public void process(StreamingInput<Tuple> stream, Tuple tuple)
             throws Exception {
         // Take the hash code, add it to the tuple, and submit.
-        T value = mapping.convertFrom(tuple);
+        Object value = mapping.convertFrom(tuple);
         OutputTuple ot = output.newTuple();
         ot.setObject(0, tuple.getObject(0));
         ot.setInt(1, getHash(value));
         output.submit(ot);
     }
     
-    abstract int getHash(T value);
+    abstract int getHash(Object value);
 
     /**
      * Removed this as a parameter.

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/KeyableTuplePartitioner.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/KeyableTuplePartitioner.java
@@ -10,10 +10,11 @@ import com.ibm.streamsx.topology.tuple.Keyable;
 
 @PrimitiveOperator
 @Icons(location16 = "opt/icons/functor_16.gif", location32 = "opt/icons/functor_32.gif")
-public class KeyableTuplePartitioner<T extends Keyable<?>> extends HashAdder<T> {
+public class KeyableTuplePartitioner extends HashAdder {
 
     @Override
-    int getHash(T value) {
-        return value.getKey().hashCode();
+    int getHash(Object value) {
+        Keyable<?> keyable = (Keyable<?>) value;
+        return keyable.getKey().hashCode();
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/ObjectHashAdder.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/ObjectHashAdder.java
@@ -9,10 +9,10 @@ import com.ibm.streams.operator.model.PrimitiveOperator;
 
 @PrimitiveOperator
 @Icons(location16 = "opt/icons/functor_16.gif", location32 = "opt/icons/functor_32.gif")
-public class ObjectHashAdder<T> extends HashAdder<T> {
+public class ObjectHashAdder extends HashAdder {
     
     @Override
-    int getHash(T value) {
+    int getHash(Object value) {
         return value.hashCode();
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/window/ContinuousAggregatorCountEvict.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/window/ContinuousAggregatorCountEvict.java
@@ -23,7 +23,7 @@ import com.ibm.streamsx.topology.internal.functional.ops.FunctionWindow;
  */
 public class ContinuousAggregatorCountEvict<I, O> extends SlidingSetAggregator<I, O> {
 
-    public ContinuousAggregatorCountEvict(FunctionWindow<?> op, StreamWindow<Tuple> window)
+    public ContinuousAggregatorCountEvict(FunctionWindow op, StreamWindow<Tuple> window)
             throws ClassNotFoundException {
         super(op, window);
     }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/window/ContinuousAggregatorTimeEvict.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/window/ContinuousAggregatorTimeEvict.java
@@ -23,7 +23,7 @@ import com.ibm.streamsx.topology.internal.functional.ops.FunctionWindow;
  */
 public class ContinuousAggregatorTimeEvict<I, O> extends SlidingSetAggregator<I, O> {
 
-    public ContinuousAggregatorTimeEvict(FunctionWindow<?> op, StreamWindow<Tuple> window)
+    public ContinuousAggregatorTimeEvict(FunctionWindow op, StreamWindow<Tuple> window)
             throws ClassNotFoundException {
         super(op, window);
     }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/window/PartitionedSlidingJoin.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/window/PartitionedSlidingJoin.java
@@ -11,7 +11,7 @@ import com.ibm.streamsx.topology.tuple.Keyable;
 
 public class PartitionedSlidingJoin<T, U, J> extends SlidingJoin<T, U, J> {
 
-    public PartitionedSlidingJoin(FunctionWindow<?> op,
+    public PartitionedSlidingJoin(FunctionWindow op,
             StreamWindow<Tuple> window) throws ClassNotFoundException {
         super(op, window);
     }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/window/PeriodicAggregator.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/window/PeriodicAggregator.java
@@ -21,7 +21,7 @@ import com.ibm.streamsx.topology.internal.functional.ops.FunctionWindow;
  */
 public class PeriodicAggregator<I, O> extends SlidingSetAggregator<I, O> {
 
-    public PeriodicAggregator(FunctionWindow<?> op, StreamWindow<Tuple> window)
+    public PeriodicAggregator(FunctionWindow op, StreamWindow<Tuple> window)
             throws ClassNotFoundException {
         super(op, window);
     }

--- a/java/src/com/ibm/streamsx/topology/internal/functional/window/SlidingJoin.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/window/SlidingJoin.java
@@ -30,7 +30,7 @@ public class SlidingJoin<T, U, J> extends SlidingSet<U, J> {
     private BiFunction<T, List<U>, J> joiner;
     protected SPLMapping<T> input1Mapping;
 
-    public SlidingJoin(FunctionWindow<?> op, StreamWindow<Tuple> window)
+    public SlidingJoin(FunctionWindow op, StreamWindow<Tuple> window)
             throws ClassNotFoundException {
         super(op, window);
         joiner = getLogicObject(op.getFunctionalLogic());

--- a/java/src/com/ibm/streamsx/topology/internal/functional/window/SlidingSet.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/window/SlidingSet.java
@@ -28,13 +28,13 @@ import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
 public abstract class SlidingSet<I, O> extends
         StatefulWindowListener<LinkedList<I>, Tuple> {
 
-    private final FunctionWindow<?> op;
+    private final FunctionWindow op;
     private final SPLMapping<I> inputMapping;
 
     protected final SPLMapping<O> outputMapping;
     protected final StreamingOutput<?> output;
 
-    protected SlidingSet(FunctionWindow<?> op, StreamWindow<Tuple> window)
+    protected SlidingSet(FunctionWindow op, StreamWindow<Tuple> window)
             throws ClassNotFoundException {
         super(window);
         this.op = op;

--- a/java/src/com/ibm/streamsx/topology/internal/functional/window/SlidingSetAggregator.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/window/SlidingSetAggregator.java
@@ -29,7 +29,7 @@ public abstract class SlidingSetAggregator<I, O> extends SlidingSet<I, O> {
 
     private Function<List<I>, O> aggregator;
 
-    public SlidingSetAggregator(FunctionWindow<?> op, StreamWindow<Tuple> window)
+    public SlidingSetAggregator(FunctionWindow op, StreamWindow<Tuple> window)
             throws ClassNotFoundException {
         super(op, window);
         aggregator = getLogicObject(op.getFunctionalLogic());

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/BlobMapping.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/BlobMapping.java
@@ -15,7 +15,7 @@ class BlobMapping extends SPLMapping<Blob> {
 
     // Singleton, as stateless.
     BlobMapping() {
-        super(Schemas.BLOB, Blob.class);
+        super(Schemas.BLOB);
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/SPLJavaObject.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/SPLJavaObject.java
@@ -4,199 +4,29 @@
  */
 package com.ibm.streamsx.topology.internal.spljava;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.util.regex.Pattern;
 
-import com.ibm.streams.operator.Attribute;
 import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streams.operator.Tuple;
-import com.ibm.streams.operator.Type;
 import com.ibm.streams.operator.types.Blob;
 
+/**
+ * Mapping for a Java object as an SPL schema.
+ * Like Java at runtime (the schema) we have no knowledge of
+ * the actual type of the Java object, the info for
+ *  generic parameter of TStream<T> is not needed. 
+ */
 class SPLJavaObject<T> extends SPLMapping<T> {
 
     public static final String SPL_JAVA_PREFIX = "__spl_j";
-    
-    public static final String SPL_JAVA_PREFIX_SIMPLE = SPL_JAVA_PREFIX + "o_";
-    public static final String SPL_JAVA_PREFIX_ENCODED = SPL_JAVA_PREFIX + "ou_";
     
     public static final String SPL_JAVA_OBJECT = SPL_JAVA_PREFIX + "object";
 
     private final Class<T> tupleClass;
 
-    private static boolean onlyASCII(String className) {
-        return Pattern.matches("^[\\dA-Za-z\\.]*$", className);
-    }
-    static String classNameToSPLAttributeName(Class<?> tupleClass) {
-        return classNameToSPLAttributeName(tupleClass.getName());
-    }
-    
-    private static String classNameToSPLAttributeName(String className) {
-        
-        if (onlyASCII(className))
-            return simpleJavaAttributeName(className);
-        
-        return encodedJavaAttributeName(className);
-    }
-    
-    /**
-     * Create a simple attribute name for a class name
-     * that only contains a-Z,A-Z,0-9 and package separators (.).
-     * 
-     * In this case just replace the dots by _ and prefix
-     * with SPL_JAVA_PREFIX_SIMPLE.
-     * 
-     * This keeps the class readable in the SPL schema.
-     */
-    private static String simpleJavaAttributeName(String className) {
-        assert onlyASCII(className);
-        assert !className.contains("_");
-        
-       String attrName = className.replace('.', '_');
-        
-       return SPL_JAVA_PREFIX_SIMPLE.concat(attrName);
-    }
-    
-    private static String simpleSPLAttributeNameToClassName(String attrName) {
-        assert attrName.startsWith(SPL_JAVA_PREFIX_SIMPLE);
-        
-        attrName = attrName.substring(SPL_JAVA_PREFIX_SIMPLE.length());
-        attrName = attrName.replace('_', '.');
-        
-        assert onlyASCII(attrName);
-        
-        return attrName;    
-    }
-    /*
-    * Create an encoded attribute name for a class name
-    * that may contain any characters. Since SPL only
-    * supports ASCII letters, numbers and underscore
-    * in identifiers, we need to escape any other character
-    * in the class name. We use underscore as the escape
-    * character:
-    * 
-    * __ (two underscores) - escape for an underscore.
-    * _p  - package separate (dot, '.')
-    * _uxxxx xxxx is the unicode escape sequence in hex.
-    * 
-    * The attribute name is prepended by SPL_JAVA_PREFIX_ENCODED 
-    * 
-    */
-    private static final String ZEROS = "000";
-   private static String encodedJavaAttributeName(String className) {
-       
-       StringBuilder sb = new StringBuilder(className.length()*2);
-       sb.append(SPL_JAVA_PREFIX_ENCODED);
-       
-       for (int i = 0; i < className.length(); i++) {
-           final char c = className.charAt(i);
-           
-           // Simple ASCII
-           if ((c >= 'a' && c <= 'z') ||
-              (c >= 'A' && c <= 'Z') ||
-              (c >= '0' && c <= '9')) {
-               sb.append(c);
-               continue;
-           }
-           
-           if (c == '.') {
-               sb.append("_p");
-               continue;
-           }
-           
-           if (c == '_') {
-               sb.append("__");
-               continue;
-           }
-           
-           sb.append("_u");
-           String hex = Integer.toHexString(c);
-           sb.append(ZEROS.substring(0, 4-hex.length()));
-           sb.append(hex);
-       }
-       
-      return sb.toString();
-   }
-   private static String encodedSPLAttributeNameToClassName(String attrName) {
-       
-       assert attrName.startsWith(SPL_JAVA_PREFIX_ENCODED);
-       
-       StringBuilder sb = new StringBuilder(attrName.length());
-       
-       for (int i = SPL_JAVA_PREFIX_ENCODED.length(); i < attrName.length(); ) {
-           final char c = attrName.charAt(i++);
-           
-           if (c != '_') {
-               sb.append(c);
-               continue;
-           }
-           
-           char ins = attrName.charAt(i++);
-           
-           if (ins == 'p') {
-               sb.append('.');
-               continue;
-           }
-           
-           if (ins == '_') {
-               sb.append('_');
-               continue;
-           }
-           
-           if (ins == 'u') {
-               String hex = attrName.substring(i, i+4);
-               i+= 4;
-               char hc = (char) Integer.parseInt(hex, 16);
-               sb.append(hc);
-               continue;
-           }
-           
-           throw new IllegalArgumentException(attrName);
-       }
-       
-      return sb.toString();
-
-   }
-
-    static String SPLAttributeNameToClassName(String attrName) {
-        if (attrName.startsWith(SPL_JAVA_PREFIX_SIMPLE))
-            return simpleSPLAttributeNameToClassName(attrName);
-        
-        return encodedSPLAttributeNameToClassName(attrName);
-    }
-
-    static <T> SPLMapping<T> createMappping(Class<T> tupleClass) {
-
-        //String splName = classNameToSPLAttributeName(tupleClass);
-        //StreamSchema schema = Type.Factory.getStreamSchema("tuple<blob "
-        //        + splName + ">");
-        StreamSchema schema = Schemas.JAVA_OBJECT;
-        
-        return new SPLJavaObject<T>(schema, tupleClass);
-    }
-
-    static SPLMapping<Object> getMapping(StreamSchema schema) {
-        assert schema.getAttributeCount() == 1;
-
-        Attribute blobAttr = schema.getAttribute(0);
-        assert blobAttr.getType().getMetaType() == Type.MetaType.BLOB;
-
-        String attrName = blobAttr.getName();
-        assert attrName.startsWith(SPL_JAVA_PREFIX);
-
-        String javaClassName = SPLAttributeNameToClassName(attrName);
-
-        try {
-            @SuppressWarnings("unchecked")
-            Class<Object> tupleClass = (Class<Object>) Class
-                    .forName(javaClassName);
-            return new SPLJavaObject<Object>(schema, tupleClass);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-
+    static <T> SPLMapping<T> createMappping(Class<T> tupleClass) {       
+        return new SPLJavaObject<T>(Schemas.JAVA_OBJECT, tupleClass);
     }
 
     protected SPLJavaObject(StreamSchema schema, Class<T> tupleClass) {
@@ -230,26 +60,5 @@ class SPLJavaObject<T> extends SPLMapping<T> {
 
         JavaObjectBlob jblob = new JavaObjectBlob(tuple);
         return getSchema().getTuple(new Blob[] { jblob });
-
-        /*
-         * 
-         * try { // baos.reset(); AB baos = new AB(); ObjectOutputStream oos =
-         * new ObjectOutputStream(baos); oos.writeObject(tuple); oos.flush();
-         * oos.close(); Blob objectAsBlob = ValueFactory.newBlob(baos.data(), 0,
-         * baos.size()); return getSchema().getTuple(new Blob[] { objectAsBlob
-         * });
-         * 
-         * } catch (IOException e) { throw new RuntimeException(e); }
-         */
-    }
-
-    static class AB extends ByteArrayOutputStream {
-        AB() {
-            super(1024);
-        }
-
-        byte[] data() {
-            return buf;
-        }
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/SPLJavaObject.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/SPLJavaObject.java
@@ -15,12 +15,14 @@ import com.ibm.streams.operator.Tuple;
 import com.ibm.streams.operator.Type;
 import com.ibm.streams.operator.types.Blob;
 
-public class SPLJavaObject<T> extends SPLMapping<T> {
+class SPLJavaObject<T> extends SPLMapping<T> {
 
     public static final String SPL_JAVA_PREFIX = "__spl_j";
     
     public static final String SPL_JAVA_PREFIX_SIMPLE = SPL_JAVA_PREFIX + "o_";
     public static final String SPL_JAVA_PREFIX_ENCODED = SPL_JAVA_PREFIX + "ou_";
+    
+    public static final String SPL_JAVA_OBJECT = SPL_JAVA_PREFIX + "object";
 
     private final Class<T> tupleClass;
 
@@ -165,7 +167,7 @@ public class SPLJavaObject<T> extends SPLMapping<T> {
         return encodedSPLAttributeNameToClassName(attrName);
     }
 
-    public static <T> SPLMapping<T> createMappping(Class<T> tupleClass) {
+    static <T> SPLMapping<T> createMappping(Class<T> tupleClass) {
 
         String splName = classNameToSPLAttributeName(tupleClass);
         StreamSchema schema = Type.Factory.getStreamSchema("tuple<blob "
@@ -174,7 +176,7 @@ public class SPLJavaObject<T> extends SPLMapping<T> {
         return new SPLJavaObject<T>(schema, tupleClass);
     }
 
-    public static SPLMapping<Object> getMapping(StreamSchema schema) {
+    static SPLMapping<Object> getMapping(StreamSchema schema) {
         assert schema.getAttributeCount() == 1;
 
         Attribute blobAttr = schema.getAttribute(0);

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/SPLJavaObject.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/SPLJavaObject.java
@@ -169,10 +169,11 @@ class SPLJavaObject<T> extends SPLMapping<T> {
 
     static <T> SPLMapping<T> createMappping(Class<T> tupleClass) {
 
-        String splName = classNameToSPLAttributeName(tupleClass);
-        StreamSchema schema = Type.Factory.getStreamSchema("tuple<blob "
-                + splName + ">");
-
+        //String splName = classNameToSPLAttributeName(tupleClass);
+        //StreamSchema schema = Type.Factory.getStreamSchema("tuple<blob "
+        //        + splName + ">");
+        StreamSchema schema = Schemas.JAVA_OBJECT;
+        
         return new SPLJavaObject<T>(schema, tupleClass);
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/SPLJavaObject.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/SPLJavaObject.java
@@ -19,9 +19,10 @@ import com.ibm.streams.operator.types.Blob;
  */
 class SPLJavaObject extends SPLMapping<Object> {
 
-    public static final String SPL_JAVA_PREFIX = "__spl_j";
-    
-    public static final String SPL_JAVA_OBJECT = SPL_JAVA_PREFIX + "object";
+    /**
+     * Attribute name for a schema with a serialized java object
+     */
+    public static final String SPL_JAVA_OBJECT = "__spl_jo";
 
     SPLJavaObject(StreamSchema schema) {
         super(schema);

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/SPLMapping.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/SPLMapping.java
@@ -21,21 +21,14 @@ public abstract class SPLMapping<T> {
     static final XMLMapping JavaXML = new XMLMapping();
 
     private final StreamSchema schema;
-    private final Class<T> tupleClass;
 
-    protected SPLMapping(StreamSchema schema, Class<T> tupleClass) {
+    protected SPLMapping(StreamSchema schema) {
         this.schema = schema;
-        this.tupleClass = tupleClass;
     }
 
-    public final StreamSchema getSchema() {
+    StreamSchema getSchema() {
         return schema;
     }
-
-    public final Class<T> getTupleClass() {
-        return tupleClass;
-    }
-
     public abstract Tuple convertTo(T tuple);
 
     public abstract T convertFrom(Tuple tuple);

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/SPLTuple.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/SPLTuple.java
@@ -14,7 +14,7 @@ import com.ibm.streams.operator.Tuple;
 class SPLTuple extends SPLMapping<Tuple> {
 
     SPLTuple(StreamSchema schema) {
-        super(schema, Tuple.class);
+        super(schema);
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/Schemas.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/Schemas.java
@@ -17,6 +17,7 @@ public class Schemas {
     public static final StreamSchema STRING = getStreamSchema("tuple<rstring string>");
     public static final StreamSchema BLOB = getStreamSchema("tuple<blob binary>");
     public static final StreamSchema XML = getStreamSchema("tuple<xml document>");
+    public static final StreamSchema JAVA_OBJECT = getStreamSchema("tuple<blob " + SPLJavaObject.SPL_JAVA_OBJECT + ">");
     
 
     public StreamSchema getSPLSchema(Class<?> tupleClass) {
@@ -51,6 +52,9 @@ public class Schemas {
 
         if (STRING.equals(schema)) {
             return SPLMapping.JavaString;
+        }
+        if (JAVA_OBJECT.equals(schema)) {
+            return new SPLJavaObject<Object>(schema, Object.class);
         }
         if (BLOB.equals(schema)) {
             return SPLMapping.JavaBlob;

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/Schemas.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/Schemas.java
@@ -6,9 +6,7 @@ package com.ibm.streamsx.topology.internal.spljava;
 
 import static com.ibm.streams.operator.Type.Factory.getStreamSchema;
 
-import com.ibm.streams.operator.Attribute;
 import com.ibm.streams.operator.StreamSchema;
-import com.ibm.streams.operator.Type;
 import com.ibm.streams.operator.types.Blob;
 import com.ibm.streams.operator.types.XML;
 
@@ -63,17 +61,7 @@ public class Schemas {
             return SPLMapping.JavaXML;
         }
 
-        Attribute attr0 = schema.getAttribute(0);
-
-        if (attr0.getType().getMetaType() == Type.MetaType.BLOB) {
-            if (attr0.getName().startsWith(SPLJavaObject.SPL_JAVA_PREFIX))
-                return SPLJavaObject.getMapping(schema);
-        }
-
         return new SPLTuple(schema);
-
-        // throw new UnsupportedOperationException(
-        // "Mapping not defined:" + schema.getLanguageType());
     }
 
 }

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/Schemas.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/Schemas.java
@@ -30,20 +30,23 @@ public class Schemas {
         throw new IllegalArgumentException(tupleClass.getName());
     }
 
-    @SuppressWarnings("unchecked")
-    public static <T> SPLMapping<T> getSPLMapping(Class<T> tupleClass) {
+    /**
+     * Return the SPL schema that will be used at runtime
+     * to hold the java object tuple.
+     */
+    public static StreamSchema getSPLMappingSchema(Class<?> tupleClass) {
 
         if (String.class.equals(tupleClass)) {
-            return (SPLMapping<T>) SPLMapping.JavaString;
+            return STRING;
         }
         if (Blob.class.equals(tupleClass)) {
-            return (SPLMapping<T>) SPLMapping.JavaBlob;
+            return BLOB;
         }
         if (XML.class.equals(tupleClass)) {
-            return (SPLMapping<T>) SPLMapping.JavaXML;
+            return XML;
         }
 
-        return SPLJavaObject.createMappping(tupleClass);
+        return JAVA_OBJECT;
     }
 
     public static SPLMapping<?> getSPLMapping(StreamSchema schema) {
@@ -52,7 +55,7 @@ public class Schemas {
             return SPLMapping.JavaString;
         }
         if (JAVA_OBJECT.equals(schema)) {
-            return new SPLJavaObject<Object>(schema, Object.class);
+            return new SPLJavaObject(schema);
         }
         if (BLOB.equals(schema)) {
             return SPLMapping.JavaBlob;

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/StringMapping.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/StringMapping.java
@@ -15,7 +15,7 @@ class StringMapping extends SPLMapping<String> {
 
     // Singleton, as stateless.
     StringMapping() {
-        super(Schemas.STRING, String.class);
+        super(Schemas.STRING);
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/spljava/XMLMapping.java
+++ b/java/src/com/ibm/streamsx/topology/internal/spljava/XMLMapping.java
@@ -15,7 +15,7 @@ class XMLMapping extends SPLMapping<XML> {
 
     // Singleton, as stateless.
     XMLMapping() {
-        super(Schemas.XML, XML.class);
+        super(Schemas.XML);
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/streams/InvokeSc.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/InvokeSc.java
@@ -13,10 +13,12 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
 import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.context.ContextProperties;
 import com.ibm.streamsx.topology.internal.process.ProcessOutputToLogger;
 
 public class InvokeSc {
@@ -28,14 +30,17 @@ public class InvokeSc {
     private final String namespace;
     private final String mainComposite;
     private final File applicationDir;
+    private final String installDir;
 
-    public InvokeSc(boolean standalone, String namespace, String mainComposite,
+    public InvokeSc(Map<String,Object> config, boolean standalone, String namespace, String mainComposite,
             File applicationDir) throws URISyntaxException, IOException {
         super();
         this.standalone = standalone;
         this.namespace = namespace;
         this.mainComposite = mainComposite;
         this.applicationDir = applicationDir;
+        
+        installDir = Util.getStreamsInstall(config, ContextProperties.COMPILE_INSTALL_DIR);
 
         addFunctionalToolkit();
     }
@@ -67,8 +72,7 @@ public class InvokeSc {
     }
 
     public void invoke() throws Exception, InterruptedException {
-        String si = Util.getStreamsInstall();
-        File sc = new File(si, "bin/sc");
+        File sc = new File(installDir, "bin/sc");
 
         List<String> commands = new ArrayList<String>();
 
@@ -96,6 +100,12 @@ public class InvokeSc {
         // Streams to ensure the bundle is not dependent on the
         // local JVM install path.
         pb.environment().remove("JAVA_HOME");
+        
+        // Set STREAMS_INSTALL in case it was overriden for compilation
+        pb.environment().put("STREAMS_INSTALL", installDir);
+        
+        // Ensure than only the toolkit path set by -t is used.
+        pb.environment().remove("STREAMS_SPLPATH");
         
         pb.directory(applicationDir);
 
@@ -126,8 +136,7 @@ public class InvokeSc {
             sb.append(splPath);
         }
 
-        String streamsInstall = Util.getStreamsInstall();
-        String streamsInstallToolkits = streamsInstall + "/toolkits";
+        String streamsInstallToolkits = installDir + "/toolkits";
         sb.append(":");
         sb.append(streamsInstallToolkits);
 

--- a/java/src/com/ibm/streamsx/topology/internal/streams/Util.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/Util.java
@@ -20,15 +20,29 @@ public class Util {
      * @throws IllegalStateException if STREAMS_INSTALL not set
      *          or not set to a Streams install directory
      */
-    public static String getStreamsInstall() throws IllegalStateException {
+    public static String getStreamsInstall() {
         if (streamsInstall==null) {
-            String si = getenv(STREAMS_INSTALL);
-            File f = new File(si, ".product");
-            if (!f.exists())
-                throw new IllegalStateException(STREAMS_INSTALL+" "+si+" is not a Streams install directory.");
-            streamsInstall = si;
+            streamsInstall = verifyStreamsInstall(getenv(STREAMS_INSTALL));
         }
         return streamsInstall;
+    }
+
+    private static String verifyStreamsInstall(String installDir) {
+        File f = new File(installDir, ".product");
+        if (!f.exists())
+            throw new IllegalStateException(STREAMS_INSTALL+" "+installDir+" is not a Streams install directory.");
+        return installDir;
+    }
+    
+    /**
+     * Get a value for Streams install directory, using the value from
+     * the config, defaulting to $STREAMS_INSTALL.
+     */
+    public static String getStreamsInstall(Map<String,Object> config, String installKey) {
+        if (config == null || !config.containsKey(installKey))
+            return getStreamsInstall();
+        
+        return verifyStreamsInstall(config.get(installKey).toString());
     }
     
     /**
@@ -37,7 +51,7 @@ public class Util {
      * @return env value
      * @throws IllegalStateException if name not set
      */
-    public static String getenv(String name) throws IllegalStateException {
+    public static String getenv(String name) {
         String s = System.getenv(name);
         if (s==null)
             throw new IllegalStateException(name+" environment variable is not set.");
@@ -63,7 +77,7 @@ public class Util {
      * @throws IllegalArgumentException if value is null or isn't instanceof requiredClass
      */
     public static Object getConfigEntry(Map<String,? extends Object> map, String key, 
-            Class<?> requiredClass) throws IllegalArgumentException {
+            Class<?> requiredClass) {
         Object val = map.get(key);
         if (val==null)
             throw new IllegalArgumentException("config item "+key+" value is null");

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -15,6 +15,9 @@
   <property name="samples.src.dir" location="../../samples/java/functional/src"/>
   <property name="samples.jar" location="../../samples/java/functional/functionalsamples.jar"/>
 
+    <property name="topology.install.compile" value="${env.STREAMS_INSTALL}"/>
+    <echo message="Streams compile install: ${topology.install.compile}"/>
+
   <path id="compile.classpath">
     <pathelement location="${tk.lib}/com.ibm.streamsx.topology.jar" />
     <pathelement location="../../samples/java/functional/functionalsamples.jar"/>
@@ -47,7 +50,9 @@
 	   srcdir="${basedir}/src" 
 	   destdir="${classes}"
 	   classpathref="compile.classpath"/>
-    <ant dir="../scala" target="all" useNativeBasedir="true" inheritAll="no"/>
+    <ant dir="../scala" target="all" useNativeBasedir="true" inheritAll="no">
+       <property name="topology.install.compile" value="${topology.install.compile}"/>
+    </ant>
   </target>
   <target name="jar" depends="compile">
     <jar destfile="${jarname}" basedir="${classes}"/>
@@ -101,6 +106,7 @@
   <target name="unittest.base.scala">
     <ant dir="../scala" target="unittest" useNativeBasedir="true" inheritAll="no">
      <property name="topology.test.type" value="${topology.test.type}"/>
+     <property name="topology.install.compile" value="${topology.install.compile}"/>
     </ant>
   </target>
 

--- a/test/java/src/com/ibm/streamsx/topology/test/TestTopology.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/TestTopology.java
@@ -13,11 +13,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 
 import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.context.ContextProperties;
 import com.ibm.streamsx.topology.context.StreamsContext;
 import com.ibm.streamsx.topology.context.StreamsContext.Type;
@@ -84,6 +86,12 @@ public class TestTopology {
                         + destFile;
                 vmArgs.add(arg);
             }
+        }
+        // Look for a different compiler
+        String differentCompile = System.getProperty(ContextProperties.COMPILE_INSTALL_DIR);
+        if (differentCompile != null) {
+            config.put(ContextProperties.COMPILE_INSTALL_DIR, differentCompile);
+            Topology.STREAMS_LOGGER.setLevel(Level.INFO);
         }
     }
     

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTest.java
@@ -1,0 +1,239 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.test.distributed;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.streams.operator.types.Blob;
+import com.ibm.streams.operator.types.ValueFactory;
+import com.ibm.streams.operator.types.XML;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.context.StreamsContext.Type;
+import com.ibm.streamsx.topology.function.Function;
+import com.ibm.streamsx.topology.function.UnaryOperator;
+import com.ibm.streamsx.topology.spl.SPLSchemas;
+import com.ibm.streamsx.topology.spl.SPLStream;
+import com.ibm.streamsx.topology.spl.SPLStreams;
+import com.ibm.streamsx.topology.streams.StringStreams;
+import com.ibm.streamsx.topology.test.TestTopology;
+
+/**
+ * Test publish/subscribe. These tests just use publish/subscribe
+ * within a single job, but the expected use case is across jobs.
+ *
+ */
+public class PublishSubscribeTest extends TestTopology {
+
+    @Before
+    public void checkIsDistributed() {
+        assumeTrue(getTesterType() == Type.DISTRIBUTED_TESTER);
+    }
+
+    @Test
+    public void testPublishString() throws Exception {
+        final Topology t = new Topology();
+        TStream<String> source = t.strings("325", "457", "9325");
+        
+        source = source.modify(new Delay<String>());
+        
+        source.publish("/testPublishString");
+        
+        TStream<String> subscribe = t.subscribe("/testPublishString", String.class);
+
+        completeAndValidate(subscribe, 20, "325", "457", "9325");
+    }
+    
+    @Test
+    public void testPublishStringMultipleTopics() throws Exception {
+        final Topology t = new Topology();
+        TStream<String> source = t.strings("325", "457", "9325");       
+        source = source.modify(new Delay<String>());       
+        source.publish("/testPublishString");
+        
+        // A stream that should not be subscribed to!
+        TStream<String> source2 = t.strings("999", "777", "8888");       
+        source2 = source2.modify(new Delay<String>());       
+        source2.publish("/testPublishString2");
+ 
+        
+        TStream<String> subscribe = t.subscribe("/testPublishString", String.class);
+
+        completeAndValidate(subscribe, 20, "325", "457", "9325");
+    }
+    
+    // Test a exported String Java stream can be subscribed to by a SPL stream.
+    @Test
+    public void testPublishStringToSPL() throws Exception {
+        final Topology t = new Topology();
+        TStream<String> source = t.strings("hello", "SPL!");
+        
+        source = source.modify(new Delay<String>());
+        
+        source.publish("/testPublishStringSPL");
+        
+        SPLStream subscribe = SPLStreams.subscribe(t, "/testPublishStringSPL", SPLSchemas.STRING);        
+
+        completeAndValidate(subscribe.toStringStream(), 20, "hello", "SPL!");
+    }
+    
+    
+    @Test
+    public void testPublishBlob() throws Exception {
+        TStream<String> strings = publishBlobTopology();
+        
+        completeAndValidate(strings, 20, "93245", "hello", "was a blob!");
+    }
+    
+    @SuppressWarnings("serial")
+    public static TStream<String> publishBlobTopology() throws Exception {
+    
+        final Topology t = new Topology();
+        TStream<String> source = t.strings("93245", "hello", "was a blob!");       
+        source = source.modify(new Delay<String>());
+        
+        TStream<Blob> blobs = source.transform(new Function<String,Blob>() {
+
+            @Override
+            public Blob apply(String v) {
+                return ValueFactory.newBlob(v.getBytes(StandardCharsets.UTF_8));
+            }}, Blob.class);
+        
+        blobs.publish("/testPublishBlob");
+        
+        TStream<Blob> subscribe = t.subscribe("/testPublishBlob", Blob.class);
+        
+        TStream<String> strings = subscribe.transform(new Function<Blob,String>() {
+
+            @Override
+            public String apply(Blob v) {
+                return new String(v.getData(), StandardCharsets.UTF_8);
+            }}, String.class);      
+
+        return strings;
+    }
+    
+    @Test
+    public void testPublishXML() throws Exception {
+        TStream<String> strings = publishXMLTopology();
+        
+        completeAndValidate(strings, 20, "<book>Catch 22</book>", "<bus>V</bus>");
+    }
+    
+    @SuppressWarnings("serial")
+    public static TStream<String> publishXMLTopology() throws Exception {
+    
+        final Topology t = new Topology();
+        TStream<String> source = t.strings("<book>Catch 22</book>", "<bus>V</bus>");       
+        source = source.modify(new Delay<String>());
+        
+        TStream<XML> xml = source.transform(new Function<String,XML>() {
+
+            @Override
+            public XML apply(String v) {
+                try {
+                    return ValueFactory.newXML(new ByteArrayInputStream(v.getBytes(StandardCharsets.UTF_8)));
+                } catch (IOException e) {
+                    return null;
+                }
+            }}, XML.class);
+        
+        xml.publish("/testPublishXML");
+        
+        TStream<XML> subscribe = t.subscribe("/testPublishXML", XML.class);
+        
+        TStream<String> strings = subscribe.transform(new Function<XML,String>() {
+
+            @Override
+            public String apply(XML v) {
+                byte[] data = new byte[100];
+                InputStream in = v.getInputStream();
+                int read;
+                try {
+                    read = in.read(data);
+                } catch (IOException e) {
+                    return null;
+                }
+                return new String(data, 0, read, StandardCharsets.UTF_8);
+            }}, String.class);      
+
+        return strings;
+    }
+    
+    @Test
+    public void testPublishJavaObject() throws Exception {
+        TStream<String> strings = publishJavaObjectTopology();
+        
+        completeAndValidate(strings, 20, "publishing", "a", "java object");
+    }
+    
+    @SuppressWarnings("serial")
+    public static TStream<String> publishJavaObjectTopology() throws Exception {
+    
+        final Topology t = new Topology();
+        TStream<String> source = t.strings("publishing", "a", "java object");       
+        source = source.modify(new Delay<String>());
+        
+        TStream<SimpleString> objects = source.transform(new Function<String,SimpleString>() {
+
+            @Override
+            public SimpleString apply(String v) {
+                return new SimpleString(v);
+            }}, SimpleString.class);
+        
+        objects.publish("/testPublishJavaObject");
+        
+        TStream<SimpleString> subscribe = t.subscribe("/testPublishJavaObject", SimpleString.class);
+        
+        TStream<String> strings = StringStreams.toString(subscribe);  
+
+        return strings;
+    }
+    
+    /**
+     * Delay to ensure that tuples are not dropped while dynamic
+     * connections are being made.
+     */
+    @SuppressWarnings("serial")
+    public static class Delay<T> implements UnaryOperator<T> {
+        
+        private boolean first = true;
+
+        @Override
+        public T apply(T v)  {
+            if (first) {
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    return null;
+                }
+                first = false;
+            }
+            
+            return v;
+        }
+    }
+    
+    @SuppressWarnings("serial")
+    public static class SimpleString implements Serializable {
+        private final String value;
+        public SimpleString(String value) {
+            this.value = value;
+        }
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+}

--- a/test/scala/build.xml
+++ b/test/scala/build.xml
@@ -62,6 +62,11 @@
      <property name="topology.test.perf_ok" value="true"/>
      <property name="topology.test.coverage" value="true"/>
      <property name="topology.test.resource_dir" location="resources"/>
+
+     <!-- Can be overridden by setting -D topology.install.compile on cmd line -->
+
+    <echo message="INSALL: ${topology.install.compile}"/>
+     
    <jacoco:coverage enabled="${topology.test.coverage}">
      <junit fork="yes" dir="${topology.test.dir}" printsummary="yes" showoutput="no"
            haltonfailure="yes" failureproperty="topology.tests.failed">
@@ -70,6 +75,8 @@
        <sysproperty key="topology.test.sc_ok" value="${topology.test.sc_ok}"/>
        <sysproperty key="topology.test.perf_ok" value="${topology.test.perf_ok}"/>
        <sysproperty key="topology.test.resource_dir" file="resources"/>
+
+       <sysproperty key="topology.install.compile" value="${topology.install.compile}"/>
        
        <classpath>
          <path refid="test.classpath"/>


### PR DESCRIPTION
A step on the path to supporting generic types, like List<String> for tuples.

Now java objects tuples basically lose the knowledge of their type at SPL runtime.