### PR TITLE
Add --make-operator to spl-make-toolkit invocations

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/streams/InvokeMakeToolkit.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/InvokeMakeToolkit.java
@@ -36,6 +36,7 @@ public class InvokeMakeToolkit {
         List<String> commands = new ArrayList<String>();
 
         commands.add(mtk.getAbsolutePath());
+        commands.add("--make-operator");
         commands.add("-i");
 
         commands.add(toolkitDir.getAbsolutePath());

--- a/samples/python/build.xml
+++ b/samples/python/build.xml
@@ -19,6 +19,7 @@
    </exec>
 
    <exec executable="${streams.install}/bin/spl-make-toolkit">
+     <arg value="--make-operator"/>
      <arg value="-i"/>
      <arg value="${pytk}"/>
    </exec>

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -107,6 +107,7 @@
        includeantruntime="no"
    	   />
    <exec executable="${streams.install}/bin/spl-make-toolkit">
+     <arg value="--make-operator"/>
      <arg value="-i"/>
      <arg value="${testtk}"/>
    </exec>

--- a/test/python/build.xml
+++ b/test/python/build.xml
@@ -25,6 +25,7 @@
 		     <arg value="${testtk}"/>
 		   </exec>
 	   <exec executable="${streams.install}/bin/spl-make-toolkit">
+             <arg value="--make-operator"/>
 	     <arg value="-i"/>
 	     <arg value="${testtk}"/>
 	   </exec>

--- a/toolkit/build.xml
+++ b/toolkit/build.xml
@@ -29,6 +29,7 @@
    <copy file="${streamsx.topology}/LICENSE" todir="${tk}/license"/>
 
    <exec executable="${streams.install}/bin/spl-make-toolkit" failonerror="true">
+     <arg value="--make-operator"/>
      <arg value="-i"/>
      <arg value="${tk}"/>
    </exec>


### PR DESCRIPTION
Ensures that the operator's `.pm` files are created in the toolkit.