### PR TITLE
Require Streams 4.0.1

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,9 +16,9 @@ The Apache Ant `build.xml` files are setup to assume that the Junit and Jacoco j
 jacocoagent.jar  jacocoant.jar  junit-4.10.jar
 ```
 
-The project also requires a local install of IBM InfoSphere Streams 4.x, with the environment variable `STREAMS_INSTALL` set to the root of the install. The recommended setup is to source the `bin/streamsprofile.sh` script in the Streams install.
+The project also requires a local install of IBM InfoSphere Streams 4.x (>= 4.0.1.0), with the environment variable `STREAMS_INSTALL` set to the root of the install. The recommended setup is to source the `bin/streamsprofile.sh` script in the Streams install.
 ```
-> source /opt/ibm/InfoSphere_Streams/4.0.0.0/bin/streamsprofile.sh
+> source /opt/ibm/InfoSphere_Streams/4.0.1.0/bin/streamsprofile.sh
 InfoSphere Streams environment variables have been set.
 ```
 

--- a/com.ibm.streamsx.topology/info.xml
+++ b/com.ibm.streamsx.topology/info.xml
@@ -27,8 +27,9 @@ in other languages.
 
 
     </description>
-    <version>1.1.3</version>
-    <requiredProductVersion>4.0.0.0</requiredProductVersion>
+    <version>1.1.6</version>
+    <!-- Require Java 8 so minimium is 4.0.1.0 -->
+    <requiredProductVersion>4.0.1.0</requiredProductVersion>
     </identity>
   <dependencies/>
   <sabFiles>

--- a/common-build.xml
+++ b/common-build.xml
@@ -20,8 +20,8 @@
   <fileset  id="junit.path" dir="${user.home}/.ant/lib" includes="junit-*.jar" erroronmissingdir="no"/>
   <pathconvert property="junit.jar" refid="junit.path"/>
 
-  <property name="ant.build.javac.source" value="7"/>
-  <property name="ant.build.javac.target" value="7"/>
+  <property name="ant.build.javac.source" value="8"/>
+  <property name="ant.build.javac.target" value="8"/>
 
   <property name="topology.test.root" location="${streamsx.topology}/test"/>
 

--- a/java/src/com/ibm/streamsx/topology/package-info.java
+++ b/java/src/com/ibm/streamsx/topology/package-info.java
@@ -6,7 +6,7 @@
  * Java application API for IBM Streams.
  * 
  * This API is used to generate streaming topologies for
- * execution by IBM Streams 4.0 or later. An instance
+ * execution by IBM Streams 4.0.1 or later. An instance
  * of {@link com.ibm.streamsx.topology.Topology} is created
  * that then is used to build a topology (or graph) of
  * streams, represented by {@link com.ibm.streamsx.topology.TStream}

--- a/java/src/overview.html
+++ b/java/src/overview.html
@@ -102,7 +102,7 @@ implemented as Java and/or Scala functions. A Java function is an implementation
 or when using Java 8 a lambda expression or a method reference.</TD><TD>{@link com.ibm.streamsx.topology.TStream}</TD><TD>1.0</TD></TR>
 
 <TR class="rowColor"><TD>Execution within the Java virtual machine, IBM Streams
-4.0+ Streams standalone or distributed & IBM Bluemix</TD><TD>{@link com.ibm.streamsx.topology.context.StreamsContext}</TD><TD>1.0</TD></TR>
+4.0.1+ Streams standalone or distributed & IBM Bluemix</TD><TD>{@link com.ibm.streamsx.topology.context.StreamsContext}</TD><TD>1.0</TD></TR>
 
 <TR class="altColor"><TD>Pipeline topologies.</TD><TD>{@link com.ibm.streamsx.topology.Topology}</TD><TD>1.0</TD></TR>
 <TR class="rowColor"><TD>Fan-out, multiple independent functions may be applied to a


### PR DESCRIPTION
and compile with Java 8.

Tested building the toolkit with Streams 4.1 and then running the tests on 4.0.1 against the 4.1 build toolkit.