### PR TITLE
Kafka Tweaks for TSink and colocation

### DIFF
--- a/java/src/com/ibm/streamsx/topology/messaging/kafka/ConsumerConnector.java
+++ b/java/src/com/ibm/streamsx/topology/messaging/kafka/ConsumerConnector.java
@@ -177,6 +177,7 @@ public class ConsumerConnector {
             Util.tagOpAsJavaPrimitive(toOp(rawKafka), kind, className);
 
             rcvdMsgs = toMessageStream(rawKafka);
+            rcvdMsgs.colocate(rawKafka);
             
             // workaround streamsx.messaging issue#118 w/java8
             // isolate even in the single consumer case since we don't
@@ -198,6 +199,7 @@ public class ConsumerConnector {
                 Util.tagOpAsJavaPrimitive(toOp(rawKafka), kind, className);
                 
                 rcvdMsgs = toMessageStream(rawKafka);
+                rcvdMsgs.colocate(rawKafka);
                 
                 // workaround streamsx.messaging issue#118 w/java8
                 rcvdMsgs = rcvdMsgs.isolate();

--- a/java/src/com/ibm/streamsx/topology/messaging/kafka/ProducerConnector.java
+++ b/java/src/com/ibm/streamsx/topology/messaging/kafka/ProducerConnector.java
@@ -91,10 +91,11 @@ public class ProducerConnector {
      * {@link Message#getTopic()}.
      * Same as {@code produce(stream, null)}.
      * @param stream the stream to publish
+     * @return the sink element
      */
-    public void publish(TStream<? extends Message> stream)
+    public TSink publish(TStream<? extends Message> stream)
     {
-        publish(stream, null/*topic*/);
+        return publish(stream, null/*topic*/);
     }
 
     /**
@@ -122,12 +123,15 @@ public class ProducerConnector {
      * 
      * @param stream the stream to publish
      * @param topic topic to publish to.  May be null.
+     * @return the sink element
      * 
      * @throws IllegalArgumentException if an empty {@code topic} is specified.
      */
-    public void publish(TStream<? extends Message> stream, String topic) {
+    public TSink publish(TStream<? extends Message> stream, String topic) {
         if (topic!=null && topic.isEmpty())
             throw new IllegalArgumentException("topic");
+        
+        stream = stream.lowLatency();
         
         @SuppressWarnings("unchecked")
         SPLStream splStream = SPLStreams.convertStream((TStream<Message>)stream,
@@ -151,6 +155,7 @@ public class ProducerConnector {
                 splStream,
                 params);
         Util.tagOpAsJavaPrimitive(sink.operator(), kind, className);
+        return sink;
     }
     
     private static BiFunction<Message,OutputTuple,OutputTuple> 

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -174,13 +174,15 @@
      <property name="topology.test.showoutput" value="yes"/>
      <property name="topology.test.include.name" value="**/kafka/*Test.java"/>
      <antcall target="unittest.simple"/>
-  	 <if>
-  	 	<equals arg1="${topology.test.type}" arg2="STANDALONE_TESTER" />
-  	    <then>
-  	      <echo message="REMEMBER TO LOCATE AND TERMINATE orphaned standalone processes."/>
-  	    </then>
-  	 </if>
+  	 <condition property="topology.test.isStandalone">
+        <equals arg1="${topology.test.type}" arg2="STANDALONE_TESTER" />
+  	 </condition>
+  	 <antcall target="-warnOrphanedStandalone"/>
      <fail message="Unittests failed" if="topology.tests.failed"/>
+  </target>
+	
+  <target name="-warnOrphanedStandalone" if="topology.test.isStandalone">
+     <echo >REMEMBER TO LOCATE AND TERMINATE orphaned standalone processes.</echo>
   </target>
 
   <target name="unittest.simple" depends="jar">


### PR DESCRIPTION
- return TSink from publish(). Enhance test for verification.
- internally, colocate the SPL KafkaSink and the convert op (via lowLatency())
  - should be a no-op at this time as the default behavior is to fuse them
- internally, colocate the SPL KafkaSource and convert op (via colocate())
  - should be a no-op at this time as the default behavior is to fuse them