### PR TITLE
Resolves #436

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -56,6 +56,9 @@ def submit(ctxtype, graph, username = None, password = None, config={}):
     fj = _createFullJSON(graph, config)
     fn = _createJSONFile(fj)
 
+    if graph.get_views() and (username is None or password is None):
+        print_exception("WARNING: Both a username and password must be supplied when submitting a job in order to access view data")
+
     # Create connection to SWS
     if username is not None and password is not None:
         rc = None


### PR DESCRIPTION
I was trying to access view data from a stream. I could see from the Instance Graph in Studio that the view was created successfully. However, when I tried to access the data using start_data_fetch(), I got the following exception:

Traceback (most recent call last):
  File "repo.py", line 21, in <module>
    queue = view.start_data_fetch()
  File "/home/cancilla/git/streamsx.topology/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py", line 444, in start_data_fetch
    self._get_view_object()
  File "/home/cancilla/git/streamsx.topology/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py", line 472, in _get_view_object
    raise "Error finding view."
TypeError: exceptions must derive from BaseException
After some digging, I realized it's because I forgot to submit the job with a username and password. It is not obvious that the username and password and required to retrieve view data.

I think a warning/error message should be shown if a user creates a view but does not supply a username/password.