### PR TITLE
Add Placeable interface without any implementation

### DIFF
--- a/java/src/com/ibm/streamsx/topology/TSink.java
+++ b/java/src/com/ibm/streamsx/topology/TSink.java
@@ -5,13 +5,14 @@
 package com.ibm.streamsx.topology;
 
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
+import com.ibm.streamsx.topology.context.Placeable;
 
 /**
  * A handle to the {@code sink} of a {@code TStream}.
  * 
  * @see TStream#sink(com.ibm.streamsx.topology.function.Consumer)
  */
-public interface TSink extends TopologyElement {
+public interface TSink extends TopologyElement, Placeable<TSink> {
     
     /**
      * Get the operator associated with the sink.

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -341,7 +341,7 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * Print each tuple on {@code System.out}. For each tuple {@code t} on this
      * stream {@code System.out.println(t.toString())} will be called.
      */
-    void print();
+    TSink print();
 
     /**
      * Class of the tuples on this stream, if known.

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import com.ibm.streamsx.topology.builder.BInputPort;
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.builder.BOutput;
+import com.ibm.streamsx.topology.context.Placeable;
 import com.ibm.streamsx.topology.function.BiFunction;
 import com.ibm.streamsx.topology.function.Consumer;
 import com.ibm.streamsx.topology.function.Function;
@@ -36,7 +37,7 @@ import com.ibm.streamsx.topology.spl.SPLStream;
  *            Tuple type, any instance of {@code T} at runtime must be
  *            serializable.
  */
-public interface TStream<T> extends TopologyElement {
+public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
 
     /**
      * Enumeration for routing tuples to parallel channels.

--- a/java/src/com/ibm/streamsx/topology/builder/BMarkerOperator.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BMarkerOperator.java
@@ -6,9 +6,9 @@ package com.ibm.streamsx.topology.builder;
 
 public class BMarkerOperator extends BOperator {
 
-    public BMarkerOperator(GraphBuilder bt, String kind) {
+    public BMarkerOperator(GraphBuilder bt, BVirtualMarker virtualMarker) {
         super(bt);
-        json().put("kind", kind);
+        json().put("kind", virtualMarker.kind());
         json().put("marker", true);
     }
 }

--- a/java/src/com/ibm/streamsx/topology/builder/BOperator.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOperator.java
@@ -68,6 +68,18 @@ public class BOperator extends BJSONObject {
         
         config.put(key, value);     
     }
+    
+    /**
+     * Get an existing configuration value.
+     * @param key Key of the value.
+     * @return The configured value, or null if it has not been set.
+     */
+    public Object getConfig(String key) {
+        JSONObject config = (JSONObject) json().get("config");
+        if (config == null)
+            return null;
+        return config.get(key);
+    }
 
     @Override
     public JSONObject complete() {

--- a/java/src/com/ibm/streamsx/topology/builder/BVirtualMarker.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BVirtualMarker.java
@@ -1,0 +1,43 @@
+package com.ibm.streamsx.topology.builder;
+
+public enum BVirtualMarker {
+    
+    UNION("$Union$"),
+    PARALLEL("$Parallel$"),
+    END_PARALLEL("$EndParallel$"),
+    LOW_LATENCY("$LowLatency$"),
+    END_LOW_LATENCY("$EndLowLatency$"),
+    ISOLATE("$Isolate$");
+    
+    private final String kind;
+    
+    private BVirtualMarker(String kind) {
+        this.kind = kind;
+    }
+    
+    public String kind() {
+        return kind;
+    }
+    
+    /**
+     * Is the operator kind this virtual marker.
+     */
+    public boolean isThis(String kind) {
+        return kind().equals(kind);
+    }
+    
+    public static boolean isVirtualMarker(String kind) {
+        if (kind == null)
+            return false;
+        
+        if (!kind.startsWith("$")) {
+            return false;
+        }
+        
+        for (BVirtualMarker marker : BVirtualMarker.values()) {
+            if (marker.kind.equals(kind))
+                return true;
+        }
+        return false;
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/context/Placeable.java
+++ b/java/src/com/ibm/streamsx/topology/context/Placeable.java
@@ -7,6 +7,7 @@
 import java.util.Set;
 
 import com.ibm.streamsx.topology.TopologyElement;
+import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 
 /**
  * Placement directives for a topology element when executing
@@ -21,6 +22,8 @@ import com.ibm.streamsx.topology.TopologyElement;
  */
 public interface Placeable<T extends Placeable<T>> extends TopologyElement {
     
+    boolean isPlaceable();
+    
     /**
      * Fuse this container with other topology elements so that
      * at runtime they all execute within the same operating system process.
@@ -31,7 +34,7 @@ public interface Placeable<T extends Placeable<T>> extends TopologyElement {
      * 
      * @return this
      */
-    public T fuse(Placeable<?> ... elements);
+    T fuse(Placeable<?> ... elements);
     
     /**
      * Add required resource tags for this topology element for distributed submission.
@@ -42,7 +45,7 @@ public interface Placeable<T extends Placeable<T>> extends TopologyElement {
      * @param tags Tags to be required at runtime.
      * @return this
      */
-    public T addResourceTags(String ... tags);
+    T addResourceTags(String ... tags);
     
     /**
      * Get the set of resource tags this element requires.
@@ -51,5 +54,7 @@ public interface Placeable<T extends Placeable<T>> extends TopologyElement {
      * of all {@link #addResourceTags(String...) resource tags added} to each fused element.
      * @return Read-only set of host tags this element requires.
      */
-    public Set<String> getResourceTags();
+    Set<String> getResourceTags();
+    
+    BOperatorInvocation operator(); 
 }

--- a/java/src/com/ibm/streamsx/topology/context/Placeable.java
+++ b/java/src/com/ibm/streamsx/topology/context/Placeable.java
@@ -1,4 +1,8 @@
-package com.ibm.streamsx.topology.context;
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+*/
+ package com.ibm.streamsx.topology.context;
 
 import java.util.Set;
 

--- a/java/src/com/ibm/streamsx/topology/context/Placeable.java
+++ b/java/src/com/ibm/streamsx/topology/context/Placeable.java
@@ -1,0 +1,51 @@
+package com.ibm.streamsx.topology.context;
+
+import java.util.Set;
+
+import com.ibm.streamsx.topology.TopologyElement;
+
+/**
+ * Placement directives for a topology element when executing
+ * in a distributed runtime.
+ * <BR>
+ * Placement directives only apply when the topology
+ * is submitted to a {@link StreamsContext.Type#DISTRIBUTED DISTRIBUTED},
+ * {@link StreamsContext.Type#ANALYTICS_SERVICE ANALYTICS_SERVICE}
+ * or {@link StreamsContext.Type#DISTRIBUTED_TESTER DISTRIBUTED_TESTER} context.
+ * <BR>
+ * For all other context types directives are ignored.
+ */
+public interface Placeable<T extends Placeable<T>> extends TopologyElement {
+    
+    /**
+     * Fuse this container with other topology elements so that
+     * at runtime they all execute within the same operating system process.
+     * At runtime the process will require a resource that has been tagged with
+     * all the {@link #addResourceTags(String...) resource tags added} to each fused element.
+     * 
+     * @param elements Elements to fuse with this container.
+     * 
+     * @return this
+     */
+    public T fuse(Placeable<?> ... elements);
+    
+    /**
+     * Add required resource tags for this topology element for distributed submission.
+     * This topology element and any it has been {@link #fuse(Placeable...) fused}
+     * with will execute on a resource (host) that has all the tags returned by
+     * {@link #getHostTags()}.
+     * 
+     * @param tags Tags to be required at runtime.
+     * @return this
+     */
+    public T addResourceTags(String ... tags);
+    
+    /**
+     * Get the set of resource tags this element requires.
+     * If this topology element has been {@link #fuse(Placeable...) fused}
+     * with other topology elements then the returned set is the union
+     * of all {@link #addResourceTags(String...) resource tags added} to each fused element.
+     * @return Read-only set of host tags this element requires.
+     */
+    public Set<String> getResourceTags();
+}

--- a/java/src/com/ibm/streamsx/topology/context/Placeable.java
+++ b/java/src/com/ibm/streamsx/topology/context/Placeable.java
@@ -37,7 +37,7 @@ public interface Placeable<T extends Placeable<T>> extends TopologyElement {
      * Add required resource tags for this topology element for distributed submission.
      * This topology element and any it has been {@link #fuse(Placeable...) fused}
      * with will execute on a resource (host) that has all the tags returned by
-     * {@link #getHostTags()}.
+     * {@link #getResourceTags()}.
      * 
      * @param tags Tags to be required at runtime.
      * @return this

--- a/java/src/com/ibm/streamsx/topology/generator/spl/GraphUtilities.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GraphUtilities.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
+import com.ibm.streamsx.topology.builder.BVirtualMarker;
 import com.ibm.streamsx.topology.function.Consumer;
 
 class GraphUtilities {
@@ -29,14 +30,13 @@ class GraphUtilities {
         return starts;
     }
 
-    static ArrayList<JSONObject> findOperatorByKind(String opKind,
+    static ArrayList<JSONObject> findOperatorByKind(BVirtualMarker virtualMarker,
             JSONObject graph) {
         ArrayList<JSONObject> kindOperators = new ArrayList<JSONObject>();
         JSONArray ops = (JSONArray) graph.get("operators");
         for (int k = 0; k < ops.size(); k++) {
             JSONObject op = (JSONObject) (ops.get(k));
-            String kind = (String) op.get("kind");
-            if (kind != null && kind.equals(opKind)) {
+            if (virtualMarker.isThis((String) op.get("kind"))) {
                 kindOperators.add(op);
             }
         }
@@ -238,7 +238,7 @@ class GraphUtilities {
     // Visits every node in the region defined by the boundaries, and applies
     // to it the consumer's accept() method.
     static void visitOnce(List<JSONObject> starts,
-            List<String> boundaries, JSONObject graph,
+            Set<BVirtualMarker> boundaries, JSONObject graph,
             Consumer<JSONObject> consumer) {
         Set<JSONObject> visited = new HashSet<JSONObject>();
         List<JSONObject> unvisited = new ArrayList<JSONObject>();
@@ -261,7 +261,7 @@ class GraphUtilities {
 
     static void getUnvisitedAdjacentNodes(
             Collection<JSONObject> visited, Collection<JSONObject> unvisited,
-            JSONObject op, JSONObject graph, List<String> boundaries) {
+            JSONObject op, JSONObject graph, Set<BVirtualMarker> boundaries) {
         
         List<JSONObject> parents = GraphUtilities.getUpstream(op, graph);
         List<JSONObject> children = GraphUtilities.getDownstream(op, graph);
@@ -317,13 +317,13 @@ class GraphUtilities {
         }
     }
 
-    private static boolean equalsAny(List<String> boundaries, String opKind) {
+    private static boolean equalsAny(Set<BVirtualMarker> boundaries, String opKind) {
         if(boundaries == null){
             return false;
         }
         
-        for (String boundary : boundaries) {
-            if (boundary.equals(opKind))
+        for (BVirtualMarker boundary : boundaries) {
+            if (boundary.isThis(opKind))
                 return true;
         }
         return false;

--- a/java/src/com/ibm/streamsx/topology/generator/spl/PEPlacement.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/PEPlacement.java
@@ -22,8 +22,7 @@ class PEPlacement {
     private void assignColocations(JSONObject isolate, List<JSONObject> starts,
             JSONObject graph) {
 
-        final String colocationTag = "Colocation"
-                + Integer.toString(colocationCount++);
+        final String colocationTag = newColocationTag();
 
         List<String> boundaries = new ArrayList<>();
         boundaries.add("$Isolate$");
@@ -121,8 +120,7 @@ class PEPlacement {
         List<JSONObject> starts = GraphUtilities.findStarts(graph);   
         
         for(JSONObject start : starts){
-            final String colocationTag = "Colocation"
-                    + Integer.toString(colocationCount++);
+            final String colocationTag = newColocationTag();
             
             String regionTag = (String) start.get("colocationTag");
             if (regionTag != null && !regionTag.isEmpty()) {
@@ -157,6 +155,10 @@ class PEPlacement {
                         }
                     });           
         }
+    }
+    
+    private String newColocationTag() {
+        return "_jaa_colocate" + colocationCount++;
     }
 
     private static void assertNotIsolated(Collection<JSONObject> jsos) {

--- a/java/src/com/ibm/streamsx/topology/generator/spl/PEPlacement.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/PEPlacement.java
@@ -6,11 +6,13 @@ package com.ibm.streamsx.topology.generator.spl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.json.java.OrderedJSONObject;
-import com.ibm.streamsx.topology.builder.GraphBuilder;
+import com.ibm.streamsx.topology.builder.BVirtualMarker;
 import com.ibm.streamsx.topology.function.Consumer;
 
 class PEPlacement {
@@ -24,8 +26,7 @@ class PEPlacement {
 
         final String colocationTag = newColocationTag();
 
-        List<String> boundaries = new ArrayList<>();
-        boundaries.add("$Isolate$");
+        Set<BVirtualMarker> boundaries = EnumSet.of(BVirtualMarker.ISOLATE);
 
         GraphUtilities.visitOnce(starts, boundaries, graph,
                 new Consumer<JSONObject>() {
@@ -77,8 +78,7 @@ class PEPlacement {
 
         assertNotIsolated(isoParents);
 
-        List<String> boundaries = new ArrayList<>();
-        boundaries.add("$Isolate$");
+        Set<BVirtualMarker> boundaries = EnumSet.of(BVirtualMarker.ISOLATE);
 
         GraphUtilities.visitOnce(isoParents, boundaries, graph,
                 new Consumer<JSONObject>() {
@@ -97,7 +97,7 @@ class PEPlacement {
     void tagIsolationRegions(JSONObject graph) {
         // Check whether graph is valid for colocations
         List<JSONObject> isolateOperators = GraphUtilities.findOperatorByKind(
-                GraphBuilder.ISOLATE, graph);
+                BVirtualMarker.ISOLATE, graph);
         
         for (JSONObject jso : isolateOperators) {
             checkValidColocationRegion(jso, graph);
@@ -130,8 +130,7 @@ class PEPlacement {
             List<JSONObject> startList = new ArrayList<JSONObject>();
             startList.add(start);
             
-            List<String> boundaries = new ArrayList<>();
-            boundaries.add("$Isolate$");
+            Set<BVirtualMarker> boundaries = EnumSet.of(BVirtualMarker.ISOLATE);
             
             GraphUtilities.visitOnce(startList, boundaries, graph,
                     new Consumer<JSONObject>() {
@@ -163,7 +162,7 @@ class PEPlacement {
 
     private static void assertNotIsolated(Collection<JSONObject> jsos) {
         for (JSONObject jso : jsos) {
-            if ("$Isolate$".equals((String) jso.get("kind"))) {
+            if (BVirtualMarker.ISOLATE.isThis((String) jso.get("kind"))) {
                 throw new IllegalStateException(
                         "Cannot put \"isolate\" regions immediately"
                                 + " adjacent to each other. E.g -- .isolate().isolate()");
@@ -173,9 +172,9 @@ class PEPlacement {
     
     void tagLowLatencyRegions(JSONObject graph) {
         List<JSONObject> lowLatencyStartOperators = GraphUtilities
-                .findOperatorByKind(GraphBuilder.LOW_LATENCY, graph);
+                .findOperatorByKind(BVirtualMarker.LOW_LATENCY, graph);
         List<JSONObject> lowLatencyEndOperators = GraphUtilities
-                .findOperatorByKind(GraphBuilder.END_LOW_LATENCY, graph);
+                .findOperatorByKind(BVirtualMarker.END_LOW_LATENCY, graph);
 
         // Assign isolation regions their lowLatency tag
         for (JSONObject llStart : lowLatencyStartOperators) {
@@ -197,9 +196,8 @@ class PEPlacement {
         final String lowLatencyTag = "LowLatencyRegion"
                 + Integer.toString(lowLatencyRegionCount++);
 
-        List<String> boundaries = new ArrayList<>();
-        boundaries.add("$LowLatency$");
-        boundaries.add("$EndLowLatency$");
+        Set<BVirtualMarker> boundaries =
+                EnumSet.of(BVirtualMarker.LOW_LATENCY, BVirtualMarker.END_LOW_LATENCY);
 
         GraphUtilities.visitOnce(llStartChildren, boundaries, graph,
                 new Consumer<JSONObject>() {

--- a/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
@@ -7,7 +7,7 @@ package com.ibm.streamsx.topology.generator.spl;
 import java.util.List;
 
 import com.ibm.json.java.JSONObject;
-import com.ibm.streamsx.topology.builder.GraphBuilder;
+import com.ibm.streamsx.topology.builder.BVirtualMarker;
 
 /**
  * Preprocessor modifies the passed in JSON to perform
@@ -35,7 +35,7 @@ class Preprocessor {
     }
        
     private void removeUnionOperators(){
-        List<JSONObject> unionOps = GraphUtilities.findOperatorByKind(GraphBuilder.UNION, graph);
+        List<JSONObject> unionOps = GraphUtilities.findOperatorByKind(BVirtualMarker.UNION, graph);
         GraphUtilities.removeOperators(unionOps, graph);
     }
 }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -12,6 +12,7 @@ import java.util.List;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.json.java.OrderedJSONObject;
+import com.ibm.streamsx.topology.builder.BVirtualMarker;
 
 public class SPLGenerator {
     // Needed for composite name generation
@@ -303,12 +304,11 @@ public class SPLGenerator {
 
 
     private boolean isParallelEnd(JSONObject visitOp) {
-        return visitOp.get("kind").equals("$Unparallel$");
+        return BVirtualMarker.END_PARALLEL.isThis((String) visitOp.get("kind"));
     }
 
     private boolean isParallelStart(JSONObject visitOp) {
-        // TODO Auto-generated method stub
-        return visitOp.get("kind").equals("$Parallel$");
+        return BVirtualMarker.PARALLEL.isThis((String) visitOp.get("kind"));
     }
 
     /**

--- a/java/src/com/ibm/streamsx/topology/internal/core/PlacementInfo.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/PlacementInfo.java
@@ -86,8 +86,6 @@ class PlacementInfo {
                 fusedResourceTags.addAll(elementResourceTags);
             }            
             resourceTags.put(element, fusedResourceTags);
-            
-            updateFusingJSON(element, null);
         }
         return true;
     }

--- a/java/src/com/ibm/streamsx/topology/internal/core/PlacementInfo.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/PlacementInfo.java
@@ -1,0 +1,98 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+*/
+package com.ibm.streamsx.topology.internal.core;
+
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.TopologyElement;
+import com.ibm.streamsx.topology.context.Placeable;
+
+/**
+ * Manages fusing of Placeables. 
+ */
+class PlacementInfo {
+    
+    private static final Map<Topology, WeakReference<PlacementInfo>> placements = new WeakHashMap<>();
+    
+    private final Map<Placeable<?>, String> fusingIds = new HashMap<>();
+    private final Map<Placeable<?>, Set<String>> resourceTags = new HashMap<>();
+      
+    static PlacementInfo getPlacementInfo(TopologyElement te) {
+        
+        PlacementInfo pi; 
+        synchronized(placements) {
+            WeakReference<PlacementInfo> wr = placements.get(te.topology());
+            if (wr == null) {
+                wr = new WeakReference<>(new PlacementInfo());
+                placements.put(te.topology(), wr);
+            }
+            pi = wr.get();
+        }
+        
+        return pi;
+    }
+    
+    void fuse(Placeable<?> first, Placeable<?> ... toFuse) {
+        
+        Set<Placeable<?>> elements = new HashSet<>();
+        elements.add(first);
+        for (Placeable<?> element : toFuse) {
+            elements.add(element);
+            if (!first.topology().equals(element.topology()) )
+                throw new IllegalArgumentException();
+        }
+        
+        if (elements.size() < 2)
+            return;
+        
+        String fusingId = null;
+        for (Placeable<?> element : elements) {
+            fusingId = fusingIds.get(element);
+            if (fusingId != null) {
+                break;
+            }
+        }
+        if (fusingId == null) {
+            fusingId = "__jaa_fuse" + fusingIds.size();
+        }
+        
+        Set<String> fusedResourceTags = new HashSet<>();
+        
+        for (Placeable<?> element : elements) {
+            fusingIds.put(element, fusingId);
+            
+            Set<String> elementResourceTags = resourceTags.get(element);
+            if (elementResourceTags != null) {
+                fusedResourceTags.addAll(elementResourceTags);
+            }            
+            resourceTags.put(element, fusedResourceTags);
+        } 
+    }
+    
+    synchronized Set<String> getResourceTags(Placeable<?> element) {
+        Set<String> elementResourceTags = resourceTags.get(element);
+        if (elementResourceTags == null) {
+            return Collections.emptySet();
+        }
+        return Collections.unmodifiableSet(elementResourceTags);
+    }
+
+    synchronized void addResourceTags(Placeable<?> element, String ... tags) {
+        Set<String> elementResourceTags = resourceTags.get(element);
+        if (elementResourceTags == null) {
+            elementResourceTags = new HashSet<>();
+            resourceTags.put(element, elementResourceTags);
+        }
+        for (String tag : tags)
+            elementResourceTags.add(tag);       
+    } 
+}

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -561,6 +561,19 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     /* Placement control */
     private PlacementInfo placement;
     
+    @Override
+    public boolean isPlaceable() {
+        // TODO Auto-generated method stub
+        return output() instanceof BOutputPort;
+    }
+    
+    @Override
+    public BOperatorInvocation operator() {
+        if (isPlaceable())
+            return ((BOutputPort) output()).operator();
+        throw new IllegalStateException();
+    }
+    
     private PlacementInfo getPlacementInfo() {
         if (placement == null)
             placement = PlacementInfo.getPlacementInfo(this);
@@ -569,12 +582,7 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
 
     @Override
     public TStream<T> fuse(Placeable<?>... elements) {
-        if (getPlacementInfo().fuse(this, elements)) {
-            if (output() instanceof BOutputPort) {
-                BOutputPort bop = (BOutputPort) output;
-                getPlacementInfo().updateFusingJSON(this, bop.operator());
-            }
-        }
+        getPlacementInfo().fuse(this, elements);
             
         return this;
     }

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -557,25 +557,33 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     public boolean isKeyed() {
         return false;
     }
+    
+    /* Placement control */
+    private PlacementInfo placement;
+    
+    private PlacementInfo getPlacementInfo() {
+        if (placement == null)
+            placement = PlacementInfo.getPlacementInfo(this);
+        return placement;
+    }
 
     @Override
     public TStream<T> fuse(Placeable<?>... elements) {
-        // TODO Auto-generated method stub
-        return null;
+        getPlacementInfo().fuse(this, elements);
+        return this;
     }
 
     @Override
     public TStream<T> addResourceTags(String... tags) {
-        // TODO Auto-generated method stub
-        return null;
+        getPlacementInfo() .addResourceTags(this, tags);
+        return this;              
     }
 
     @Override
     public Set<String> getResourceTags() {
-        // TODO Auto-generated method stub
-        return null;
+        return getPlacementInfo() .getResourceTags(this);
     }
     
-    /* Placement control */
+
     
 }

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -28,6 +28,7 @@ import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.builder.BOutput;
 import com.ibm.streamsx.topology.builder.BOutputPort;
 import com.ibm.streamsx.topology.builder.BUnionOutput;
+import com.ibm.streamsx.topology.context.Placeable;
 import com.ibm.streamsx.topology.function.BiFunction;
 import com.ibm.streamsx.topology.function.Consumer;
 import com.ibm.streamsx.topology.function.Function;
@@ -338,7 +339,7 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
         
         BOperatorInvocation op;
         if (Schemas.usesDirectSchema(getTupleType())
-                 || this instanceof SPLStream) {
+                 || ((TStream<T>) this) instanceof SPLStream) {
             // Publish as a stream consumable by SPL & Java/Scala
             op = builder().addSPLOperator("Publish",
                     "com.ibm.streamsx.topology.topic::Publish",
@@ -556,4 +557,25 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     public boolean isKeyed() {
         return false;
     }
+
+    @Override
+    public TStream<T> fuse(Placeable<?>... elements) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public TStream<T> addResourceTags(String... tags) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Set<String> getResourceTags() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+    
+    /* Placement control */
+    
 }

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -28,6 +28,7 @@ import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.builder.BOutput;
 import com.ibm.streamsx.topology.builder.BOutputPort;
 import com.ibm.streamsx.topology.builder.BUnionOutput;
+import com.ibm.streamsx.topology.builder.BVirtualMarker;
 import com.ibm.streamsx.topology.context.Placeable;
 import com.ibm.streamsx.topology.function.BiFunction;
 import com.ibm.streamsx.topology.function.Consumer;
@@ -563,9 +564,12 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     
     @Override
     public boolean isPlaceable() {
-        if (output() instanceof BOutputPort)
-        System.out.println(((BOutputPort) output()).operator().json());
-        return output() instanceof BOutputPort;
+        if (output() instanceof BOutputPort) {
+            BOutputPort port = (BOutputPort) output();
+            return !BVirtualMarker.isVirtualMarker(
+                    (String) port.operator().json().get("kind"));
+        }
+        return false;
     }
     
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -569,7 +569,13 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
 
     @Override
     public TStream<T> fuse(Placeable<?>... elements) {
-        getPlacementInfo().fuse(this, elements);
+        if (getPlacementInfo().fuse(this, elements)) {
+            if (output() instanceof BOutputPort) {
+                BOutputPort bop = (BOutputPort) output;
+                getPlacementInfo().updateFusingJSON(this, bop.operator());
+            }
+        }
+            
         return this;
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -272,8 +272,8 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     }
 
     @Override
-    public void print() {
-        sink(new Print<T>());
+    public TSink print() {
+        return sink(new Print<T>());
     }
 
     @Override
@@ -575,7 +575,7 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
 
     @Override
     public TStream<T> addResourceTags(String... tags) {
-        getPlacementInfo() .addResourceTags(this, tags);
+        getPlacementInfo().addResourceTags(this, tags);
         return this;              
     }
 
@@ -583,7 +583,4 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     public Set<String> getResourceTags() {
         return getPlacementInfo() .getResourceTags(this);
     }
-    
-
-    
 }

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -563,7 +563,8 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     
     @Override
     public boolean isPlaceable() {
-        // TODO Auto-generated method stub
+        if (output() instanceof BOutputPort)
+        System.out.println(((BOutputPort) output()).operator().json());
         return output() instanceof BOutputPort;
     }
     

--- a/java/src/com/ibm/streamsx/topology/internal/core/TSinkImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/TSinkImpl.java
@@ -30,6 +30,11 @@ public class TSinkImpl extends TopologyItem implements TSink {
     /* Placement control */
     private PlacementInfo placement;
     
+    @Override
+    public boolean isPlaceable() {
+        return true;
+    }
+    
     private PlacementInfo getPlacementInfo() {
         if (placement == null)
             placement = PlacementInfo.getPlacementInfo(this);
@@ -38,8 +43,7 @@ public class TSinkImpl extends TopologyItem implements TSink {
 
     @Override
     public TSink fuse(Placeable<?>... elements) {
-        if (getPlacementInfo().fuse(this, elements))
-            getPlacementInfo().updateFusingJSON(this, operator());
+        getPlacementInfo().fuse(this, elements);
         return this;
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/core/TSinkImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/TSinkImpl.java
@@ -4,9 +4,12 @@
  */
 package com.ibm.streamsx.topology.internal.core;
 
+import java.util.Set;
+
 import com.ibm.streamsx.topology.TSink;
 import com.ibm.streamsx.topology.TopologyElement;
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
+import com.ibm.streamsx.topology.context.Placeable;
 
 /**
  * TSink implementation.
@@ -22,6 +25,32 @@ public class TSinkImpl extends TopologyItem implements TSink {
     @Override
     public BOperatorInvocation operator() {
         return op;
+    }
+    
+    /* Placement control */
+    private PlacementInfo placement;
+    
+    private PlacementInfo getPlacementInfo() {
+        if (placement == null)
+            placement = PlacementInfo.getPlacementInfo(this);
+        return placement;
+    }
+
+    @Override
+    public TSink fuse(Placeable<?>... elements) {
+        getPlacementInfo().fuse(this, elements);
+        return this;
+    }
+
+    @Override
+    public TSink addResourceTags(String... tags) {
+        getPlacementInfo().addResourceTags(this, tags);
+        return this;              
+    }
+
+    @Override
+    public Set<String> getResourceTags() {
+        return getPlacementInfo() .getResourceTags(this);
     }
 
 }

--- a/java/src/com/ibm/streamsx/topology/internal/core/TSinkImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/TSinkImpl.java
@@ -38,7 +38,8 @@ public class TSinkImpl extends TopologyItem implements TSink {
 
     @Override
     public TSink fuse(Placeable<?>... elements) {
-        getPlacementInfo().fuse(this, elements);
+        if (getPlacementInfo().fuse(this, elements))
+            getPlacementInfo().updateFusingJSON(this, operator());
         return this;
     }
 

--- a/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.context.Placeable;
 
 /**
  * Tests to verify Placeable
@@ -23,9 +24,20 @@ import com.ibm.streamsx.topology.Topology;
 public class PlaceableTest {  
 
     @Test
-    public void testSimpleTags() {
+    public void testSimpleTagsStream() {
         Topology t = new Topology();        
         TStream<String> s = t.strings("3");
+        testSimpleTags(s);
+    }
+    
+    @Test
+    public void testSimpleTagsSink() {
+        Topology t = new Topology();        
+        TStream<String> s = t.strings("3");
+        testSimpleTags(s.print());
+    }
+    
+    private void testSimpleTags(Placeable<?> s) {
         
         assertTrue(s.getResourceTags().isEmpty());
         
@@ -55,10 +67,30 @@ public class PlaceableTest {
     }
     
     @Test
-    public void testTagThenFuse() {
+    public void testTagThenFuseStream() {
         Topology t = new Topology();        
         TStream<String> s1 = t.strings("3");
         TStream<String> s2 = t.strings("3");
+        testTagThenFuse(s1, s2);
+    }
+    
+    @Test
+    public void testTagThenFuseSink() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+        testTagThenFuse(s1.print(), s2.print());
+    }
+    
+    @Test
+    public void testTagThenFuseStreamSink() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+        testTagThenFuse(s1, s2.print());
+    }
+    
+    private void testTagThenFuse(Placeable<?> s1, Placeable<?> s2) {
 
         assertTrue(s1.getResourceTags().isEmpty());
         assertTrue(s2.getResourceTags().isEmpty());
@@ -83,10 +115,28 @@ public class PlaceableTest {
     }
     
     @Test
-    public void testTagBothThenFuse() {
+    public void testTagBothThenFuseStream() {
         Topology t = new Topology();        
         TStream<String> s1 = t.strings("3");
         TStream<String> s2 = t.strings("3");
+        testTagBothThenFuse(s1, s2);
+    }
+    @Test
+    public void testTagBothThenFuseSink() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+        testTagBothThenFuse(s1.print(), s2.print());
+    }
+    @Test
+    public void testTagBothThenFuseSinkStream() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+        testTagBothThenFuse(s1.print(), s2);
+    }
+    
+    private void testTagBothThenFuse(Placeable<?> s1, Placeable<?> s2)  {
 
         assertTrue(s1.getResourceTags().isEmpty());
         assertTrue(s2.getResourceTags().isEmpty());
@@ -104,10 +154,28 @@ public class PlaceableTest {
     }
 
     @Test
-    public void testFuseThenTag() {
+    public void testFuseThenTagStream() {
         Topology t = new Topology();        
         TStream<String> s1 = t.strings("3");
         TStream<String> s2 = t.strings("3");
+        testFuseThenTag(s1, s2);
+    }
+    @Test
+    public void testFuseThenTagSink() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+        testFuseThenTag(s1.print(), s2.print());
+    }
+    @Test
+    public void testFuseThenTagStreamSink() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+        testFuseThenTag(s1, s2.print());
+    }
+    
+    private void testFuseThenTag(Placeable<?> s1, Placeable<?> s2) {
         
         assertTrue(s1.getResourceTags().isEmpty());
         assertTrue(s2.getResourceTags().isEmpty());

--- a/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
@@ -211,6 +211,8 @@ public class PlaceableTest {
         TStream<String> s2 = t.strings("3");
         TStream<String> snf = t.strings("3");
         
+        assertTrue(s1.isPlaceable());
+        
         assertSame(s1.fuse(s2), s1);
                 
                 
@@ -225,6 +227,7 @@ public class PlaceableTest {
         TStream<String> s3 = t.strings("3");
         TStream<String> s4 = t.strings("3");
         TSink s5 = s4.print();
+        assertTrue(s5.isPlaceable());
         
         assertSame(s3.fuse(s4, s5), s3);
         assertEquals(getFusingId(s3), getFusingId(s4));
@@ -238,6 +241,18 @@ public class PlaceableTest {
         s1.fuse(s6);
         assertEquals(getFusingId(s1), getFusingId(s6));
     }
+    
+    @Test
+    public void testNonplaceable() {
+        Topology t = new Topology();
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+        
+        assertFalse(s1.union(s2).isPlaceable());
+        // assertFalse(s1.isolate().isPlaceable());
+    }
+
+    
     
     private static String getFusingId(TStream<?> s) {
         BOperator bop  =  ((BOutputPort) s.output()).operator();

--- a/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
@@ -249,7 +249,11 @@ public class PlaceableTest {
         TStream<String> s2 = t.strings("3");
         
         assertFalse(s1.union(s2).isPlaceable());
-        // assertFalse(s1.isolate().isPlaceable());
+        assertFalse(s1.isolate().isPlaceable());
+        
+        TStream<String> sp = s1.parallel(3);
+        assertFalse(sp.isPlaceable());
+        assertFalse(sp.endParallel().isPlaceable());
     }
 
     

--- a/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
@@ -1,0 +1,129 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.test.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+
+/**
+ * Tests to verify Placeable
+ *
+ */
+public class PlaceableTest {  
+
+    @Test
+    public void testSimpleTags() {
+        Topology t = new Topology();        
+        TStream<String> s = t.strings("3");
+        
+        assertTrue(s.getResourceTags().isEmpty());
+        
+        s.addResourceTags();
+        assertTrue(s.getResourceTags().isEmpty());
+        
+        s.addResourceTags("ingest");        
+        assertEquals(Collections.singleton("ingest"), s.getResourceTags());
+        
+        s.addResourceTags();
+        assertEquals(Collections.singleton("ingest"), s.getResourceTags());
+        
+        s.addResourceTags("ingest");
+        assertEquals(Collections.singleton("ingest"), s.getResourceTags());
+
+        Set<String> expected = new HashSet<>();
+        expected.add("ingest");
+        expected.add("database");
+        
+        s.addResourceTags("database");
+        assertEquals(expected, s.getResourceTags());
+
+        expected.add("db2");
+        expected.add("sales");
+        s.addResourceTags("sales", "db2");
+        assertEquals(expected, s.getResourceTags());
+    }
+    
+    @Test
+    public void testTagThenFuse() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+
+        assertTrue(s1.getResourceTags().isEmpty());
+        assertTrue(s2.getResourceTags().isEmpty());
+        
+        s1.addResourceTags("ingest");
+        s1.fuse(s2);
+        assertEquals(Collections.singleton("ingest"), s1.getResourceTags());
+        assertEquals(s1.getResourceTags(), s2.getResourceTags());  
+        
+        Set<String> expected = new HashSet<>();
+        expected.add("ingest");
+        expected.add("database");
+        
+        s1.addResourceTags("database");
+        assertEquals(expected, s1.getResourceTags());
+        assertEquals(s1.getResourceTags(), s2.getResourceTags()); 
+        
+        expected.add("db2");
+        s2.addResourceTags("db2");
+        assertEquals(expected, s1.getResourceTags());
+        assertEquals(s1.getResourceTags(), s2.getResourceTags());  
+    }
+    
+    @Test
+    public void testTagBothThenFuse() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+
+        assertTrue(s1.getResourceTags().isEmpty());
+        assertTrue(s2.getResourceTags().isEmpty());
+        
+        s1.addResourceTags("ingest");
+        s2.addResourceTags("database");
+        s1.fuse(s2);
+        
+        Set<String> expected = new HashSet<>();
+        expected.add("ingest");
+        expected.add("database");
+        
+        assertEquals(expected, s1.getResourceTags());
+        assertEquals(s1.getResourceTags(), s2.getResourceTags()); 
+    }
+
+    @Test
+    public void testFuseThenTag() {
+        Topology t = new Topology();        
+        TStream<String> s1 = t.strings("3");
+        TStream<String> s2 = t.strings("3");
+        
+        assertTrue(s1.getResourceTags().isEmpty());
+        assertTrue(s2.getResourceTags().isEmpty());
+
+        s1.fuse(s2);
+        assertTrue(s1.getResourceTags().isEmpty());
+        assertTrue(s2.getResourceTags().isEmpty());
+        
+        s1.addResourceTags("ingest");
+        s2.addResourceTags("database");
+     
+        Set<String> expected = new HashSet<>();
+        expected.add("ingest");
+        expected.add("database");
+        
+        assertEquals(expected, s1.getResourceTags());
+        assertEquals(s1.getResourceTags(), s2.getResourceTags()); 
+    }
+}


### PR DESCRIPTION
Do not merge, for review only!

Just adding as a indication of the direction for supporting host placement.

I added a new interface Placeable which has the fuse and add resource tag methods. It allows continued fluent style as was raised as an issue in #9 , e.g.

`top.endlessSource(…).addResourceTag("ingest").filter(...).transform(...)….`
