### PR TITLE
Wildcard support for topics.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/namespace-info.spl
@@ -13,23 +13,43 @@
  * those written using application APIs
  * provided by this toolkit.
  *
- * A subscriber matches a publisher if their topic
- * and stream type are an exact match to that of the publisher.
+ * A subscriber matches a publisher if their topic filter matches
+ * a publisher's topic name
+ * and the stream type is an exact match to that of the publisher.
  * It is recommended that a single stream type is used for a topic name.
  *
- * A topic is a `rstring` value (encoded with UTF-8), it is recommended that the
- * [http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#appendix-a|MQTT topic style]
- * is used, and that topic names do not
- * include wild-cards. Future versions may support subscription
- * by MQTT style wild cards (e.g. `cdr/voice/\*`).
+ * A topic is a `rstring` value (encoded with UTF-8), based upon the
+ * [http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#appendix-a|MQTT topic style].
  *
  * Topic names for publishing a stream:
  *
  *  * Must be at least one character long.
- *  * Use `/` as a level separator.
- *  * Must not include wild card characters `*` and `#`.
+ *  * Use `/` as a level separator, zero length topic levels are valid.
+ *  * Must not include wild card characters `\+` and `\#`.
  *  * Must not include the nul character `\\u0000`.
- * 
+ *
+ * Topic filters for subscribing to streams:
+ *  * Must be at least one character long.
+ *  * Use `/` as a level separator.
+ *  * Must not include the nul character `\\u0000`.
+ *  * `\+` is a single-level wildcard character that can be used at any level, but it must occupy the entire level. `+`, `a/b/+`, `+/b/+` and `+/b` are valid but `a/b/c+` is not valid.
+ *  * `\#` is a wildcard character that matches any number of levels including the parent and any number of child levels. The multi-level wildcard character must be specified either on its own or following a topic level separator. In either case it must be the last character specified in the topic filter. `#` and 'a/b/#' are valid but `a/b/c#` and `a/#/c` are not valid.
+ *
+ * Without a wildcard character a topic filter is an exact match for a topic name
+ * so that filter `a/b/c` only matches `a/b/c`.
+ *
+ * Single-level filter (`+`) match examples are:
+ * * filter `+` matches `a` and `b` but not `a/b`
+ * * filter `a/+` matches `a/b`, `a/c` and `a/` but not `a`, `b/c` or `a/b/c`
+ * * filter `+/+` matches `a/b`, `b/c`, `d/` and `/`  but not `a` or `a/b/c`
+ *
+ * Multi-level filter (`#`) match examples are:
+ * * filter `#` matches every topic name such as `a`, `b/c`, `//`
+ * * filter `a/b/#` matches `a/b` (parent), `a/b/c`, `a/b/d` and `a/b/c/d`
+ *
+ * **Note:** *a publish-subscribe match requires the stream type
+ * to match as well as the topic filter matching the topic name.*
+ *
  * Publish-subscribe is a many to many relationship,
  * any number of publishers can publish to the same topic
  * and stream type, and there can be many subscribers to a topic.
@@ -91,7 +111,7 @@
  *
  * # Behavior with parallel regions
  * 
- * Topic publish-subscribe model was changed for releases 1.1.X
+ * Topic publish-subscribe model was changed for releases 1.1.6
  * to have intuitive and defined behavior when the publisher or subscriber
  * is in a parallel region (with width > 1).
  * 
@@ -131,7 +151,7 @@
  * | *M > 1*       | *N > 1*       |                                                                                                                                                                    |
  * -----------------------------------------------
 
- * **Note** *It's important to remember there may be multiple applications publishing and/or subscribing to the same topic and thus publish/subscribe must work in all combinations,
+ * **Note:** *It's important to remember there may be multiple applications publishing and/or subscribing to the same topic and thus publish/subscribe must work in all combinations,
  * e.g. there may be a publishers to the same topic of non-parallel, parallel(5) and parallel(3), and subscribers of non-parallel and parallel(7). This is especially true in a microservices style
  * architecture where analytic applications may come and go and there may not be pre-assigned agreement that publisher and subscribers will have matching channel numbers.*
  * 
@@ -146,7 +166,8 @@
  * using these stream properties:
  * * `int64 __spl_version`: Version of the publish properties scheme, set to.
  *   * unset - Initial version - 1.1.2 release
- *   * `2` - Second version: `__spl_version >= 2`
+ *   * `2` - Second version - 1.1.6 release - Support for filtering and parallel regions
+ *   * `3` - Third version - 1.3.0 release - Support for topic filters with wildcards
  * * `rstring __spl_exportType` : Set to the literal `topic` for SPL publish, `topic.java` for publishing by a Java class.
  * * `rstring __spl_topic` : Set to the topic to publish to.
  * * `rstring __spl_allowFilter` : Set to `true` if the [Publish] operator allows filters, otherwise `false`. Earlier releases have the value missing indicating filters are allowed.
@@ -156,6 +177,10 @@
  *   * Set if:`__spl_version >= 2`
  * * `int64 __spl_maxChannels` : Set to the publisher's maximum number of parallel channels returned by `getMaxChannels()`.
  *   * Set if:`__spl_version >= 2`
+ * * `list<rstring> __spl_topicLevels` : list of the levels within the topic.
+ *   * Set if:`__spl_version >= 3`
+ * * `int64 __spl_topicLevelCount` : count of the levels within the topic.
+ *   * Set if:`__spl_version >= 3`
  *
  * [Subscribe] is a composite operator that invokes an `spl.adapter::Import` operator
  * using a subscription to match the published topics.

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topics.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topics.spl
@@ -35,24 +35,32 @@ public composite Publish(input In )
 }
 
 stateful int32 setTopicNameProperties(rstring topicName, boolean allowFilter) {
-   appLog(spl::Log.error, "Setting Topic name:" + topicName);
+   appTrc(spl::Trace.debug, "Setting Topic name:" + topicName);
    if (!checkTopicName(topicName)) {
        appLog(spl::Log.error, "Topic name is invalid:" + topicName);
+       appTrc(spl::Trace.error, "Topic name is invalid:" + topicName);
        assert(true, "Topic name is invalid:" + topicName);
        return -1;
    }
-   appLog(spl::Log.error, "About to Setting Topic name:" + topicName);
+   list<rstring> levels = tokenize(topicName, "/", true);
    
    int32 rc = setOutputPortExportProperties(
                   {
-                     __spl_version = 2l,
+                     __spl_version = 3l,
                      __spl_exportType = "topic",
                      __spl_topic = topicName,
+                     __spl_topicLevels = levels,
+                     __spl_topicLevelCount = (int64) size(levels),
                      __spl_allowFilter = allowFilter ? "true" : "false",
                      __spl_channel = (int64) getChannel(),
                      __spl_maxChannels = (int64) getMaxChannels()
                   }, 0u);
-   appLog(spl::Log.error, "Set Topic name:" + topicName + " = " + (rstring) rc);
+
+   appTrc(spl::Trace.debug, "Set Topic name:" + topicName + " = " + (rstring) rc);
+   if (rc != 0) {
+       appLog(spl::Log.error, "Setting topic name failed:" + topicName + " rc=" + (rstring) rc);
+       assert(true, "Setting topic name failed:" + topicName + " rc=" + (rstring) rc);
+   }
 
    return rc;
 }
@@ -102,13 +110,66 @@ public composite Subscribe(output Topic )
  * @param topic Topic to subscribe to.
 */
 public rstring getTopicSubscription(rstring topic) {
+  appTrc(spl::Trace.debug, "Topic filter:" + topic);
   if (!checkTopicFilter(topic)) {
        appLog(spl::Log.error, "Topic filter is invalid:" + topic);
        assert(true, "Topic filter is invalid:" + topic);
        return "invalid topic filter:" + topic;
   }
+
+  // Wildcard expression is more complicated
+  if (findFirst(topic, "+") != -1 || findFirst(topic, "#") != -1) {
+      return wildcardExpression(topic);
+  }
        
   return "( __spl_exportType == \"topic\" ) && ( __spl_topic == " + makeRStringLiteral(topic) + " )";
+}
+
+rstring wildcardExpression(rstring filter) {
+
+    appTrc(spl::Trace.debug, "Wildcard topic filter:" + filter);
+
+    list<rstring> tokens = tokenize(filter, "/", true);
+    
+    boolean hasHash = findFirst(filter, "#") != -1;
+    
+    mutable rstring tw = "( ( __spl_exportType == \"topic\" )";
+    
+    // If there is not a hash wildcard then the topic name
+    // must have the same number of levels as the filter
+    if (!hasHash) {
+       tw += "&& ( __spl_topicLevelCount == " + (rstring) size(tokens) + " )";
+    }
+
+    // Single plus, single level, the level count check is sufficient.
+    if (filter == "+") {
+      tw += ")";
+      return tw;
+    }
+
+    for (int32 i in range(tokens)) {
+      rstring level = tokens[i];
+      
+      // match anything at this level
+      if (level == "+")
+          continue;
+          
+       tw += " && ";
+
+       if (hasHash) {
+           tw += "( ";
+           tw += "( __spl_topicLevelCount > " + (rstring) i + " )";
+           tw += " && ";
+       }
+       tw += "( __spl_topicLevels["+((rstring) i)+"] == " + makeRStringLiteral(level) + " )";
+       if (hasHash) {
+           tw += " )";
+       }
+       
+    }
+    tw += " )";
+    
+    return tw;
 }
 
 /**
@@ -224,7 +285,7 @@ public boolean checkTopicFilter(rstring topic) {
     for (rstring token in tokens) {
        if (token == "+")
            continue;
-       if (findFirst(topic, "+") != -1)
+       if (findFirst(token, "+") != -1)
            return false;
     }
       

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topics.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topics.spl
@@ -66,14 +66,15 @@ stateful int32 setTopicNameProperties(rstring topicName, boolean allowFilter) {
 }
 
 /**
- * Subscribe to a topic.
+ * Subscribe to topics using a filter.
  * Generates a stream that is subscribed, through
  * IBM Streams dynamic connections, to all streams
- * published to the same `topic` and `streamType`.
+ * published to topics that match the topic filter `topic`
+ * and are an exact stream type match to `streamType`.
  * See [namespace:com.ibm.streamsx.topology.topic] for details.
  
  * @output Topic Subscription to `topic`.
- * @param topic Topic to subscribe to.
+ * @param topic Topic filter to subscribe to.
  * @param streamType Type of output stream `Topic`.
 */
 public composite Subscribe(output Topic )
@@ -125,6 +126,13 @@ public rstring getTopicSubscription(rstring topic) {
   return "( __spl_exportType == \"topic\" ) && ( __spl_topic == " + makeRStringLiteral(topic) + " )";
 }
 
+/**
+  Create the subscription expression for supporting
+  wildcards. Assumes that:
+  1) the filter has been checked to be valid.
+  2) the filter does contain a wildcard. If there is no
+     wildcard then the simpler direct equality on topic is used.
+*/
 rstring wildcardExpression(rstring filter) {
 
     appTrc(spl::Trace.debug, "Wildcard topic filter:" + filter);
@@ -142,9 +150,21 @@ rstring wildcardExpression(rstring filter) {
     }
 
     // Single plus, single level, the level count check is sufficient.
-    if (filter == "+") {
+    // Single hash every topic is matched, just have the exportType check
+    if (filter == "+" || filter == "#") {
       tw += ")";
       return tw;
+    }
+
+    // If hashHash is true:
+    // This must be a '/#' wildcard at the end of the filter
+    // so we need to make sure we have at least the required
+    // number of levels, at least to cover a/+/# as the
+    // code below will not add any checks for the + sign.
+    // Note that a/+/# matches the parent as well, so
+    // there must be at least 2 levels (not 3).
+    if (hasHash) {
+       tw += "&& ( __spl_topicLevelCount >= " + (rstring) (size(tokens) - 1) + " )";
     }
 
     for (int32 i in range(tokens)) {
@@ -153,6 +173,10 @@ rstring wildcardExpression(rstring filter) {
       // match anything at this level
       if (level == "+")
           continue;
+
+      // must be the last element
+      if (level == "#")
+          break;
           
        tw += " && ";
 
@@ -209,7 +233,7 @@ public rstring addUDPSubscription(rstring subscription) {
 /**
  * Set a subscription expression adding in UDP
  * channel based matching if the subscriber
- * is in a paralel region.
+ * is in a parallel region.
  * @param subscription Subscription to be set on input port
  * connected to `Import` operator.
 */

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topics.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topics.spl
@@ -16,9 +16,24 @@ namespace com.ibm.streamsx.topology.topic ;
 */
 public composite Publish(input In )
 {
+    param
+      expression<rstring> $topic ;
+      expression<boolean> $allowFilter : false;
+
+    graph
+    () as PublishTopic = _Publish(In) {
+       param
+          topic: $topic;
+          allowFilter: $allowFilter;
+    }
+}
+
+composite _Publish(input In) {
 	param
-		expression<rstring> $topic ;
-        expression<boolean> $allowFilter : false;
+          expression<rstring> $exportType : "topic";
+          expression<rstring> $topic ;
+          expression<boolean> $allowFilter;
+          expression<rstring> $class : "";
 	graph
 		() as ExportTopic = Export(TopicProperties)
 		{
@@ -30,11 +45,11 @@ public composite Publish(input In )
                   allowFilter: $allowFilter;
 		}
                 stream<In> TopicProperties = Filter(In) {
-                   logic state: int32 rc = setTopicNameProperties($topic, $allowFilter);
+                   logic state: int32 rc = setTopicNameProperties($exportType, $topic, $allowFilter, $class);
                 }
 }
 
-stateful int32 setTopicNameProperties(rstring topicName, boolean allowFilter) {
+stateful int32 setTopicNameProperties(rstring exportType, rstring topicName, boolean allowFilter, rstring class) {
    appTrc(spl::Trace.debug, "Setting Topic name:" + topicName);
    if (!checkTopicName(topicName)) {
        appLog(spl::Log.error, "Topic name is invalid:" + topicName);
@@ -47,13 +62,14 @@ stateful int32 setTopicNameProperties(rstring topicName, boolean allowFilter) {
    int32 rc = setOutputPortExportProperties(
                   {
                      __spl_version = 3l,
-                     __spl_exportType = "topic",
+                     __spl_exportType = exportType,
                      __spl_topic = topicName,
                      __spl_topicLevels = levels,
                      __spl_topicLevelCount = (int64) size(levels),
                      __spl_allowFilter = allowFilter ? "true" : "false",
                      __spl_channel = (int64) getChannel(),
-                     __spl_maxChannels = (int64) getMaxChannels()
+                     __spl_maxChannels = (int64) getMaxChannels(),
+                     __spl_class = class
                   }, 0u);
 
    appTrc(spl::Trace.debug, "Set Topic name:" + topicName + " = " + (rstring) rc);
@@ -111,6 +127,10 @@ public composite Subscribe(output Topic )
  * @param topic Topic to subscribe to.
 */
 public rstring getTopicSubscription(rstring topic) {
+    return getTopicSubscription("topic", topic);
+}
+
+rstring getTopicSubscription(rstring exportType, rstring topic) {
   appTrc(spl::Trace.debug, "Topic filter:" + topic);
   if (!checkTopicFilter(topic)) {
        appLog(spl::Log.error, "Topic filter is invalid:" + topic);
@@ -120,10 +140,11 @@ public rstring getTopicSubscription(rstring topic) {
 
   // Wildcard expression is more complicated
   if (findFirst(topic, "+") != -1 || findFirst(topic, "#") != -1) {
-      return wildcardExpression(topic);
+      return wildcardExpression(exportType, topic);
   }
        
-  return "( __spl_exportType == \"topic\" ) && ( __spl_topic == " + makeRStringLiteral(topic) + " )";
+  return "( __spl_exportType == " + makeRStringLiteral(exportType)
+         + ") && ( __spl_topic == " + makeRStringLiteral(topic) + " )";
 }
 
 /**
@@ -133,7 +154,7 @@ public rstring getTopicSubscription(rstring topic) {
   2) the filter does contain a wildcard. If there is no
      wildcard then the simpler direct equality on topic is used.
 */
-rstring wildcardExpression(rstring filter) {
+rstring wildcardExpression(rstring exportType, rstring filter) {
 
     appTrc(spl::Trace.debug, "Wildcard topic filter:" + filter);
 
@@ -141,7 +162,7 @@ rstring wildcardExpression(rstring filter) {
     
     boolean hasHash = findFirst(filter, "#") != -1;
     
-    mutable rstring tw = "( ( __spl_exportType == \"topic\" )";
+    mutable rstring tw = "( ( __spl_exportType ==" + makeRStringLiteral(exportType) + " )";
     
     // If there is not a hash wildcard then the topic name
     // must have the same number of levels as the filter

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topicsjava.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.topic/topicsjava.spl
@@ -19,19 +19,13 @@ public composite PublishJava(input In )
 		expression<rstring> $topic ;
 		expression<rstring> $class ;
 	graph
-		() as ExportTopic = Export(In)
+		() as PublishTopic = _Publish(In)
 		{
                    param
-                     properties :
-                    {
-                      __spl_version = 2,
-                      __spl_exportType = "topic.java",
-                      __spl_topic = $topic,
-                      __spl_class = $class,
-                      __spl_allowFilter = "false",
-                      __spl_channel = getChannel(),
-                      __spl_maxChannels = getMaxChannels()
-                    } ;
+                     exportType: "topic.java";
+                     topic: $topic;
+                     allowFilter: false;
+                     class: $class;
 		}
 }
 
@@ -74,5 +68,6 @@ public composite SubscribeJava(output Topic )
  * @exclude
 */
 rstring getTopicJavaSubscription(rstring topic, rstring class) {
-     return "( __spl_exportType == \"topic.java\" ) && ( __spl_topic == \"" + topic + "\" ) && ( __spl_class == \"" + class + "\" )";
+     return getTopicSubscription("topic.java", topic) 
+        + " && ( __spl_class == " + makeRStringLiteral(class) + " )";
 }

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -429,13 +429,12 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
         
         if (topic.isEmpty()
                 || topic.indexOf('\u0000') != -1
-                || topic.indexOf('*') != -1
+                || topic.indexOf('+') != -1
                 || topic.indexOf('#') != -1
                 )
         {
             throw new IllegalArgumentException("Invalid topic name:" + topic);
         }
-        
     }
     
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.streams.operator.StreamSchema;
-import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TSink;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.TWindow;
@@ -421,7 +420,7 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     /**
      * Topic name:
      *  - must not be zero length
-     *  - must not contain \u0000
+     *  - must not contain nul
      *  - must not contain wildcard characters
      * @param topic
      */

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTopicNames.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTopicNames.java
@@ -10,8 +10,8 @@ import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.test.TestTopology;
 
 /**
- * Test publish/subscribe. These tests just use publish/subscribe
- * within a single job, but the expected use case is across jobs.
+ * Test publish/subscribe invalid topic names
+ * and filters.
  *
  */
 public class PublishSubscribeTopicNames extends TestTopology {
@@ -65,5 +65,44 @@ public class PublishSubscribeTopicNames extends TestTopology {
        
         t.strings().publish("#", true);
     }
+    
+    @Test(expected=NullPointerException.class)
+    public void testNullTopicFilter() throws Exception {
+        new Topology().subscribe(null, String.class);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testNulTopicFilter() throws Exception {
+        new Topology().subscribe("a\u0000c", String.class);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardPlus1TopicFilter() throws Exception {
+        new Topology().subscribe("a+", String.class);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardPlus2TopicFilter() throws Exception {
+        new Topology().subscribe("a/+/+b", String.class);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardHash1TopicFilter() throws Exception {
+        new Topology().subscribe("a#", String.class);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardHash2TopicFilter() throws Exception {
+        new Topology().subscribe("a/b#", String.class);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardHash3TopicFilter() throws Exception {
+        new Topology().subscribe("a/#/b", String.class);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardHash4TopicFilter() throws Exception {
+        new Topology().subscribe("a/#b/c", String.class);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardHash5TopicFilter() throws Exception {
+        new Topology().subscribe("a/#/c/#", String.class);
+    }
+    
     
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTopicNames.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTopicNames.java
@@ -1,0 +1,69 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.test.distributed;
+
+import org.junit.Test;
+
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.test.TestTopology;
+
+/**
+ * Test publish/subscribe. These tests just use publish/subscribe
+ * within a single job, but the expected use case is across jobs.
+ *
+ */
+public class PublishSubscribeTopicNames extends TestTopology {
+
+  
+    @Test(expected=NullPointerException.class)
+    public void testNullTopicName() throws Exception {
+        final Topology t = new Topology();
+       
+        t.strings().publish(null, true);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testEmptyTopicName() throws Exception {
+        final Topology t = new Topology();
+       
+        t.strings().publish("", true);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testNulCharTopicName() throws Exception {
+        final Topology t = new Topology();
+       
+        t.strings().publish("a\u0000b", true);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardPlus1TopicName() throws Exception {
+        final Topology t = new Topology();
+       
+        t.strings().publish("+", true);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardPlus2TopicName() throws Exception {
+        final Topology t = new Topology();
+       
+        t.strings().publish("engine/+", true);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardHash1TopicName() throws Exception {
+        final Topology t = new Topology();
+       
+        t.strings().publish("engine/#", true);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testWildcardHash2TopicName() throws Exception {
+        final Topology t = new Topology();
+       
+        t.strings().publish("#", true);
+    }
+    
+}

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeWildcard.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeWildcard.java
@@ -6,6 +6,7 @@ package com.ibm.streamsx.topology.test.distributed;
 
 import static org.junit.Assume.assumeTrue;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -17,6 +18,7 @@ import org.junit.Test;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.context.StreamsContext.Type;
+import com.ibm.streamsx.topology.streams.StringStreams;
 import com.ibm.streamsx.topology.test.TestTopology;
 
 /**
@@ -35,7 +37,7 @@ public class PublishSubscribeWildcard extends TestTopology {
     
     @Test
     public void testNoFilter() throws Exception {
-        wildcardSingle("a/b/c", "a/b/c");
+        wildcardSingle("a/b/c", "a/b/c", "a/b/d", "a/b/c/d");
     }
     
     @Test
@@ -119,9 +121,9 @@ public class PublishSubscribeWildcard extends TestTopology {
         
         Topology t = new Topology();
         
-        List<String> data = publish(t, topicName, "P");
+        List<String> data = publish(t, topicName, "P", nonMatchTopics.length);
         for (String nonMatchTopic : nonMatchTopics) {
-            publishPoll(t, nonMatchTopic, "X");
+            publishPoll(t, nonMatchTopic);
         }
         
         TStream<String> subscribe = t.subscribe(topicFilter, String.class);
@@ -129,8 +131,7 @@ public class PublishSubscribeWildcard extends TestTopology {
         completeAndValidate(subscribe, 30, data.toArray(new String[0]));
     }
     
-    
-    private List<String> publish(Topology t, String topic, String leadIn) {
+    private List<String> publish(Topology t, String topic, String leadIn, int count) {
         int base = sbase;
         sbase +=200;
         List<String> data = new ArrayList<>(10);
@@ -138,15 +139,85 @@ public class PublishSubscribeWildcard extends TestTopology {
             data.add(leadIn + base + rand.nextInt(100));
         }
         
-        t.constants(data).asType(String.class).modify(new PublishSubscribeTest.Delay<>()).publish(topic);
+        t.constants(data).asType(String.class).modify(new PublishSubscribeTest.Delay<>((1+count)*5)).publish(topic);
         return data;
     }
-    private void publishPoll(Topology t, String topic, String leadIn) {
-        final int base = sbase;
-        sbase +=200;
-        final String tuple = leadIn + base + rand.nextInt(100);
+    private void publishPoll(Topology t, String topic) {
+
+        final String tuple = "X" + rand.nextInt(100);
 
         t.periodicSource(() -> tuple, 200, TimeUnit.MILLISECONDS).asType(String.class).publish(topic);
 
+    }
+    
+    public static class WrapString implements Serializable{
+        private static final long serialVersionUID = 1L;
+        private final String s;
+        public WrapString(String s) {
+            this.s = s;
+        }
+        @Override
+        public String toString() {
+            return s;
+        }
+    }
+    
+    private List<String> publishJava(Topology t, String topic, String leadIn, int count) {
+        int base = sbase;
+        sbase +=200;
+        List<String> data = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            data.add(leadIn + base + rand.nextInt(100));
+        }
+        
+                
+        t.constants(data).transform(WrapString::new).asType(WrapString.class).modify(new PublishSubscribeTest.Delay<>((1+count)*5)).publish(topic);
+        return data;
+    }
+    private void publishPollJava(Topology t, String topic) {
+        final String tuple = "X" + rand.nextInt(100);
+
+        t.periodicSource(() -> tuple, 200, TimeUnit.MILLISECONDS).transform(WrapString::new).asType(WrapString.class).publish(topic);
+
+    }
+    
+    private void wildcardSingleJava(String topicName, String topicFilter, String ...nonMatchTopics) throws Exception {
+        
+        Topology t = new Topology();
+        
+        List<String> data = publishJava(t, topicName, "J", nonMatchTopics.length);
+        for (String nonMatchTopic : nonMatchTopics) {
+            publishPollJava(t, nonMatchTopic);
+        }
+        
+        TStream<String> subscribe = StringStreams.toString(t.subscribe(topicFilter, WrapString.class));
+        
+        completeAndValidate(subscribe, 30, data.toArray(new String[0]));
+    }
+    
+    // Java uses the same SPL subscription code under the covers so just have a few basic java tests
+    
+    @Test
+    public void testNoFilterJava() throws Exception {
+        wildcardSingleJava("a/b/c", "a/b/c", "a/b/d", "a/b/c/d");
+    }
+    
+    @Test
+    public void testPlusFilter1Java() throws Exception {
+        wildcardSingleJava("a", "+", "a/b");
+    }
+    
+    @Test
+    public void testPlusFilter7Java() throws Exception {
+        wildcardSingleJava("d/e/f", "+/e/+", "d/a/f");
+    }
+    
+    @Test
+    public void testHashAllFilter1Java() throws Exception {
+        wildcardSingleJava("a", "#");
+    }
+    @Test
+    public void testHashFilter1Java() throws Exception {
+        wildcardSingleJava("a/b/c", "a/#", "/", "d", "d/f");
     }
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeWildcard.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeWildcard.java
@@ -1,0 +1,113 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.test.distributed;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.context.StreamsContext.Type;
+import com.ibm.streamsx.topology.test.TestTopology;
+
+/**
+ * Test publish/subscribe. These tests just use publish/subscribe
+ * within a single job, but the expected use case is across jobs.
+ *
+ */
+public class PublishSubscribeWildcard extends TestTopology {
+    
+    private final Random rand = new Random();
+    private static int sbase;
+
+    @Before
+    public void checkIsDistributed() {
+        assumeTrue(getTesterType() == Type.DISTRIBUTED_TESTER);
+    }
+    
+    @Test
+    public void testNoFilter() throws Exception {
+        wildcardSingle("a/b/c", "a/b/c");
+    }
+    
+    @Test
+    public void testPlusFilter1() throws Exception {
+        wildcardSingle("a", "+");
+    }
+    
+    @Test
+    public void testPlusFilter2() throws Exception {
+        wildcardSingle("a/b", "+/b");
+    }
+    @Test
+    public void testPlusFilter3() throws Exception {
+        wildcardSingle("a/b", "a/+");
+    }
+    @Test
+    public void testPlusFilter4() throws Exception {
+        wildcardSingle("/b", "+/b");
+    }
+    @Test
+    public void testPlusFilter5() throws Exception {
+        wildcardSingle("a/b/c", "a/+/c");
+    }
+    @Test
+    public void testPlusFilter6() throws Exception {
+        wildcardSingle("a/b/c", "a/b/+");
+    }
+    @Test
+    public void testPlusFilter7() throws Exception {
+        wildcardSingle("d/e/f", "+/e/+");
+    }
+    @Test
+    public void testPlusFilter8() throws Exception {
+        wildcardSingle("d/e/f", "+/+/+");
+    }
+    @Test
+    public void testPlusFilter9() throws Exception {
+        wildcardSingle("d//f", "d/+/f");
+    }
+    @Test
+    public void testPlusFilter10() throws Exception {
+        wildcardSingle("/c/", "+/c/");
+    }
+    
+    
+    /**
+     * Tests subscribing to a single stream with a wildcard filter.
+     * @param topicName
+     * @param topicFilter
+     * @throws Exception
+     */
+    private void wildcardSingle(String topicName, String topicFilter) throws Exception {
+        
+        Topology t = new Topology();
+        
+        List<String> data = publish(t, topicName);
+        
+        TStream<String> subscribe = t.subscribe(topicFilter, String.class);
+        
+        completeAndValidate(subscribe, 30, data.toArray(new String[0]));
+    }
+    
+    
+    private List<String> publish(Topology t, String topic) {
+        int base = sbase;
+        sbase +=200;
+        List<String> data = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            data.add("P" + base + rand.nextInt(100));
+        }
+        
+        t.constants(data).asType(String.class).modify(new PublishSubscribeTest.Delay<>()).publish(topic);
+        return data;
+    }
+}

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeWildcard.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeWildcard.java
@@ -9,6 +9,7 @@ import static org.junit.Assume.assumeTrue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -19,8 +20,7 @@ import com.ibm.streamsx.topology.context.StreamsContext.Type;
 import com.ibm.streamsx.topology.test.TestTopology;
 
 /**
- * Test publish/subscribe. These tests just use publish/subscribe
- * within a single job, but the expected use case is across jobs.
+ * Test publish/subscribe with wildcard subscriptions.
  *
  */
 public class PublishSubscribeWildcard extends TestTopology {
@@ -40,46 +40,74 @@ public class PublishSubscribeWildcard extends TestTopology {
     
     @Test
     public void testPlusFilter1() throws Exception {
-        wildcardSingle("a", "+");
+        wildcardSingle("a", "+", "a/b");
     }
     
     @Test
     public void testPlusFilter2() throws Exception {
-        wildcardSingle("a/b", "+/b");
+        wildcardSingle("a/b", "+/b", "a/c");
     }
     @Test
     public void testPlusFilter3() throws Exception {
-        wildcardSingle("a/b", "a/+");
+        wildcardSingle("a/b", "a/+","b/b");
     }
     @Test
     public void testPlusFilter4() throws Exception {
-        wildcardSingle("/b", "+/b");
+        wildcardSingle("/b", "+/b", "/c");
     }
     @Test
     public void testPlusFilter5() throws Exception {
-        wildcardSingle("a/b/c", "a/+/c");
+        wildcardSingle("a/b/c", "a/+/c", "d/b/c");
     }
     @Test
     public void testPlusFilter6() throws Exception {
-        wildcardSingle("a/b/c", "a/b/+");
+        wildcardSingle("a/b/c", "a/b/+", "d/b/c");
     }
     @Test
     public void testPlusFilter7() throws Exception {
-        wildcardSingle("d/e/f", "+/e/+");
+        wildcardSingle("d/e/f", "+/e/+", "d/a/f");
     }
     @Test
     public void testPlusFilter8() throws Exception {
-        wildcardSingle("d/e/f", "+/+/+");
+        wildcardSingle("d/e/f", "+/+/+", "d/a/f/");
     }
     @Test
     public void testPlusFilter9() throws Exception {
-        wildcardSingle("d//f", "d/+/f");
+        wildcardSingle("d//f", "d/+/f", "e//f");
     }
     @Test
     public void testPlusFilter10() throws Exception {
-        wildcardSingle("/c/", "+/c/");
+        wildcardSingle("/c/", "+/c/", "/c/b");
     }
     
+    @Test
+    public void testHashAllFilter1() throws Exception {
+        wildcardSingle("a", "#");
+    }
+    @Test
+    public void testHashAllFilter2() throws Exception {
+        wildcardSingle("a/c", "#");
+    }
+    @Test
+    public void testHashAllFilter3() throws Exception {
+        wildcardSingle("/", "#");
+    }
+    @Test
+    public void testHashFilter1() throws Exception {
+        wildcardSingle("a/b/c", "a/#", "/", "d", "d/f");
+    }
+    @Test
+    public void testHashFilter2() throws Exception {
+        wildcardSingle("a/b/c", "a/b/#", "a/c/e");
+    }
+    @Test
+    public void testHashFilter3() throws Exception {
+        wildcardSingle("a/b/c", "a/b/c/#", "a/b/d");
+    }
+    @Test
+    public void testHashFilter4() throws Exception {
+        wildcardSingle("//c", "//c/#", "x//c");
+    }   
     
     /**
      * Tests subscribing to a single stream with a wildcard filter.
@@ -87,11 +115,14 @@ public class PublishSubscribeWildcard extends TestTopology {
      * @param topicFilter
      * @throws Exception
      */
-    private void wildcardSingle(String topicName, String topicFilter) throws Exception {
+    private void wildcardSingle(String topicName, String topicFilter, String ...nonMatchTopics) throws Exception {
         
         Topology t = new Topology();
         
-        List<String> data = publish(t, topicName);
+        List<String> data = publish(t, topicName, "P");
+        for (String nonMatchTopic : nonMatchTopics) {
+            publishPoll(t, nonMatchTopic, "X");
+        }
         
         TStream<String> subscribe = t.subscribe(topicFilter, String.class);
         
@@ -99,15 +130,23 @@ public class PublishSubscribeWildcard extends TestTopology {
     }
     
     
-    private List<String> publish(Topology t, String topic) {
+    private List<String> publish(Topology t, String topic, String leadIn) {
         int base = sbase;
         sbase +=200;
         List<String> data = new ArrayList<>(10);
         for (int i = 0; i < 10; i++) {
-            data.add("P" + base + rand.nextInt(100));
+            data.add(leadIn + base + rand.nextInt(100));
         }
         
         t.constants(data).asType(String.class).modify(new PublishSubscribeTest.Delay<>()).publish(topic);
         return data;
+    }
+    private void publishPoll(Topology t, String topic, String leadIn) {
+        final int base = sbase;
+        sbase +=200;
+        final String tuple = leadIn + base + rand.nextInt(100);
+
+        t.periodicSource(() -> tuple, 200, TimeUnit.MILLISECONDS).asType(String.class).publish(topic);
+
     }
 }

--- a/toolkit/build.xml
+++ b/toolkit/build.xml
@@ -28,14 +28,14 @@
    <mkdir dir="${tk}/license"/>
    <copy file="${streamsx.topology}/LICENSE" todir="${tk}/license"/>
 
-   <exec executable="${streams.install}/bin/spl-make-toolkit">
+   <exec executable="${streams.install}/bin/spl-make-toolkit" failonerror="true">
      <arg value="-i"/>
      <arg value="${tk}"/>
    </exec>
    </target>
 
    <target name="spldoc" depends="all">
-   <exec executable="${streams.install}/bin/spl-make-doc">
+   <exec executable="${streams.install}/bin/spl-make-doc" failonerror="true">
      <arg value="-i"/>
      <arg value="${tk}"/>
    </exec>


### PR DESCRIPTION
Working + in topic filter, e.g.

a/+/c on a subscribe  matches a/b/c and a/d/c  but not a/b/c/d

`#` wildcard working as well

a/b/# matches a/b, a/b/c, a/b/d and a/b/d/f

`#` matches all topics