### PR TITLE
Adapt to streamsx.messaging v3.0 (new Kafka Producer properties)

### DIFF
--- a/java/src/com/ibm/streamsx/topology/messaging/kafka/ProducerConnector.java
+++ b/java/src/com/ibm/streamsx/topology/messaging/kafka/ProducerConnector.java
@@ -67,7 +67,15 @@ public class ProducerConnector {
      * configuration properties at <a href="http://kafka.apache.org">http://kafka.apache.org</a>.
      * Configuration property values are strings.
      * <p>
-     * Minimal configuration typically includes:
+     * Starting with {@code com.ibm.streamsx.messaging v3.0}, the 
+     * Kafka "New Producer configs" are used.  Minimal configuration
+     * typically includes:
+     * <p>
+     * <ul>
+     * <li><code>bootstrap.servers</code></li>
+     * <li><code>acks</code></li>
+     * </ul>
+     * Earlier streamsx.messaging version's minimal configuration typically includes:
      * <ul>
      * <li><code>metadata.broker.list</code></li>
      * <li><code>serializer.class</code></li>

--- a/java/src/com/ibm/streamsx/topology/messaging/kafka/Util.java
+++ b/java/src/com/ibm/streamsx/topology/messaging/kafka/Util.java
@@ -13,9 +13,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import com.ibm.streamsx.topology.TopologyElement;
 
-class Util {
+public class Util {
     @SuppressWarnings("unused")
     private static final Util forCoverage = new Util();
     
@@ -51,4 +62,22 @@ class Util {
         }
     }
  
+    public static String identifyStreamsxMessagingVer() throws Exception {
+        String tkloc = System.getenv("STREAMS_INSTALL")
+                        + "/toolkits/com.ibm.streamsx.messaging";
+        File info = new File(tkloc, "info.xml");
+        // e.g., <info:version>2.0.1</info:version>
+
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document d = db.parse(info);
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        NodeList nodes = (NodeList)xpath.evaluate("/toolkitInfoModel/identity/version",
+                d.getDocumentElement(), XPathConstants.NODESET);
+        Element e = (Element) nodes.item(0);
+        Node n = e.getChildNodes().item(0);
+        String ver = n.getNodeValue();
+        return ver;
+    }
+
 }


### PR DESCRIPTION
fixes #240

- update the kafka.ProducerConnector doc
- update the KafkaSample to use the correct properties based on the
STREAMS_INSTALL/.../com.ibm.streamsx.messaging tk version
- ditto for the kafka tests