### PR TITLE
Simplify PyFunctionTransform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ test/spl/testtk
 test/python/topology/tk*
 test/spl/testtk
 test/java
-com.ibm.streamsx.topology/opt/python/packages/streamsx
 com.ibm.streamsx.topology/toolkit.xml
 samples/python/com.ibm.streamsx.topology.pysamples/com.ibm.streamsx.topology.pysamples.mail/
 samples/python/com.ibm.streamsx.topology.pysamples/com.ibm.streamsx.topology.pysamples.positional/

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_cpp.cgt
@@ -64,31 +64,29 @@ MY_OPERATOR::MY_OPERATOR() : function_(NULL), pickleObjectFunction_(NULL)
 
 <% if ($pystyle eq 'python') { %>
 
-    PyObject * depickleInput = NULL;
-    PyObject * funcArg = PyTuple_New(1);
+    // The object to be called is either appCallable for
+    // a function passed into the operator
+    // or a pickled encoded class instance
+    // represented as a string in parameter pyCallable
     
     <% if ($pyCallable) { %>
-      depickleInput = streamsx::topology::Splpy::loadFunction("streamsx.topology.runtime", "depickleInputForCallableInstance");
+    //   depickleInput = streamsx::topology::Splpy::loadFunction("streamsx.topology.runtime", "depickleInputForCallableInstance");
       // argument is the serialized callable instance
-      PyTuple_SetItem(funcArg, 0, Py_BuildValue("s", <%=$pyCallable%>));
       Py_DECREF(appCallable);
-    <%} else {%>
-      depickleInput = streamsx::topology::Splpy::loadFunction("streamsx.topology.runtime", "depickleInput");
-      // argument is the application function
-      PyTuple_SetItem(funcArg, 0, appCallable);
+      appCallable = Py_BuildValue("s", <%=$pyCallable%>);
     <%}%>
 
+     PyObject * depickleInput = streamsx::topology::Splpy::loadFunction("streamsx.topology.runtime", "depickleInputPickleReturn");
+    PyObject * funcArg = PyTuple_New(1);
+    PyTuple_SetItem(funcArg, 0, appCallable);
     function_ = PyObject_CallObject(depickleInput, funcArg);
+    Py_DECREF(depickleInput);
+    Py_DECREF(funcArg);
     if(function_ == 0){
       PyErr_Print();
-      Py_DECREF(depickleInput);
-      Py_DECREF(funcArg);
       throw;
     }
 
-    Py_DECREF(depickleInput);
-    Py_DECREF(funcArg);
-    
     pickleObjectFunction_ = 
       streamsx::topology::Splpy::loadFunction("streamsx.topology.runtime", "pickleObject"); 
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_cpp.cgt
@@ -25,7 +25,7 @@
 %>
 
 // Constructor
-MY_OPERATOR::MY_OPERATOR() : function_(NULL), pickleObjectFunction_(NULL)
+MY_OPERATOR::MY_OPERATOR() : function_(NULL)
 {
   std::string tkDir = ProcessingElement::pe().getToolkitDirectory();
   std::string streamsxDir = tkDir + "/opt/python/packages/streamsx/topology";
@@ -87,9 +87,6 @@ MY_OPERATOR::MY_OPERATOR() : function_(NULL), pickleObjectFunction_(NULL)
       throw;
     }
 
-    pickleObjectFunction_ = 
-      streamsx::topology::Splpy::loadFunction("streamsx.topology.runtime", "pickleObject"); 
-
 <%}%>
 <% if ($pystyle eq 'string') { %>
     function_ = appCallable;
@@ -101,13 +98,10 @@ MY_OPERATOR::MY_OPERATOR() : function_(NULL), pickleObjectFunction_(NULL)
 MY_OPERATOR::~MY_OPERATOR() 
 {
     // Finalization code goes here
-    if (function_ || pickleObjectFunction_) {
+    if (function_) {
       streamsx::topology::PyGILLock lock;
       if (function_) {
         Py_DECREF(function_);
-      }
-      if (pickleObjectFunction_) {
-        Py_DECREF(pickleObjectFunction_);
       }
     }
 }
@@ -146,7 +140,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
   SPL::rstring value = ip.get_string();
 <%}%>
 
-  std::auto_ptr<SPL::blob> out_blob = streamsx::topology::Splpy::pyTupleTransform(function_, pickleObjectFunction_, value);
+  std::auto_ptr<SPL::blob> out_blob = streamsx::topology::Splpy::pyTupleTransform(function_, value);
   if (out_blob.get()) {
     OPort0Type otuple(*out_blob);
     submit(otuple, 0);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_h.cgt
@@ -33,12 +33,10 @@ public:
 private:
     // Members
     
-    // Python nested function that depickles the input value
+    // Python function that processes the input value
     // and calls the application function
+    // and returns a suitable value
     PyObject *function_;
-    
-    // Python utility function that pickles the input value
-    PyObject *pickleObjectFunction_;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -150,7 +150,7 @@ namespace streamsx {
       return ret;
     }
     
-    static std::auto_ptr<SPL::blob> pyTupleTransform(PyObject * function, PyObject * pickleObjectFunction, SPL::blob & pyblob) {
+    static std::auto_ptr<SPL::blob> pyTupleTransform(PyObject * function, SPL::blob & pyblob) {
 
       std::auto_ptr<SPL::blob> ret;
       PyGILLock lock;

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -168,19 +168,11 @@ namespace streamsx {
         throw;
       } 
 
-      // invoke python utliity function that pickles the return value from the
-      // application function
-      PyObject * pyPickledReturnVar = pyTupleFunc(pickleObjectFunction, pyReturnVar);
-      if (pyPickledReturnVar == 0){
-        PyErr_Print();
-        throw;
-      }
-      
-       // construct spl blob from pickled return value
-      long int size = PyBytes_Size(pyPickledReturnVar);
-      char * bytes = PyBytes_AsString(pyPickledReturnVar);          
+      // construct spl blob from pickled return value
+      long int size = PyBytes_Size(pyReturnVar);
+      char * bytes = PyBytes_AsString(pyReturnVar);          
       ret.reset(new SPL::blob((const unsigned char *)bytes, size));
-      Py_DECREF(pyPickledReturnVar);
+      Py_DECREF(pyReturnVar);
       return ret;
     }
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -25,10 +25,42 @@ def pickleReturn(function) :
 
 # Given a callable 'callable', return a function
 # that depickles the input and then calls 'callable'
+# returning the callable's return
 def depickleInput(callable) :
+    callable = _getCallable(callable)
     def _depickleInput(v):
         return callable(pickle.loads(v))
     return _depickleInput
+
+# Get the callable from the value
+# passed into the SPL PyFunction operator.
+#
+# It is either something that is callable
+# and is used directly or is string
+# that is a encoded pickled class instance
+#
+# TODO throw exception
+def _getCallable(f):
+    if callable(f):
+        return f
+    if isinstance(f, str):
+        ci = pickle.loads(base64.b64decode(f))
+        if callable(ci):
+            return ci
+    return None
+
+# Given a callable 'callable', return a function
+# that depickles the input and then calls 'callable'
+# returning the callable's return already pickled.
+# If the return is None then it is not pickled.
+def depickleInputPickleReturn(callable):
+    ac = _getCallable(callable)
+    def _depickleInputPickleReturn(v):
+        rv = ac(pickle.loads(v))
+        if rv is None:
+            return None
+        return pickle.dumps(rv)
+    return _depickleInputPickleReturn
 
 # Given a serialized callable instance, 
 # deserialize and return the callable


### PR DESCRIPTION
The intention was to have tuple processing only call a single python function, wrapping the user's function or callable in a function that did the pickling & depickling. Basically the goal is to do as much in Python as possible, rather than have to switch between Python and C++ multiple times.

The second commit:
* Uses a single setup function that supports a function or a serialized class instance when creating the wrapper that will be called at tuple processing.
* The wrapper function depickles the input and pickles the return value.

The third commit removes pythonObjectFunction as it is no longer used.

This is a step to having:
* consistent shared code between the functional Python operators
* supporting multiple types in line with the topology toolkit  ( @sdickes related to pull request #298 )

