### PR TITLE
Add initial publish/subscribe support.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -272,6 +272,19 @@ To avoid name conflicts, do not create modules with the same name as
 
   return: A Stream whose tuples are the result of the output obtained by invoking the provided callable.
 
+* `subscribe(self, topic, schema=CommonSchema.Python)` function on `Topology`
+
+  Subscribe to a topic published by other Streams applications.
+  A Streams application may publish a stream to allow other
+  applications to subscribe to it. A subscriber matches a
+  publisher if the topic and schema match.
+
+  See [namespace:com.ibm.streamsx.topology.topic] for more details.
+
+  param `topic`: Topic to subscribe to.
+  param `schema`: Schema to subscriber to. Defaults to CommonSchema.Python representing Python objects.
+  return: A Stream whose tuples have been published to the topic by other Streams applications.
+
 * `sink(self, func)` function on `Stream`
 
   Sends information as a stream to an external system.
@@ -376,13 +389,26 @@ To avoid name conflicts, do not create modules with the same name as
      
   param `width`: degree of parallelism
   
-  return: Stream
+  return: Stream whose subsequent processing will occur on `width` channels.
         
 * `end_parallel(self)` function on `Stream`
 
   Ends a parallel region by merging the channels into a single stream
   
   return: A Stream for which subsequent transformations are no longer parallelized
+* `publish(self, topic, schema=schema.CommonSchema.Python)` function on `Stream`
+
+  Publish this stream on a topic for other Streams applications to subscribe to.
+  A Streams application may publish a stream to allow other
+  applications to subscribe to it. A subscriber matches a
+  publisher if the topic and schema match.
+
+  See [namespace:com.ibm.streamsx.topology.topic] for more details.
+
+  param `topic`: Topic to publish this stream to.
+  param: `schema`: Schema to publish. Defaults to CommonSchema.Python representing Python objects.
+
+  return: None
 
 # Sample Transform Application
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/namespace-info.spl
@@ -55,6 +55,14 @@
  * A Java application uses [../../javadoc/com/ibm/streamsx/topology/TStream.html#publish(java.lang.String)|TStream.publish(topic)]
  * to publish streams.
  * 
+ * # Python Publish-Subscribe
+ * A Python application uses `Stream.publish(topic)` to publish
+ * streams and `Topology.subscribe(topic)` to subscribe to published
+ * streams.
+ *
+ * Python only supports publishing and subscribing to streams
+ * containing Python objects.
+ *
  * # Interchangeable Stream Types
  * 
  * Published streams can be subscribed to by IBM Streams applications

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -147,13 +147,19 @@ class SPLInvocation(object):
         _op["config"] = {}
 
         _params = {}
-        for param in self.params:
-            _value = {}
-            _value["value"] = self.params[param]
-            _params[param] = _value
-
+        # Add parameters as their string representation
+        # unless they value has a spl_json() function,
+        # then use that
+        _params = {}
+        for name in self.params:
+            param = self.params[name]
+            try:
+                _params[name] = param.spl_json()
+            except:
+                _value = {}
+                _value["value"] = param
+                _params[name] = _value
         _op["parameters"] = _params
-
         return _op
 
     def _addOperatorFunction(self, function):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -1,7 +1,7 @@
 import enum
 
 class StreamSchema(object) :
-    """SPL Schema"""
+    """SPL stream schema"""
 
     def __init__(self, schema):
         self.__schema=schema
@@ -9,10 +9,17 @@ class StreamSchema(object) :
     def schema(self):
         return self.__schema;
 
+    def spl_json(self):
+        _splj = {}
+        _splj["type"] = 'spltype'
+        _splj["value"] = self.schema()
+        return _splj
+
 # XML = StreamSchema("tuple<xml document>")
 
 @enum.unique
 class CommonSchema(enum.Enum):
+    """Common stream schemas for interoperability"""
     Python = StreamSchema("tuple<blob __spl_po>")
     Json = StreamSchema("tuple<rstring jsonString>")
     String = StreamSchema("tuple<rstring string>")
@@ -20,6 +27,9 @@ class CommonSchema(enum.Enum):
 
     def schema(self):
         return self.value.schema();
+
+    def spl_json(self):
+        return self.value.spl_json()
 
     def subscribeOp(self):
         if (self == CommonSchema.String):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -30,7 +30,3 @@ class CommonSchema(enum.Enum):
 
     def spl_json(self):
         return self.value.spl_json()
-
-    def subscribeOp(self):
-        if (self == CommonSchema.String):
-            return "com.ibm.streamsx.topology.topic::SubscribeString"

--- a/samples/python/topology/pubsub/publish.py
+++ b/samples/python/topology/pubsub/publish.py
@@ -1,0 +1,39 @@
+from streamsx.topology.topology import *
+import streamsx.topology.context
+import pubsub_functions;
+
+# Application that publishes a stream
+# of integers with the topic 'simple'.
+#
+# This app is submitted to a distributed
+# Streams instance using
+#
+# python3 publish.py
+#
+# This is the companion application to subscribe.py
+#
+# Any number of these applications can be submitted
+# as publish subscribe model is a many publisher
+# to many subscriber model
+
+def main():
+  topo = Topology("PublishSimple")
+
+  # Create a source that is a sequence 0..inifinity
+  ts = topo.source(pubsub_functions.sequence)
+
+  # Delay to reduce cpu overhead for the demo
+  ts = ts.filter(pubsub_functions.delay)
+
+  # Publish the stream as Python objects with
+  # topic simple.
+  ts.publish('simple')
+
+  # Also print to see some output (in the PE Console log)
+  ts.print()
+
+  # Submit application to a distributed instance
+  streamsx.topology.context.submit('DISTRIBUTED', topo.graph)
+
+if __name__ == '__main__':
+    main()

--- a/samples/python/topology/pubsub/pubsub_functions.py
+++ b/samples/python/topology/pubsub/pubsub_functions.py
@@ -1,0 +1,9 @@
+import itertools
+import time
+
+def sequence():
+    return itertools.count()
+
+def delay(v):
+    time.sleep(0.1)
+    return True

--- a/samples/python/topology/pubsub/subscribe.py
+++ b/samples/python/topology/pubsub/subscribe.py
@@ -1,0 +1,30 @@
+from streamsx.topology.topology import *
+import streamsx.topology.context
+
+# Application that subscribes to a stream
+# with the topic 'simple'.
+#
+# This app is submitted to a distributed
+# Streams instance using
+#
+# python3 subscribe.py
+#
+# This is the companion application to publish.py
+#
+# Any number of these applications can be submitted
+# as publish subscribe model is a many publisher
+# to many subscriber model
+
+def main():
+  topo = Topology("SubscribeSimple")
+
+  # Subscribe to streams with Python objects and topic 'simple'
+  ts = topo.subscribe('simple')
+
+  # Print to see some output (in the PE Console log)
+  ts.print()
+
+  streamsx.topology.context.submit("DISTRIBUTED", topo.graph)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds publish subscribe between Python applications where the streams contain python objects.

Includes a sample application, that can be run multiple times to end up with live graph views like this:

![image](https://cloud.githubusercontent.com/assets/3769612/14446856/30a51ff0-000f-11e6-9acc-bc8903839d7e.png)
