### PR TITLE
Use the tuple name method in a window operator naming

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/core/WindowDefinition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/WindowDefinition.java
@@ -152,7 +152,7 @@ public class WindowDefinition<T,K> extends TopologyItem implements TWindow<T,K> 
         
         String opName = LogicUtils.functionName(joiner);
         if (opName.isEmpty()) {
-            opName = getTupleClass().getSimpleName() + "Join";
+            opName = TypeDiscoverer.getTupleName(getTupleType()) + "Join";
         }
         
         Map<String, Object> params = getOperatorParams();


### PR DESCRIPTION
Fixes #210