### PR TITLE
Change function names to be consistent with style

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionFilter/PyFunctionFilter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionFilter/PyFunctionFilter_cpp.cgt
@@ -47,13 +47,7 @@ MY_OPERATOR::MY_OPERATOR() : function_(NULL)
 
 <%
  # Select the Python wrapper function
- my $pywrapfunc= '_unknown_';
- if ($pystyle eq 'python') {
-   $pywrapfunc = 'depickleInput';
- }
- if ($pystyle eq 'json') {
-   $pywrapfunc = 'jsonInput';
- }
+ my $pywrapfunc= $pystyle . '_in';
 %>
 @include "../pywrapfunction.cgt"
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionHashAdder/PyFunctionHashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionHashAdder/PyFunctionHashAdder_cpp.cgt
@@ -49,13 +49,7 @@ MY_OPERATOR::MY_OPERATOR() : function_(NULL)
 
 <%
  # Select the Python wrapper function
- my $pywrapfunc= '_unknown_';
- if ($pystyle eq 'python') {
-   $pywrapfunc = 'depickleInput';
- }
- if ($pystyle eq 'json') {
-   $pywrapfunc = 'jsonInput';
- }
+ my $pywrapfunc= $pystyle . '_in';
 %>
 @include "../pywrapfunction.cgt"
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionMultiTransform/PyFunctionMultiTransform_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionMultiTransform/PyFunctionMultiTransform_cpp.cgt
@@ -48,13 +48,7 @@ MY_OPERATOR::MY_OPERATOR() : function_(NULL)
 
 <%
  # Select the Python wrapper function
- my $pywrapfunc= '_unknown_';
- if ($pystyle eq 'python') {
-   $pywrapfunc = 'depickleInputPickleIterator';
- }
- if ($pystyle eq 'json') {
-   $pywrapfunc = 'jsonInputPickleIterator';
- }
+ my $pywrapfunc= $pystyle . '_in__pickle_iter';
 %>
 @include "../pywrapfunction.cgt"
 }
@@ -107,7 +101,7 @@ print splpy_inputtuple2value($pystyle);
     streamsx::topology::PyGILLock lock;
 
 <%
- if ($pystyle eq 'python') {
+ if ($pystyle eq 'pickle') {
 %>
     // convert spl blob to bytes
     PyObject * pyArg = streamsx::topology::Splpy::pyBlobToBytes(value);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionSink/PyFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionSink/PyFunctionSink_cpp.cgt
@@ -47,13 +47,7 @@ MY_OPERATOR::MY_OPERATOR(): function_(NULL)
 
 <%
  # Select the Python wrapper function
- my $pywrapfunc= '_unknown_';
- if ($pystyle eq 'python') {
-   $pywrapfunc = 'depickleInput';
- }
- if ($pystyle eq 'json') {
-   $pywrapfunc = 'jsonInput';
- }
+ my $pywrapfunc= $pystyle . '_in';
 %>
 @include "../pywrapfunction.cgt"
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_cpp.cgt
@@ -14,10 +14,11 @@
 
 
 <%
-  # determine which tuple stype is being used
+  # determine which tuple style is being used
   my $fpdir = $model->getContext()->getToolkitDirectory()."/com.ibm.streamsx.topology.functional.python";
  require $fpdir."/pyfunction.pm";
  my $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
+ my $pyoutstyle = splpy_tuplestyle($model->getOutputPortAt(0));
 %>
 
 // Constructor
@@ -49,13 +50,9 @@ MY_OPERATOR::MY_OPERATOR() : function_(NULL)
 
 <%
  # Select the Python wrapper function
- my $pywrapfunc= '_unknown_';
- if ($pystyle eq 'python') {
-   $pywrapfunc = 'depickleInputPickleReturn';
- }
- if ($pystyle eq 'json') {
-   $pywrapfunc = 'jsonInputPickleReturn';
- }
+
+ my $pywrapfunc= $pystyle . '_in__' . $pyoutstyle . '_out';
+ 
 %>
 
 @include "../pywrapfunction.cgt"
@@ -100,7 +97,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
   IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
 
 <%
-print splpy_inputtuple2value($pystyle);
+print splpy_inputtuple2value($pystyle, $pyoutstyle);
 %>
 
   std::auto_ptr<SPL::blob> out_blob = streamsx::topology::Splpy::pyTupleTransform(function_, value);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyfunction.pm
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyfunction.pm
@@ -18,12 +18,12 @@
 
 sub splpy_tuplestyle{
 
- my ($inputPort) = @_;
+ my ($port) = @_;
 
- my $attr =  $inputPort->getAttributeAt(0);
+ my $attr =  $port->getAttributeAt(0);
  my $pystyle = 'unk';
  if ($attr->getName() eq '__spl_po') {
-    $pystyle = 'python';
+    $pystyle = 'pickle';
  } elsif ($attr->getName() eq 'string') {
     $pystyle = 'string';
  } elsif ($attr->getName() eq 'jsonString') {
@@ -40,7 +40,7 @@ sub splpy_tuplestyle{
 #
 sub splpy_inputtuple2value{
  my ($pystyle) = @_;
- if ($pystyle eq 'python') {
+ if ($pystyle eq 'pickle') {
   return 'SPL::blob value = ip.get___spl_po();';
  }
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -27,20 +27,20 @@ def pickleReturn(function) :
 # Given a callable 'callable', return a function
 # that depickles the input and then calls 'callable'
 # returning the callable's return
-def depickleInput(callable) :
+def pickle_in(callable) :
     ac = _getCallable(callable)
-    def _depickleInput(v):
+    def _pickle_in(v):
         return ac(pickle.loads(v))
-    return _depickleInput
+    return _pickle_in
 
 # Given a callable 'callable', return a function
 # that loads an object from the serialized JSON input
 # and then calls 'callable' returning the callable's return
-def jsonInput(callable) :
+def json_in(callable) :
     ac = _getCallable(callable)
-    def _jsonInput(v):
+    def _json_in(v):
         return ac(json.loads(v))
-    return _jsonInput
+    return _json_in
 
 # Get the callable from the value
 # passed into the SPL PyFunction operator.
@@ -63,28 +63,28 @@ def _getCallable(f):
 # that depickles the input and then calls 'callable'
 # returning the callable's return already pickled.
 # If the return is None then it is not pickled.
-def depickleInputPickleReturn(callable):
+def pickle_in__pickle_out(callable):
     ac = _getCallable(callable)
-    def _depickleInputPickleReturn(v):
+    def _pickle_in__pickle_out(v):
         rv = ac(pickle.loads(v))
         if rv is None:
             return None
         return pickle.dumps(rv)
-    return _depickleInputPickleReturn
+    return _pickle_in__pickle_out
 
 # Given a callable 'callable', return a function
 # that loads an object from the serialized JSON input
 # and then calls 'callable'
 # returning the callable's return already pickled.
 # If the return is None then it is not pickled.
-def jsonInputPickleReturn(callable):
+def json_in__pickle_out(callable):
     ac = _getCallable(callable)
-    def _jsonInputPickleReturn(v):
+    def _json_in__pickle_out(v):
         rv = ac(json.loads(v))
         if rv is None:
             return None
         return pickle.dumps(rv)
-    return _jsonInputPickleReturn
+    return _json_in__pickle_out
 
 # Given a function that returns an iterable
 # return a function that can be called
@@ -126,20 +126,20 @@ class _PickleIterator:
 # an instance of _PickleIterator
 # wrapping an iterator from the iterable
 # Used by PyFunctionMultiTransform
-def depickleInputPickleIterator(callable):
+def pickle_in__pickle_iter(callable):
     ac =_getCallable(callable)
-    def _depickleInputPickleIterator(v):
+    def _pickle_in__pickle_iter(v):
         irv = ac(pickle.loads(v))
         if irv is None:
             return None
         return _PickleIterator(irv)
-    return _depickleInputPickleIterator
+    return _pickle_in__pickle_iter
 
-def jsonInputPickleIterator(callable):
+def json_in__pickle_iter(callable):
     ac =_getCallable(callable)
-    def _depickleInputPickleIterator(v):
+    def _json_in__pickle_iter(v):
         irv = ac(json.loads(v))
         if irv is None:
             return None
         return _PickleIterator(irv)
-    return _depickleInputPickleIterator
+    return _json_in__pickle_iter


### PR DESCRIPTION
Changes the name of the python functions used to create the wrapper function to be consistently along the lines of:

**instyle**`_in__`**outstyle**`_out`

e.g.

`json_in__pickle_out`

* instyle is the style of how tuples are handed on the input port.
* outstyle is the  style of how tuples are handed on the output port.

This makes it easy to add additional styles.

