### PR TITLE
Fix issues with Python SPl operators

### DIFF
--- a/com.ibm.streamsx.topology/info.xml
+++ b/com.ibm.streamsx.topology/info.xml
@@ -41,7 +41,7 @@ Applications use Python code to process tuples and tuples are Python objects.
 See the documentation under [namespace:com.ibm.streamsx.topology.python|com.ibm.streamsx.topology.python] for details.
 
     </description>
-    <version>1.2.6.alpha</version>
+    <version>1.2.7.alpha</version>
     <!-- Require Java 8 so minimium is 4.0.1.0 -->
     <requiredProductVersion>4.0.1.0</requiredProductVersion>
     </identity>

--- a/com.ibm.streamsx.topology/opt/python/templates/common/splpy_python.pm
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/splpy_python.pm
@@ -45,21 +45,14 @@ sub stringBasedCppToPythonPrimitiveConversion{
 # (or the equivalent for this function)
 
     my ($convert_from_string, $type) = @_;
-    if($type eq "int32" || $type eq "int64") {
-	return "PyLong_FromLong($convert_from_string)";
-    } elsif($type eq "uint32" || $type eq "uint64") {
-	return "PyLong_FromUnsignedLong($convert_from_string)";
-    } elsif($type eq "float32" || $type eq "float64") {
-	return "PyFloat_FromDouble($convert_from_string)";
-    } elsif ($type eq "rstring") {
-	return "PyUnicode_FromString(" . $convert_from_string . ".c_str())";
-    } elsif($type eq "boolean") {
-	return "$convert_from_string ? Py_True : Py_False; Py_INCREF(pyValue)";
-    } elsif ($type eq "complex32" || $type eq "complex64") {
-	return "PyComplex_FromDoubles(". $convert_from_string . ".real(), ". $convert_from_string . ".imag())";
-    }
-    else{
-	SPL::CodeGen::errorln("An unknown type was encountered when converting to python types: $type"); 
+    switch ($type) {
+      case ['int8', 'int16', 'int32', 'int64'] { return "PyLong_FromLong($convert_from_string)";}
+      case ['uint8', 'uint16', 'uint32', 'uint64'] { return "PyLong_FromUnsignedLong($convert_from_string)";}
+      case ['float32', 'float64'] { return "PyFloat_FromDouble($convert_from_string)";}
+      case 'rstring' { return "PyUnicode_FromString(" . $convert_from_string . ".c_str())";}
+      case 'boolean' { return "$convert_from_string ? Py_True : Py_False; Py_INCREF(pyValue)";}
+      case ['complex32', 'complex64'] { return "PyComplex_FromDoubles(". $convert_from_string . ".real(), ". $convert_from_string . ".imag())";}
+      else { SPL::CodeGen::errorln("An unknown type was encountered when converting to python types: $type"); }
     }
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/common/splpy_python.pm
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/splpy_python.pm
@@ -21,6 +21,8 @@ sub cppToPythonPrimitiveConversion{
 	return "PyFloat_FromDouble($convert_from_string)";
     } elsif (SPL::CodeGen::Type::isRString($type) || SPL::CodeGen::Type::isBString($type)) {
 	return "PyUnicode_FromString(" . $convert_from_string . ".c_str())";
+    } elsif (SPL::CodeGen::Type::isUString($type)) {
+	return 'PyUnicode_DecodeUTF16((const char*)  (' . $convert_from_string . ".getBuffer()), " . $convert_from_string . ".length()*2, NULL, NULL)";
     } elsif(SPL::CodeGen::Type::isBoolean($type)) {
 	return "$convert_from_string ? Py_True : Py_False; Py_INCREF(pyValue)";
     } elsif (SPL::CodeGen::Type::isComplex32($type) || SPL::CodeGen::Type::isComplex64($type)) {
@@ -50,6 +52,7 @@ sub stringBasedCppToPythonPrimitiveConversion{
       case ['uint8', 'uint16', 'uint32', 'uint64'] { return "PyLong_FromUnsignedLong($convert_from_string)";}
       case ['float32', 'float64'] { return "PyFloat_FromDouble($convert_from_string)";}
       case 'rstring' { return "PyUnicode_FromString(" . $convert_from_string . ".c_str())";}
+      case 'ustring' {return 'PyUnicode_DecodeUTF16((const char*)  (' . $convert_from_string . ".getBuffer()), " . $convert_from_string . ".length()*2, NULL, NULL)";}
       case 'boolean' { return "$convert_from_string ? Py_True : Py_False; Py_INCREF(pyValue)";}
       case ['complex32', 'complex64'] { return "PyComplex_FromDoubles(". $convert_from_string . ".real(), ". $convert_from_string . ".imag())";}
       else { SPL::CodeGen::errorln("An unknown type was encountered when converting to python types: $type"); }
@@ -67,6 +70,7 @@ sub pythonToCppPrimitiveConversion{
   my ($convert_from_string, $type) = @_;
     switch ($type) {
              case 'rstring' {return "SPL::rstring( PyUnicode_AsUTF8($convert_from_string))";}
+             case 'ustring' {return "SPL::ustring::fromUTF8( PyUnicode_AsUTF8($convert_from_string))";}
              case 'int8' {return "(int8_t) PyLong_AsLong($convert_from_string)";}
              case 'int16' {return "(int16_t) PyLong_AsLong($convert_from_string)";}
              case 'int32' {return "(int32_t) PyLong_AsLong($convert_from_string)";}

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -21,7 +21,6 @@
  use Switch;
  require $cmnDir."/splpy_python.pm";
 
-
  my $module = splpy_Module();
  my $functionName = splpy_FunctionName();
  my $fixedParam = splpy_FixedParam();

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
@@ -21,9 +21,8 @@
  use Switch;
  require $cmnDir."/splpy_python.pm";
 
- // must be a C++ expression
- my $module =  '"' . splpy_Module() . '"';
- my $functionName = '"' . splpy_FunctionName() . '"';
+ my $module = splpy_Module();
+ my $functionName = splpy_FunctionName();
  my $fixedParam = splpy_FixedParam();
  
  my $iport = $model->getInputPortAt(0);

--- a/samples/python/com.ibm.streamsx.topology.pysamples/com.ibm.streamsx.topology.pysamples.apps/NoopSample.spl
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/com.ibm.streamsx.topology.pysamples.apps/NoopSample.spl
@@ -1,6 +1,6 @@
 namespace com.ibm.streamsx.topology.pysamples.apps;
 
-use com.ibm.streamsx.topology.pysamples.positional::noop ;
+use com.ibm.streamsx.topology.pysamples.positional::Noop ;
 
 public composite NoopSample
 {
@@ -14,7 +14,7 @@ public composite NoopSample
                             msg = "Hello" + (rstring) IterationCount();
 		}
 
-		stream<NS> NSPY = noop(NS)
+		stream<NS> NSPY = Noop(NS)
 		{
 		}
 

--- a/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
@@ -138,3 +138,7 @@ def ReturnList(a,b,c):
     "Demonstrate returning a list of values, each value is submitted as a tuple" 
     return [(a+1,b+1,c+1),(a+2,b+2,c+2),(a+3,b+3,c+3),(a+4,b+4,c+4)]
 
+@spl.sink
+def PrintTuple(*tuple):
+    "Print each tuple to standard out"
+    print(tuple, flush=True)


### PR DESCRIPTION
I was trying to add support for ustring and found the Python SPL operator code had "degraded".

Sink operators didn't work, a sample was broken, and some of the conversion code was incomplete (e.g. only supporting int32, int64, not int8 and int 16)