### PR TITLE
Don't assume python3 is in /usr/local/bin

### DIFF
--- a/samples/python/build.xml
+++ b/samples/python/build.xml
@@ -12,7 +12,7 @@
   <target name="all" depends="spldoc,extract"/>
 
   <target name="extract">
-   <exec executable="/usr/local/bin/python3">
+   <exec executable="python3">
      <arg value="${tk}/bin/spl-python-extract.py"/>
      <arg value="-i"/>
      <arg value="${pytk}"/>


### PR DESCRIPTION
Installed Anaconda without Python 3 being installed and hit this during the build.

See #383