### PR TITLE
Support TStream.autonomous

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -285,6 +285,21 @@ Functions to create topologies and streams.
 
   return: None
 
+* `autonomous(self)` function on `Stream`
+  Starts an autonomous region for downstream processing.
+  By default IBM Streams processing is executed in an autonomous region
+  where any checkpointing of operator state is autonomous (independent)
+  of other operators.
+  
+  This function may be used to end a consistent region by starting an
+  autonomous region. This may be called even if this stream is in
+  an autonomous region.
+  
+  Autonomous is not applicable when a topology is submitted
+  to a STANDALONE contexts and will be ignored.
+  
+  Supported since v1.5
+  
 ++ Sample Application
 
 Example code that builds and then submits a simple topology.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -414,7 +414,7 @@ class Stream(object):
 
     def autonomous(self):
         """
-        Guarantees that downstream processing will run in an autonomous region.
+        Starts an autonomous region for downstream processing.
         By default IBM Streams processing is executed in an autonomous region
         where any checkpointing of operator state is autonomous (independent)
         of other operators.
@@ -425,6 +425,8 @@ class Stream(object):
 
         Autonomous is not applicable when a topology is submitted
         to a STANDALONE contexts and will be ignored.
+
+        Supported since v1.5
 
         Args:
             None

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -412,6 +412,27 @@ class Stream(object):
         op = self.topology.graph.addOperator("com.ibm.streamsx.topology.topic::Publish", params=publishParams)
         op.addInputPort(outputPort=self.oport)
 
+    def autonomous(self):
+        """
+        Guarantees that downstream processing will run in an autonomous region.
+        By default IBM Streams processing is executed in an autonomous region
+        where any checkpointing of operator state is autonomous (independent)
+        of other operators.
+        
+        This function may be used to end a consistent region by starting an
+        autonomous region. This may be called even if this stream is in
+        an autonomous region.
+
+        Args:
+            None
+        Returns:
+            Stream
+        """
+        op = self.topology.graph.addOperator("$Autonomous$")
+        op.addInputPort(outputPort=self.oport)
+        oport = op.addOutputPort()
+        return Stream(self.topology, oport)
+
 class Routing(Enum):
     ROUND_ROBIN=1
     KEY_PARTITIONED=2

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -423,6 +423,9 @@ class Stream(object):
         autonomous region. This may be called even if this stream is in
         an autonomous region.
 
+        Autonomous is not applicable when a topology is submitted
+        to a STANDALONE contexts and will be ignored.
+
         Args:
             None
         Returns:

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1074,6 +1074,20 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
     // TKeyedStream<T,T> key();
     
     /**
+     * Return a stream matching this stream whose subsequent
+     * processing will execute in an autonomous region.
+     * By default IBM Streams processing
+     * is executed in an autonomous region where any checkpointing of
+     * operator state is autonomous (independent) of other operators.
+     * <BR>
+     * This method may be used to end a consistent region
+     * by starting an autonomous region. This may be called
+     * even if this stream is in an autonomous region.
+     * @since v1.5
+     */
+    TStream<T> autonomous();
+    
+    /**
      * Internal method.
      * <BR>
      * <B><I>Not intended to be called by applications, may be removed at any time.</I></B>

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1083,6 +1083,12 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * This method may be used to end a consistent region
      * by starting an autonomous region. This may be called
      * even if this stream is in an autonomous region.
+     * <BR>
+     * Autonomous is not applicable when a topology is submitted
+     * to {@link com.ibm.streamsx.topology.context.StreamsContext.Type#EMBEDDED embedded}
+     * and {@link com.ibm.streamsx.topology.context.StreamsContext.Type#STANDALONE standalone}
+     * contexts and will be ignored.
+     * 
      * @since v1.5
      */
     TStream<T> autonomous();

--- a/java/src/com/ibm/streamsx/topology/builder/BVirtualMarker.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BVirtualMarker.java
@@ -7,7 +7,9 @@ public enum BVirtualMarker {
     END_PARALLEL("$EndParallel$"),
     LOW_LATENCY("$LowLatency$"),
     END_LOW_LATENCY("$EndLowLatency$"),
-    ISOLATE("$Isolate$");
+    ISOLATE("$Isolate$"),
+    AUTONOMOUS("$Autonomou$"),
+    ;
     
     private final String kind;
     

--- a/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
+++ b/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
@@ -152,6 +152,9 @@ public class GraphBuilder extends BJSONObject {
     public BOutput isolate(BOutput parent){
         return addPassThroughMarker(parent, BVirtualMarker.ISOLATE, false);
     }
+    public BOutput autonomous(BOutput parent){
+        return addPassThroughMarker(parent, BVirtualMarker.AUTONOMOUS, false);
+    }
 
     public BOutput addUnion(Set<BOutput> outputs) {
         BOperator op = addVirtualMarkerOperator(BVirtualMarker.UNION);

--- a/java/src/com/ibm/streamsx/topology/generator/spl/AutonomousRegions.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/AutonomousRegions.java
@@ -1,0 +1,48 @@
+package com.ibm.streamsx.topology.generator.spl;
+
+import java.util.List;
+
+import com.ibm.json.java.JSONObject;
+import com.ibm.streamsx.topology.builder.BVirtualMarker;
+
+/**
+ * Processing related to autonomous regions.
+ * 
+ * After pre-processing the JSON for the operator
+ * can contain the key {@code autonomous} set to true
+ * if the operator needs to be annotated.
+ *
+ */
+class AutonomousRegions {
+	
+	static final String AUTONOMOUS = "autonomous";
+	
+	/**
+	 * Preprocess autonomous virtual markers to mark
+	 * downstream operators as autonomous.  
+	 */
+    static void preprocessAutonomousRegions(JSONObject graph) {
+
+        List<JSONObject> autonomousOperators = GraphUtilities.findOperatorByKind(
+                BVirtualMarker.AUTONOMOUS, graph);
+
+        for (JSONObject autonomous : autonomousOperators) {
+        	List<JSONObject> startAutonomous = GraphUtilities.getDownstream(autonomous, graph);
+        	for (JSONObject sa : startAutonomous) {
+        		if (!sa.containsKey(AUTONOMOUS))
+        		    sa.put(AUTONOMOUS, Boolean.TRUE);
+        	}
+        }
+ 
+        GraphUtilities.removeOperators(autonomousOperators, graph);
+    }
+    
+    /**
+     * Add in the annotation.
+     */
+    static void autonomousAnnotation(JSONObject op, StringBuilder sb) {
+    	Boolean set = (Boolean) op.get(AUTONOMOUS);
+    	if (set != null && set)
+    		sb.append("@autonomous\n");
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -40,6 +40,7 @@ class OperatorGenerator {
         noteAnnotations(op, sb);
         parallelAnnotation(op, sb);
 	viewAnnotation(op, sb);
+        AutonomousRegions.autonomousAnnotation(op, sb);
         outputClause(op, sb);
         operatorNameAndKind(op, sb);
         inputClause(op, sb);

--- a/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
@@ -43,6 +43,8 @@ class Preprocessor {
         
         // At this point, the $Union$ operators in the graph are just place holders.
         removeUnionOperators();
+        
+        AutonomousRegions.preprocessAutonomousRegions(graph);
     }
        
     private void removeUnionOperators(){

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -579,6 +579,12 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     }
     
     @Override
+    public TStream<T> autonomous() {
+        BOutput autonomousOutput = builder().autonomous(output()); 
+        return addMatchingStream(autonomousOutput);
+    }
+    
+    @Override
     public TStream<T> lowLatency() {
         BOutput toBeLowLatency = output();
         BOutput lowLatencyOutput = builder().lowLatency(toBeLowLatency);

--- a/java/src/com/ibm/streamsx/topology/spl/SPLStream.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLStream.java
@@ -155,4 +155,10 @@ public interface SPLStream extends TStream<Tuple>, SPLInput {
      */
     @Override
     SPLStream endParallel();
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SPLStream autonomous();
 }

--- a/java/src/com/ibm/streamsx/topology/spl/SPLStreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLStreamImpl.java
@@ -121,6 +121,10 @@ class SPLStreamImpl extends StreamImpl<Tuple> implements SPLStream {
     public SPLStream endLowLatency() {
         return asSPL(super.endLowLatency());
     }
+    @Override
+    public SPLStream autonomous() {
+    	return asSPL(super.autonomous());
+    }
        
     private SPLStream asSPL(TStream<Tuple> tupleStream) {
         // must have been created from addMatchingOutput or addMatchingStream

--- a/test/java/src/com/ibm/streamsx/topology/test/api/StreamTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/StreamTest.java
@@ -58,6 +58,8 @@ public class StreamTest extends TestTopology {
         assertStream(topology, source);
         assertSame(String.class, source.getTupleClass());
         assertSame(String.class, source.getTupleType());
+        
+        assertNotSame(source, source.autonomous());
     }
 
     @Test

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTest.java
@@ -93,6 +93,11 @@ public class PublishSubscribeTest extends TestTopology {
     public void testPublishStringToSPL() throws Exception {
         TStream<String> source = source();
         
+        // Check autonomous works in that it produces working SPL code.
+        source = source.autonomous();
+        assertEquals(String.class, source.getTupleClass());
+        assertEquals(String.class, source.getTupleType());
+        
         source.publish("testPublishStringSPL");
         
         SPLStream subscribe = SPLStreams.subscribe(source.topology(), "testPublishStringSPL", SPLSchemas.STRING);        

--- a/test/java/src/com/ibm/streamsx/topology/test/spl/SPLStreamsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/spl/SPLStreamsTest.java
@@ -283,8 +283,9 @@ public class SPLStreamsTest extends TestTopology {
         assertSPLStream(splStreamA, TEST_SCHEMA);
         assertNotSame(splStreamA, splStreamB);
 
-        
-
+        splStreamB = splStreamA.autonomous();
+        assertSPLStream(splStreamB, TEST_SCHEMA);
+        assertNotSame(splStreamA, splStreamB);
     }
     
     static void assertSPLStream(SPLStream splStream, StreamSchema schema) {

--- a/test/python/pubsub/json_filter_json.py
+++ b/test/python/pubsub/json_filter_json.py
@@ -14,6 +14,9 @@ def main():
 
   ts = ts.filter(pytest_funcs.json_filter)
 
+  # Verify that autonomous can be called from Python
+  ts = ts.autonomous()
+
   ts.publish("pytest/json/filter/result", schema=CommonSchema.Json)
 
   config = {}


### PR DESCRIPTION
Adds support to mark a stream as autonomous.

Currently would only be required if a SPL composite operator  is invoked that is is annotated with @consistent in the SPL source.

Fixes #490 