### PR TITLE
Avoid copies converting attribute to Python object

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyfunction.pm
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyfunction.pm
@@ -54,15 +54,15 @@ sub splpy_tuplestyle{
 sub splpy_inputtuple2value{
  my ($pystyle) = @_;
  if ($pystyle eq 'pickle') {
-  return 'SPL::blob value = ip.get___spl_po();';
+  return 'SPL::blob const & value = ip.get___spl_po();';
  }
 
  if ($pystyle eq 'string') {
-  return 'SPL::rstring value = ip.get_string();';
+  return 'SPL::rstring const & value = ip.get_string();';
  }
  
  if ($pystyle eq 'json') {
-  return 'SPL::rstring value = ip.get_jsonString();';
+  return 'SPL::rstring const & value = ip.get_jsonString();';
  }
 
  if ($pystyle eq 'dict') {

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -82,13 +82,13 @@ namespace streamsx {
 
 
     /**
-     * Convert a SPL blob into a Python Byte string 
+     * Convert a SPL blob into a Python Memory view object.
      */
     inline PyObject * pyAttributeToPyObject(const SPL::blob & attr) {
       long int sizeb = attr.getSize();
       const unsigned char * bytes = attr.getData();
 
-      return PyBytes_FromStringAndSize((const char *)bytes, sizeb);
+      return PyMemoryView_FromMemory((char *) bytes, sizeb, PyBUF_READ);
     }
 
     /**

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -24,6 +24,9 @@ def pickleReturn(function) :
 # Given a callable 'callable', return a function
 # that depickles the input and then calls 'callable'
 # returning the callable's return
+# The returned function must not maintain a reference
+# to the passed in value as it will be a memory view
+# object with memory that will become invalid after the call.
 def pickle_in(callable) :
     ac = _getCallable(callable)
     def _wf(v):
@@ -119,6 +122,9 @@ def _getCallable(f):
 ## {pickle,json,string} -> {pickle}
 ##
 
+# The returned function must not maintain a reference
+# to the passed in value as it will be a memory view
+# object with memory that will become invalid after the call.
 def pickle_in__pickle_out(callable):
     ac = _getCallable(callable)
     def _wf(v):
@@ -161,6 +167,9 @@ def object_in__pickle_out(callable):
 ##  {pickle} ->  {json,string}
 ##
 
+# The returned function must not maintain a reference
+# to the passed in value as it will be a memory view
+# object with memory that will become invalid after the call.
 def pickle_in__json_out(callable):
     ac = _getCallable(callable)
     def _wf(v):
@@ -220,6 +229,10 @@ class _PickleIterator:
 # an instance of _PickleIterator
 # wrapping an iterator from the iterable
 # Used by PyFunctionMultiTransform
+
+# The returned function must not maintain a reference
+# to the passed in value as it will be a memory view
+# object with memory that will become invalid after the call.
 def pickle_in__pickle_iter(callable):
     ac =_getCallable(callable)
     def _wf(v):


### PR DESCRIPTION
* Use reference when accessing values from the SPL tuple. 
* Use a memoryview object to pass the SPL blob attribute into Python.

Fixes #470 