### PR TITLE
Fix testSubmissionParamsWithoutDefault for distributed.

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/streams/InvokeStandalone.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/InvokeStandalone.java
@@ -68,6 +68,10 @@ public class InvokeStandalone {
             @SuppressWarnings("unchecked")
             Map<String,Object> params = (Map<String,Object>) config.get(ContextProperties.SUBMISSION_PARAMS); 
             for(Map.Entry<String,Object> e :  params.entrySet()) {
+                // note: this execution path does correctly
+                // handle / preserve the semantics of escaped \t and \n.
+                // e.g., "\\n" is NOT treated as a newline 
+                // rather it's the two char '\','n'
                 commands.add(e.getKey()+"="+e.getValue().toString());
             }
         }

--- a/java/src/com/ibm/streamsx/topology/internal/streams/InvokeSubmit.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/InvokeSubmit.java
@@ -101,8 +101,15 @@ public class InvokeSubmit {
             @SuppressWarnings("unchecked")
             Map<String,Object> params = (Map<String,Object>) config.get(ContextProperties.SUBMISSION_PARAMS); 
             for(Map.Entry<String,Object> e :  params.entrySet()) {
+                // note: this "streamtool" execution path does NOT correctly
+                // handle / preserve the semantics of escaped \t and \n.
+                // e.g., "\\n" is treated as a newline 
+                // rather than the two char '\','n'
+                // This seems to be happening internal to streamtool.
+                // Adjust accordingly.
                 commands.add("-P");
-                commands.add(e.getKey()+"="+e.getValue().toString());
+                commands.add(e.getKey()+"="+e.getValue().toString()
+                                                .replace("\\", "\\\\\\"));
             }
         }
         commands.add(bundle.getAbsolutePath());

--- a/test/java/src/com/ibm/streamsx/topology/test/spl/SPLOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/spl/SPLOperatorsTest.java
@@ -93,9 +93,9 @@ public class SPLOperatorsTest extends TestTopology {
                 + " >");
         
         Random rand = new Random();
-        String r = "test\"Lit\nerals\\n" + rand.nextInt();
+        String r = "test    X\tY\"Lit\nerals\\nX\\tY " + rand.nextInt();
         opParamAdder.put("r", r);
-        String u = "test\"Lit\nerals\\n" + rand.nextInt();
+        String u = "test    X\tY\"Lit\nerals\\nX\\tY " + rand.nextInt();
         opParamAdder.put("u", SPL.createValue(u, MetaType.USTRING));
 
         boolean b = rand.nextBoolean();
@@ -127,6 +127,9 @@ public class SPLOperatorsTest extends TestTopology {
         SPL.addToolkit(topology, new File(getTestRoot(), "spl/testtk"));
         SPLStream paramTuple = SPL.invokeSource(topology, "testgen::TypeLiteralTester", opParamAdder.getParams(), schema);
 
+        // paramTuple.print();
+        // paramTuple.filter(new AllowAll<Tuple>());
+        
         Tester tester = topology.getTester();
         
         Condition<Long> expectedCount = tester.tupleCount(paramTuple, 1);
@@ -137,6 +140,7 @@ public class SPLOperatorsTest extends TestTopology {
 
         assertTrue(expectedCount.toString(), expectedCount.valid());
         Tuple tuple = mr.getMostRecentTuple();
+        // System.out.println("tuple: " + tuple);
         
         assertEquals(r, tuple.getString("r"));
         assertEquals(u, tuple.getString("u"));


### PR DESCRIPTION
fixes issue#190

streamtool is misbehaving with submission parameter value handling with respect to escape sequences such as "\\n" ultimately being incorrectly passed to the application as a newline instead of the two character sequence '\', 'n'.  This change works around the problem.