### PR TITLE
Bring TKeyedStream to parity with TSTream and parallel() variants

### DIFF
--- a/java/src/com/ibm/streamsx/topology/TKeyedStream.java
+++ b/java/src/com/ibm/streamsx/topology/TKeyedStream.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.ibm.streamsx.topology.function.Function;
 import com.ibm.streamsx.topology.function.Predicate;
+import com.ibm.streamsx.topology.function.Supplier;
 import com.ibm.streamsx.topology.function.UnaryOperator;
 
 /**
@@ -111,7 +112,20 @@ public interface TKeyedStream<T,K> extends TStream<T> {
     @Override
     TKeyedStream<T,K> parallel(int width,
             com.ibm.streamsx.topology.TStream.Routing routing);
-    
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    TKeyedStream<T,K> parallel(Supplier<Integer> width);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    TKeyedStream<T,K> parallel(Supplier<Integer> width,
+            com.ibm.streamsx.topology.TStream.Routing routing);
+   
     /**
      * {@inheritDoc}
      */

--- a/java/src/com/ibm/streamsx/topology/internal/core/KeyedStreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/KeyedStreamImpl.java
@@ -11,6 +11,7 @@ import com.ibm.streamsx.topology.builder.BOutput;
 import com.ibm.streamsx.topology.builder.BOutputPort;
 import com.ibm.streamsx.topology.function.Function;
 import com.ibm.streamsx.topology.function.Predicate;
+import com.ibm.streamsx.topology.function.Supplier;
 import com.ibm.streamsx.topology.function.ToIntFunction;
 import com.ibm.streamsx.topology.function.UnaryOperator;
 import com.ibm.streamsx.topology.internal.logic.KeyFunctionHasher;
@@ -114,6 +115,17 @@ class KeyedStreamImpl<T,K> extends StreamImpl<T> implements TKeyedStream<T, K> {
     
     @Override
     public TKeyedStream<T,K> parallel(int width,
+            com.ibm.streamsx.topology.TStream.Routing routing) {
+        return _key(super.parallel(width, routing));
+    }
+    
+    @Override
+    public TKeyedStream<T,K> parallel(Supplier<Integer> width) {
+        return parallel(width, Routing.KEY_PARTITIONED);
+    }
+    
+    @Override
+    public TKeyedStream<T,K> parallel(Supplier<Integer> width,
             com.ibm.streamsx.topology.TStream.Routing routing) {
         return _key(super.parallel(width, routing));
     }


### PR DESCRIPTION
add the missing the submission parameter parallel(Supplier) variants to TKeyedStream.