### PR TITLE
Cleanup of SPL tuples to Python tuple/dict

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionFilter/PyFunctionFilter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionFilter/PyFunctionFilter_cpp.cgt
@@ -11,14 +11,6 @@
 
 <%SPL::CodeGen::implementationPrologue($model);%>
 
-<%
-  # determine which tuple stype is being used
-  my $fpdir = $model->getContext()->getToolkitDirectory()."/com.ibm.streamsx.topology.functional.python";
- require $fpdir."/pyfunction.pm";
- require $fpdir."/pyspltuple.pm";
- my $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
-%>
-
 @include "../pyspltuple.cgt"
 
 // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionHashAdder/PyFunctionHashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionHashAdder/PyFunctionHashAdder_cpp.cgt
@@ -12,15 +12,6 @@
 
 <%SPL::CodeGen::implementationPrologue($model);%>
 
-<%
-  # determine which tuple stype is being used
-  my $fpdir = $model->getContext()->getToolkitDirectory()."/com.ibm.streamsx.topology.functional.python";
- require $fpdir."/pyfunction.pm";
- require $fpdir."/pyspltuple.pm";
- my $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
-# my $otupleInit = SPL::CodeGen::getOutputTupleCppInitializer($model->getOutputPortAt(0));
-%>
-
 @include "../pyspltuple.cgt"
 
 // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionMultiTransform/PyFunctionMultiTransform_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionMultiTransform/PyFunctionMultiTransform_cpp.cgt
@@ -12,14 +12,6 @@
 
 <%SPL::CodeGen::implementationPrologue($model);%>
 
-<%
-  # determine which tuple stype is being used
-  my $fpdir = $model->getContext()->getToolkitDirectory()."/com.ibm.streamsx.topology.functional.python";
- require $fpdir."/pyfunction.pm";
- require $fpdir."/pyspltuple.pm";
- my $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
-%>
-
 @include "../pyspltuple.cgt"
 
 // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionSink/PyFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionSink/PyFunctionSink_cpp.cgt
@@ -11,14 +11,6 @@
 
 <%SPL::CodeGen::implementationPrologue($model);%>
 
-<%
-  # determine which tuple stype is being used
-  my $fpdir = $model->getContext()->getToolkitDirectory()."/com.ibm.streamsx.topology.functional.python";
- require $fpdir."/pyfunction.pm";
- require $fpdir."/pyspltuple.pm";
- my $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
-%>
-
 @include "../pyspltuple.cgt"
 
 // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform_cpp.cgt
@@ -12,17 +12,10 @@
 
 <%SPL::CodeGen::implementationPrologue($model);%>
 
-
+@include "../pyspltuple.cgt"
 <%
-  # determine which tuple style is being used
-  my $fpdir = $model->getContext()->getToolkitDirectory()."/com.ibm.streamsx.topology.functional.python";
- require $fpdir."/pyfunction.pm";
- require $fpdir."/pyspltuple.pm";
- my $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
  my $pyoutstyle = splpy_tuplestyle($model->getOutputPortAt(0));
 %>
-
-@include "../pyspltuple.cgt"
 
 // Constructor
 MY_OPERATOR::MY_OPERATOR() : function_(NULL)

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyfunction.pm
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyfunction.pm
@@ -9,29 +9,34 @@
 # xml document - xml - XML document
 # blob binary - binary - Binary data
 #
-# tuple<...> - tuple - Any SPL tuple type apart from above
+# tuple<...> - spltupleDict - Any SPL tuple type apart from above
 #
 # Not all are supported yet.
 # 
-# We only check the attribute name here as
-# these operators are only invoked by the PAA
 
 sub splpy_tuplestyle{
 
  my ($port) = @_;
 
  my $attr =  $port->getAttributeAt(0);
+ my $attrtype = $attr->getSPLType();
+ my $attrname = $attr->getName();
  my $pystyle = 'unk';
- my $itupleType = $port->getSPLTupleType();
  my $numattrs = $port->getNumberOfAttributes();
- if (($numattrs == 1) && ($attr->getName() eq '__spl_po')) {
+
+ if (($numattrs == 1) && SPL::CodeGen::Type::isBlob($attrtype) && ($attrname eq '__spl_po')) {
     $pystyle = 'pickle';
- } elsif (($numattrs == 1) && ($attr->getName() eq 'string')) {
+ } elsif (($numattrs == 1) && SPL::CodeGen::Type::isRString($attrtype) && ($attrname eq 'string')) {
     $pystyle = 'string';
- } elsif (($numattrs == 1) && ($attr->getName() eq 'jsonString')) {
+ } elsif (($numattrs == 1) && SPL::CodeGen::Type::isRString($attrtype) && ($attrname eq 'jsonString')) {
     $pystyle = 'json';
- }
- else {
+ } elsif (($numattrs == 1) && SPL::CodeGen::Type::isBlob($attrtype) && ($attrname eq 'binary')) {
+    $pystyle = 'binary';
+    SPL::CodeGen::errorln("Blob schema is not currently supported for Python."); 
+ } elsif (($numattrs == 1) && SPL::CodeGen::Type::isXml($attrtype) && ($attrname eq 'document')) {
+    $pystyle = 'xml';
+    SPL::CodeGen::errorln("XML schema is not currently supported for Python."); 
+ } else {
     $pystyle = 'spltupleDict';
  }
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
@@ -1,4 +1,10 @@
 <%
+ my $tkdir = $model->getContext()->getToolkitDirectory();
+ my $fpdir = $tkdir."/com.ibm.streamsx.topology.functional.python";
+
+ require $fpdir."/pyfunction.pm";
+ require $fpdir."/pyspltuple.pm";
+
  # setup the variables used when processing spltuples
  my $pyport = $model->getInputPortAt(0);
  my $pytupleType = $pyport->getSPLTupleType();
@@ -9,5 +15,8 @@
  
  my $pytuple = $pyport->getCppTupleName();
 
+ # determine which input tuple style is being used
+
+ my $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
 %>
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
@@ -1,9 +1,11 @@
 <%
  my $tkdir = $model->getContext()->getToolkitDirectory();
+ my $cmndir = $tkdir."/opt/python/templates/common";
  my $fpdir = $tkdir."/com.ibm.streamsx.topology.functional.python";
 
  require $fpdir."/pyfunction.pm";
  require $fpdir."/pyspltuple.pm";
+ require $cmndir."/splpy_python.pm";
 
  # setup the variables used when processing spltuples
  my $pyport = $model->getInputPortAt(0);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
@@ -9,8 +9,6 @@ sub convertToPythonDictionaryObject {
 
   my $pyTypeConv = "UNKNOWN_TYPE";
   my $get = undef;
-  my $getval = undef;
-  my $setdict = undef;
 
   # input value
 #   my $iv = $ituple . ".get_" . $name . "()";
@@ -20,14 +18,7 @@ sub convertToPythonDictionaryObject {
   # corresponding Python type. The List needsto be iterated through at
   # runtime becaues it could be of variable length.
   if (SPL::CodeGen::Type::isList($type)) {
-      my $size = $iv . ".size()";
-      my $loop = "for(int i = 0; i < $size; i++){\n";
-      $get = "pyValue = PyList_New($size);\n";
-      my $element_type = SPL::CodeGen::Type::getElementType($type);
-      $loop = $loop . "PyObject *o =" . cppToPythonPrimitiveConversion("($iv)[i]", $element_type) . ";\n";      
-      $loop = $loop . "PyList_SetItem(pyValue, i, o);\n";
-      $loop = $loop . "}\n";
-      $get = $get . $loop;
+      $get = cppToPythonListConversion($iv, $type);
   }  
   elsif(SPL::CodeGen::Type::isSet($type)){      
 # my $value_type = SPL::CodeGen::Type::getValueType($type);
@@ -39,45 +30,27 @@ sub convertToPythonDictionaryObject {
       $loop = $loop . "it!=$iv.end(); it++){\n";
       $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("*it", $element_type) . ";\n";
       $loop = $loop . "PySet_Add(pyValue, v);\n";
+      $loop = $loop . "Py_DECREF(v);\n";
       $loop = $loop . "}";
       $get = $get . $loop;
   }
   # If the type is a map, again, get the key and value types, then
   # iterate through the map to copy its contents.
   elsif(SPL::CodeGen::Type::isMap($type)){      
-      my $key_type = SPL::CodeGen::Type::getKeyType($type);
-      my $value_type = SPL::CodeGen::Type::getValueType($type);
-
-      $get = "pyValue = PyDict_New();\n";
-
-      my $loop = "for(std::tr1::unordered_map<SPL::$key_type,SPL::$value_type>::const_iterator it = $iv.begin();\n";
-      $loop = $loop . "it!=$iv.end(); it++){\n";
-      $loop = $loop . "PyObject *k = " . cppToPythonPrimitiveConversion("it->first", $key_type) . ";\n";
-      $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("it->second", $value_type) . ";\n";
-      # Note PyDict_SetItem does not steal the referenceis to the key and value
-      $loop = $loop . "PyDict_SetItem(pyValue, k, v);\n";
-      $loop = $loop . "Py_DECREF(k);\n";
-      $loop = $loop . "Py_DECREF(v);\n";
-      $loop = $loop . "}";
-      $get = $get . $loop;
+      $get = cppToPythonMapConversion($iv, $type);
   }
   # Must be primitive type
   else {
-
-    my $key_type = SPL::CodeGen::Type::getKeyType($type);
-    my $value_type = SPL::CodeGen::Type::getValueType($type);
-
-    my $assign = undef;
-    $getval = "  pyValue = " . cppToPythonPrimitiveConversion($iv, $type) . ";\n";
+    $get = "  pyValue = " . cppToPythonPrimitiveConversion($iv, $type) . ";\n";
   }
   $getkey = 'pyDictKey = PyUnicode_DecodeUTF8((const char*)  "' . $name . '", ((int)(sizeof("' . $name . '")))-1 , NULL);'."\n";
 
 # Note PyDict_SetItem does not steal the references to the key and value
-  $setdict =  "  PyDict_SetItem(pyDict, pyDictKey, pyValue);\n";
+  my $setdict =  "  PyDict_SetItem(pyDict, pyDictKey, pyValue);\n";
   $setdict =  $setdict . "  Py_DECREF(pyDictKey);\n";
   $setdict =  $setdict . "  Py_DECREF(pyValue);\n";
 
-  return $get . $assign . $getval . $getkey . $setdict ;
+  return $get . $getkey . $setdict ;
 }
 
 1;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
@@ -1,51 +1,5 @@
 use Switch;
 
-# This function takes the string of a value to be converted and its
-# type, and generates the corresponding code to convert the type from
-# c++ to Python. Note that the $type argument is a SPL::CodeGen type,
-# and not a string literal
-#
-sub cppToPythonPrimitiveConversion{
-# TODO: do error checking for the conversions. E.g., 
-# char * str = PyUnicode_AsUTF8(pyAttrValue)
-# if(str==NULL) exit(0);
-#
-# (or the equivalent for this function)
-
-    my ($convert_from_string, $type) = @_;
-
-    my $supported = 0;
-
-    if(SPL::CodeGen::Type::isSigned($type)) {
-      return "PyLong_FromLong($convert_from_string)";
-    } 
-    elsif(SPL::CodeGen::Type::isUnsigned($type)) {
-      return "PyLong_FromUnsignedLong($convert_from_string)";
-    } 
-    elsif(SPL::CodeGen::Type::isFloatingpoint($type)) {
-      $supported = 1;
-    } 
-    elsif (SPL::CodeGen::Type::isRString($type) || SPL::CodeGen::Type::isBString($type)) {
-      $supported = 1;
-    } 
-    elsif (SPL::CodeGen::Type::isUString($type)) {
-      $supported = 1;
-    } 
-    elsif(SPL::CodeGen::Type::isBoolean($type)) {
-      $supported = 1;
-    } 
-    elsif (SPL::CodeGen::Type::isComplex32($type) || SPL::CodeGen::Type::isComplex64($type)) {
-      $supported = 1;
-    }
-
-    if ($supported == 1) {
-      return "streamsx::topology::pyAttributeToPyObject($convert_from_string)";
-    }
-    else{
-      SPL::CodeGen::errorln("An unknown type was encountered when converting to python types." . $type ); 
-    }
-}
-
 # This function does the reverse, converting a Python type back to a
 # c++ type based on the $type argument which is a string literal.
 #
@@ -73,68 +27,6 @@ sub pythonToCppPrimitiveConversion{
              case 'complex64' { return "SPL::complex64(PyComplex_RealAsDouble($convert_from_string), PyComplex_ImagAsDouble($convert_from_string))";}
 	     else {SPL::CodeGen::exitln("An unknown type $type was encountered when converting to back to cpp types."); }
     }
-}
-
-
-#
-# Return a C++ statement converting a input attribute
-# from an SPL input tuple to a Python object and
-# setting it into pyTuple (as a Python Tuple).
-# Assumes a C++ variable pyValue and pyTuple are defined.
-#
-sub convertToPythonValue {
-  my $ituple = $_[0];
-  my $i = $_[1];
-  my $type = $_[2];
-  my $name = $_[3];
-
-
-  my $pyTypeConv = "UNKNOWN_TYPE";
-  my $get = undef;
-
-  # input value
-  my $iv = $ituple . ".get_" . $name . "()";
-  
-  # If the type is a list, get the element type and make the
-  # corresponding Python type. The List needsto be iterated through at
-  # runtime becaues it could be of variable length.
-  if (SPL::CodeGen::Type::isList($type)) {
-      my $size = $iv . ".size()";
-      my $loop = "for(int i = 0; i < $size; i++){\n";
-      $get = "pyValue = PyList_New($size);\n";
-      my $element_type = SPL::CodeGen::Type::getElementType($type);
-      $loop = $loop . "PyObject *o =" . cppToPythonPrimitiveConversion("($iv)[i]", $element_type) . ";\n";      
-      $loop = $loop . "PyList_SetItem(pyValue, i, o);\n";
-      $loop = $loop . "}\n";
-      $get = $get . $loop;
-  }  
-
-  # If the type is a map, again, get the key and value types, then
-  # iterate through the map to copy its contents.
-  elsif(SPL::CodeGen::Type::isMap($type)){      
-      my $key_type = SPL::CodeGen::Type::getKeyType($type);
-      my $value_type = SPL::CodeGen::Type::getValueType($type);
-
-      $get = "pyValue = PyDict_New();\n";
-
-      my $loop = "for(std::tr1::unordered_map<SPL::$key_type,SPL::$value_type>::const_iterator it = $iv.begin();\n";
-      $loop = $loop . "it!=$iv.end(); it++){\n";
-      $loop = $loop . "PyObject *k = " . cppToPythonPrimitiveConversion("it->first", $key_type) . ";\n";
-      $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("it->second", $value_type) . ";\n";
-      $loop = $loop . "PyDict_SetItem(pyValue, k, v);\n";
-      $loop = $loop . "}";
-      $get = $get . $loop;
-  }
-
-  # Must be primitive type
-  else{
-      $get = "pyValue = " . cppToPythonPrimitiveConversion($iv, $type) . ";\n";
-  }
-  
-  # Note PyTuple_SetItem steals the reference to the value
-  my $assign =  "    PyTuple_SetItem(pyTuple, " . $i  .", pyValue);\n";
-
-  return $get . $assign ;
 }
 
 sub convertToPythonDictionaryObject {

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
@@ -1,34 +1,5 @@
 use Switch;
 
-# This function does the reverse, converting a Python type back to a
-# c++ type based on the $type argument which is a string literal.
-#
-sub pythonToCppPrimitiveConversion{
-# TODO: do error checking for the conversions. E.g., 
-# char * str = PyUnicode_AsUTF8(pyAttrValue)
-# if(str==NULL) exit(0);
- 
-  my ($convert_from_string, $type) = @_;
-    switch ($type) {
-             case 'rstring' {return "SPL::rstring( PyUnicode_AsUTF8($convert_from_string))";}
-             case 'ustring' {return "SPL::ustring::fromUTF8( PyUnicode_AsUTF8($convert_from_string))";}
-             case 'int8' {return "(int8_t) PyLong_AsLong($convert_from_string)";}
-             case 'int16' {return "(int16_t) PyLong_AsLong($convert_from_string)";}
-             case 'int32' {return "(int32_t) PyLong_AsLong($convert_from_string)";}
-             case 'int64' {return "PyLong_AsLong($convert_from_string)";}
-             case 'uint8' {return "(uint8_t) PyLong_AsUnsignedLong($convert_from_string)";}
-             case 'uint16' {return "(uint16_t) PyLong_AsUnsignedLong($convert_from_string)";}
-             case 'uint32' {return "(uint32_t) PyLong_AsUnsignedLong($convert_from_string)";}
-             case 'uint64' {return "PyLong_AsUnsignedLong($convert_from_string)";}
-             case 'float32' {return "(float) PyFloat_AsDouble($convert_from_string)";}
-             case 'float64' {return "PyFloat_AsDouble($convert_from_string)";}
-             case 'boolean' {return "PyObject_IsTrue($convert_from_string)";}
-             case 'complex32' { return "SPL::complex32((float32_t) PyComplex_RealAsDouble($convert_from_string), (float32_t) PyComplex_ImagAsDouble($convert_from_string))";}
-             case 'complex64' { return "SPL::complex64(PyComplex_RealAsDouble($convert_from_string), PyComplex_ImagAsDouble($convert_from_string))";}
-	     else {SPL::CodeGen::exitln("An unknown type $type was encountered when converting to back to cpp types."); }
-    }
-}
-
 sub convertToPythonDictionaryObject {
   my $ituple = $_[0];
   my $i = $_[1];

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
@@ -46,15 +46,6 @@ sub cppToPythonPrimitiveConversion{
     }
 }
 
-sub rstring2python {
-    my ($convert_from_string) = @_;
-    return 'PyUnicode_DecodeUTF8((const char*)  (' . $convert_from_string . ".data()), " . $convert_from_string . ".size(), NULL)";
-}
-sub ustring2python {
-    my ($convert_from_string) = @_;
-    return 'PyUnicode_DecodeUTF16((const char*)  (' . $convert_from_string . ".getBuffer()), " . $convert_from_string . ".length()*2, NULL, NULL)";
-}
-
 # This function does the reverse, converting a Python type back to a
 # c++ type based on the $type argument which is a string literal.
 #

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.pm
@@ -6,43 +6,8 @@ sub convertToPythonDictionaryObject {
   my $type = $_[2];
   my $name = $_[3];
 
+  my $get = convertToPythonValue($ituple, $type, $name);
 
-  my $pyTypeConv = "UNKNOWN_TYPE";
-  my $get = undef;
-
-  # input value
-#   my $iv = $ituple . ".get_" . $name . "()";
-  my $iv = "ip.get_" . $name . "()";
-#
-  # If the type is a list, get the element type and make the
-  # corresponding Python type. The List needsto be iterated through at
-  # runtime becaues it could be of variable length.
-  if (SPL::CodeGen::Type::isList($type)) {
-      $get = cppToPythonListConversion($iv, $type);
-  }  
-  elsif(SPL::CodeGen::Type::isSet($type)){      
-# my $value_type = SPL::CodeGen::Type::getValueType($type);
-      my $element_type = SPL::CodeGen::Type::getElementType($type);
-
-      $get = "pyValue = PySet_New(NULL);\n";
-
-      my $loop = "for(std::tr1::unordered_set<SPL::$element_type>::const_iterator it = $iv.begin();\n";
-      $loop = $loop . "it!=$iv.end(); it++){\n";
-      $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("*it", $element_type) . ";\n";
-      $loop = $loop . "PySet_Add(pyValue, v);\n";
-      $loop = $loop . "Py_DECREF(v);\n";
-      $loop = $loop . "}";
-      $get = $get . $loop;
-  }
-  # If the type is a map, again, get the key and value types, then
-  # iterate through the map to copy its contents.
-  elsif(SPL::CodeGen::Type::isMap($type)){      
-      $get = cppToPythonMapConversion($iv, $type);
-  }
-  # Must be primitive type
-  else {
-    $get = "  pyValue = " . cppToPythonPrimitiveConversion($iv, $type) . ";\n";
-  }
   $getkey = 'pyDictKey = PyUnicode_DecodeUTF8((const char*)  "' . $name . '", ((int)(sizeof("' . $name . '")))-1 , NULL);'."\n";
 
 # Note PyDict_SetItem does not steal the references to the key and value

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2dict.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2dict.cgt
@@ -12,7 +12,7 @@
   pyDict = PyDict_New();
 <%
      for (my $i = 0; $i < $pynumattrs; ++$i) {
-         print convertToPythonDictionaryObject($pytuple, $i, $pyatypes[$i], $pyanames[$i]);
+         print convertToPythonDictionaryObject("ip", $i, $pyatypes[$i], $pyanames[$i]);
      }
 %>
   value = pyDict;

--- a/com.ibm.streamsx.topology/opt/python/templates/common/splpy_python.pm
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/splpy_python.pm
@@ -42,32 +42,6 @@ sub ustring2python {
     return 'PyUnicode_DecodeUTF16((const char*)  (' . $convert_from_string . ".getBuffer()), " . $convert_from_string . ".length()*2, NULL, NULL)";
 }
 
-# This function is identical to the cppToPythonPrimitiveConversion,
-# except the type of the object to be converted is passed as a string,
-# instead of an SPL::CodeGen type. This is necessary because there are
-# functions in the CodeGen API that return strings and not a CodeGen
-# types, such as OutputPort::getAttributeAt().
-#
-sub stringBasedCppToPythonPrimitiveConversion{
-# TODO: do error checking for the conversions. E.g., 
-# char * str = PyUnicode_AsUTF8(pyAttrValue)
-# if(str==NULL) exit(0);
-#
-# (or the equivalent for this function)
-
-    my ($convert_from_string, $type) = @_;
-    switch ($type) {
-      case ['int8', 'int16', 'int32', 'int64'] { return "PyLong_FromLong($convert_from_string)";}
-      case ['uint8', 'uint16', 'uint32', 'uint64'] { return "PyLong_FromUnsignedLong($convert_from_string)";}
-      case ['float32', 'float64'] { return "PyFloat_FromDouble($convert_from_string)";}
-      case 'rstring' { return rstring2python($convert_from_string);}
-      case 'ustring' { return ustring2python($convert_from_string);}
-      case 'boolean' { return "$convert_from_string ? Py_True : Py_False; Py_INCREF(pyValue)";}
-      case ['complex32', 'complex64'] { return "PyComplex_FromDoubles(". $convert_from_string . ".real(), ". $convert_from_string . ".imag())";}
-      else { SPL::CodeGen::errorln("An unknown type was encountered when converting to python types: $type"); }
-    }
-}
-
 # This function does the reverse, converting a Python type back to a
 # c++ type based on the $type argument which is a string literal.
 #
@@ -125,7 +99,7 @@ sub convertToPythonValue {
       my $loop = "for(int i = 0; i < $size; i++){\n";
       $get = "pyValue = PyList_New($size);\n";
       my $element_type = SPL::CodeGen::Type::getElementType($type);
-      $loop = $loop . "PyObject *o =" . stringBasedCppToPythonPrimitiveConversion("($iv)[i]", $element_type) . ";\n";      
+      $loop = $loop . "PyObject *o =" . cppToPythonPrimitiveConversion("($iv)[i]", $element_type) . ";\n";      
       $loop = $loop . "PyList_SetItem(pyValue, i, o);\n";
       $loop = $loop . "}\n";
       $get = $get . $loop;
@@ -141,8 +115,8 @@ sub convertToPythonValue {
 
       my $loop = "for(std::tr1::unordered_map<SPL::$key_type,SPL::$value_type>::const_iterator it = $iv.begin();\n";
       $loop = $loop . "it!=$iv.end(); it++){\n";
-      $loop = $loop . "PyObject *k = " . stringBasedCppToPythonPrimitiveConversion("it->first", $key_type) . ";\n";
-      $loop = $loop . "PyObject *v = " . stringBasedCppToPythonPrimitiveConversion("it->second", $value_type) . ";\n";
+      $loop = $loop . "PyObject *k = " . cppToPythonPrimitiveConversion("it->first", $key_type) . ";\n";
+      $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("it->second", $value_type) . ";\n";
       $loop = $loop . "PyDict_SetItem(pyValue, k, v);\n";
       $loop = $loop . "}";
       $get = $get . $loop;

--- a/com.ibm.streamsx.topology/opt/python/templates/common/splpy_python.pm
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/splpy_python.pm
@@ -75,6 +75,44 @@ sub pythonToCppPrimitiveConversion{
     }
 }
 
+sub cppToPythonListConversion {
+
+    my ($iv, $type) = @_;
+
+      my $element_type = SPL::CodeGen::Type::getElementType($type);
+
+      my $size = $iv . ".size()";
+      my $get = "pyValue = PyList_New($size);\n";
+
+      my $loop = "for(int i = 0; i < $size; i++){\n";
+      $loop = $loop . "PyObject *o =" . cppToPythonPrimitiveConversion("($iv)[i]", $element_type) . ";\n";      
+      $loop = $loop . "PyList_SetItem(pyValue, i, o);\n";
+      $loop = $loop . "}\n";
+
+      $get = $get . $loop;
+      return $get;
+}
+
+sub cppToPythonMapConversion {
+      my ($iv, $type) = @_;
+
+      my $key_type = SPL::CodeGen::Type::getKeyType($type);
+      my $value_type = SPL::CodeGen::Type::getValueType($type);
+
+      my $get = "pyValue = PyDict_New();\n";
+
+      my $loop = "for(std::tr1::unordered_map<SPL::$key_type,SPL::$value_type>::const_iterator it = $iv.begin();\n";
+      $loop = $loop . "it!=$iv.end(); it++){\n";
+      $loop = $loop . "PyObject *k = " . cppToPythonPrimitiveConversion("it->first", $key_type) . ";\n";
+      $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("it->second", $value_type) . ";\n";
+      $loop = $loop . "PyDict_SetItem(pyValue, k, v);\n";
+      $loop =  $loop . "  Py_DECREF(k);\n";
+      $loop =  $loop . "  Py_DECREF(v);\n";
+      $loop = $loop . "}";
+      $get = $get . $loop;
+
+      return $get;
+}
 
 #
 # Return a C++ statement converting a input attribute
@@ -99,31 +137,13 @@ sub convertToPythonValue {
   # corresponding Python type. The List needsto be iterated through at
   # runtime becaues it could be of variable length.
   if (SPL::CodeGen::Type::isList($type)) {
-      my $size = $iv . ".size()";
-      my $loop = "for(int i = 0; i < $size; i++){\n";
-      $get = "pyValue = PyList_New($size);\n";
-      my $element_type = SPL::CodeGen::Type::getElementType($type);
-      $loop = $loop . "PyObject *o =" . cppToPythonPrimitiveConversion("($iv)[i]", $element_type) . ";\n";      
-      $loop = $loop . "PyList_SetItem(pyValue, i, o);\n";
-      $loop = $loop . "}\n";
-      $get = $get . $loop;
+      $get = cppToPythonListConversion($iv, $type);
   }  
 
   # If the type is a map, again, get the key and value types, then
   # iterate through the map to copy its contents.
   elsif(SPL::CodeGen::Type::isMap($type)){      
-      my $key_type = SPL::CodeGen::Type::getKeyType($type);
-      my $value_type = SPL::CodeGen::Type::getValueType($type);
-
-      $get = "pyValue = PyDict_New();\n";
-
-      my $loop = "for(std::tr1::unordered_map<SPL::$key_type,SPL::$value_type>::const_iterator it = $iv.begin();\n";
-      $loop = $loop . "it!=$iv.end(); it++){\n";
-      $loop = $loop . "PyObject *k = " . cppToPythonPrimitiveConversion("it->first", $key_type) . ";\n";
-      $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("it->second", $value_type) . ";\n";
-      $loop = $loop . "PyDict_SetItem(pyValue, k, v);\n";
-      $loop = $loop . "}";
-      $get = $get . $loop;
+      $get = cppToPythonMapConversion($iv, $type);
   }
 
   # Must be primitive type

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -88,7 +88,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
     PyObject *pyValue;
 <%
      for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
-         print convertToPythonValue($ituple, $i, $itypes[$i], $inames[$i]);
+         print convertToPythonValueAsTuple($ituple, $i, $itypes[$i], $inames[$i]);
      }
 %>
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
@@ -80,7 +80,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
     PyObject *pyValue;
 <%
      for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
-         print convertToPythonValue($ituple, $i, $itypes[$i], $inames[$i]);
+         print convertToPythonValueAsTuple($ituple, $i, $itypes[$i], $inames[$i]);
      }
 %>
   

--- a/java/src/com/ibm/streamsx/topology/json/JSONStreams.java
+++ b/java/src/com/ibm/streamsx/topology/json/JSONStreams.java
@@ -68,7 +68,7 @@ public class JSONStreams {
                 wrapper.put(PAYLOAD, artifact);
                 return wrapper;
             } catch (IOException e) {
-                return null;
+                throw new RuntimeException(e);
             }
         }
     }

--- a/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribeJsonPythonTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribeJsonPythonTest.java
@@ -25,7 +25,7 @@ public class PublishSubscribeJsonPythonTest extends PublishSubscribePython {
 	 * Json Subscribe feeding a map
 	 */
     @Test
-    public void testPublishMap() throws Exception {
+    public void testPublishJsonMap() throws Exception {
     	
     	Random r = new Random();
         final Topology t = new Topology();
@@ -71,7 +71,7 @@ public class PublishSubscribeJsonPythonTest extends PublishSubscribePython {
 	 * Json Subscribe feeding a filter
 	 */
     @Test
-    public void testPublishFilter() throws Exception {
+    public void testPublishJsonFilter() throws Exception {
     	
     	Random r = new Random();
     	
@@ -111,7 +111,7 @@ public class PublishSubscribeJsonPythonTest extends PublishSubscribePython {
 	 * Json Subscribe feeding a flat map
 	 */
     @Test
-    public void testPublishFlatMap() throws Exception {
+    public void testPublishJsonFlatMap() throws Exception {
     	
     	Random r = new Random();
         final Topology t = new Topology();

--- a/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribeJsonPythonTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribeJsonPythonTest.java
@@ -141,13 +141,13 @@ public class PublishSubscribeJsonPythonTest extends PublishSubscribePython {
    	    	
         TStream<JSONObject> source = t.constants(Arrays.asList(j1, j2, j3));
         
-        source = source.modify(new Delay<JSONObject>(10)).asType(JSONObject.class);
+        source = source.modify(new Delay<JSONObject>(15)).asType(JSONObject.class);
         
         source.publish("pytest/json/flatmap");
         
         TStream<String> subscribe = t.subscribe("pytest/json/flatmap/result", String.class);
 
-        completeAndValidate(subscribe, 30, s1a, s1b, s2a, s2b, s3a, s3b);
+        completeAndValidate(subscribe, 60, s1a, s1b, s2a, s2b, s3a, s3b);
     }
 
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribeStringPythonTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribeStringPythonTest.java
@@ -21,7 +21,7 @@ public class PublishSubscribeStringPythonTest extends PublishSubscribePython {
 	 * String Subscribe feeding a map
 	 */
     @Test
-    public void testPublishMap() throws Exception {
+    public void testPublishStringMap() throws Exception {
     	
         final Topology t = new Topology();
   	
@@ -42,7 +42,7 @@ public class PublishSubscribeStringPythonTest extends PublishSubscribePython {
 	 * String Subscribe feeding a filter
 	 */
     @Test
-    public void testPublishFilter() throws Exception {
+    public void testPublishStringFilter() throws Exception {
     	
         final Topology t = new Topology();
   	
@@ -60,7 +60,7 @@ public class PublishSubscribeStringPythonTest extends PublishSubscribePython {
     }
 
     @Test
-    public void testPublishFlatMap() throws Exception {
+    public void testPublishStringFlatMap() throws Exception {
     	
         final Topology t = new Topology();
   	

--- a/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribeStringPythonTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribeStringPythonTest.java
@@ -68,13 +68,13 @@ public class PublishSubscribeStringPythonTest extends PublishSubscribePython {
    	    	
         TStream<String> source = t.strings("mary had a little lamb", "If you can keep your head when all about you");
         
-        source = source.modify(new Delay<String>(10));
+        source = source.modify(new Delay<String>(15));
         
         source.publish("pytest/string/flatmap");
         
         TStream<String> subscribe = t.subscribe("pytest/string/flatmap/result", String.class);
 
-        completeAndValidate(subscribe, 30,
+        completeAndValidate(subscribe, 60,
         		"mary", "had", "a", "little", "lamb", "If", "you", "can", "keep", "your", "head", "when", "all", "about", "you");
     }
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/python/SubscribeSPLDictTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/python/SubscribeSPLDictTest.java
@@ -35,7 +35,7 @@ public class SubscribeSPLDictTest extends PublishSubscribePython {
         
         // Publish a stream with all the SPL types supported by Python.
         SPLStream tuples = PythonFunctionalOperatorsTest.testTupleStream(topology);
-        tuples = tuples.modify(new Delay<Tuple>(10));
+        tuples = tuples.modify(new Delay<Tuple>(15));
         tuples.publish("pytest/spl/map");
                      
         SPLStream viaSPL = SPL.invokeOperator("spl.relational::Functor", tuples, tuples.getSchema(), null);
@@ -55,7 +55,7 @@ public class SubscribeSPLDictTest extends PublishSubscribePython {
         Condition<List<Tuple>> viaSPLResult = tester.tupleContents(viaSPL);
         Condition<List<Tuple>> viaPythonResult = tester.tupleContents(viaPythonJsonSpl);
         
-        complete(tester, allConditions(expectedCount, expectedCountSpl), 600, TimeUnit.SECONDS);
+        complete(tester, allConditions(expectedCount, expectedCountSpl), 60, TimeUnit.SECONDS);
 
         assertTrue(expectedCount.valid());
         assertTrue(expectedCountSpl.valid());

--- a/test/java/src/com/ibm/streamsx/topology/test/python/SubscribeSPLDictTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/python/SubscribeSPLDictTest.java
@@ -30,7 +30,7 @@ import com.ibm.streamsx.topology.tester.Tester;
 public class SubscribeSPLDictTest extends PublishSubscribePython {
     
     @Test
-    public void testSubscribeMap() throws Exception {
+    public void testSubscribeSPLDictMap() throws Exception {
         Topology topology = new Topology("testSubscribeMap");
         
         // Publish a stream with all the SPL types supported by Python.


### PR DESCRIPTION
1. Remove string based varients of Perl conversion functions - These were added due a misunderstanding (the doc is not clear), an attribute type in the perl code gen api is always a string.