### PR TITLE
Support stateful SPL operators.

### DIFF
--- a/com.ibm.streamsx.topology/bin/spl-python-extract.py
+++ b/com.ibm.streamsx.topology/bin/spl-python-extract.py
@@ -91,14 +91,23 @@ def copyCGT(opdir, ns, name, funcTuple):
          _funcdoc_ = 'Python function ' + funcTuple.__name__ + ' (module ' + funcTuple.__module__ + ')'
      replaceTokenInFile(opmodel_xml, "__SPLPY__DESCRIPTION__SPLPY__", _funcdoc_);
 
+# Write information about the Python function parameters.
+#
 def writeParameterInfo(cfgfile, opobj):
-        if inspect.isclass(opobj):
+        is_class = inspect.isclass(opobj)
+        if is_class:
             opobj = opobj.__call__
         
         sig = inspect.signature(opobj)
         fixedCount = 0
         params = sig.parameters
+        seenFirst = False
         for pname in params:
+             if not seenFirst:
+                 # Skip 'self' for classes
+                 seenFirst = True
+                 if is_class:
+                     continue
              param = params[pname]
              if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
                  fixedCount += 1

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -529,7 +529,8 @@ For an input port all the above types are supported.
 For an output port only primitive types are supported.
 
 ++ \@spl.map
-Decorator to create a stateful or stateless SPL operator from a Python callable class or function.
+Decorator to create a stateful or stateless SPL map operator from a Python callable class or function.
+
 When a Python callable class is decorated with `@spl.map`
 a potentially stateful SPL operator is created with a single input port
 and single output port.  For each input tuple the `__call__` function is called,
@@ -545,9 +546,24 @@ and its return value is used to submit zero or more tuples on the output port.
 
 TODO: Add more info about parameter passing.
  
+++ \@spl.for_each
+Decorator to create a stateful or stateless SPL sink operator from a Python callable class or function.
+
+When a Python callable class is decorated with `@spl.for_each`
+a potentially stateful SPL operator is created with a single input port
+and no output ports.  For each input tuple the `__call__` function is called.
+If the class has instance attributes then they are the state of the
+operator and are private to each invocation of the operator and maintained
+across calls to its `__call__` method.
+
+When a Python function is decorated with `@spl.for_each`
+a stateless SPL operator is created with a single input port
+and no output ports. For each input tuple the function is called.
+
+TODO: Add more info about parameter passing.
 
 ++ \@spl.pipe
-Decorator to create a stateless SPL operator from a Python function.
+Decorator to create a stateless SPL map operator from a Python function.
 When a Python function is decorated with `@spl.pipe`
 a stateless SPL operator is created with a single input port
 and single output port.  For each input tuple the function is called,
@@ -582,7 +598,7 @@ Demonstration of returning multiple tuples as a list.
 
 
 ++ \@spl.sink
-Decorator to create a sink SPL operator.
+Decorator to create a stateless SPL sink operator.
 If the Python function is decorated with `@spl.sink`
 then the operator is a sink operator, with a single
 input port and no output ports.

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -528,12 +528,28 @@ For an input port all the above types are supported.
 
 For an output port only primitive types are supported.
 
+++ \@spl.map
+Decorator to create a stateful or stateless SPL operator from a Python callable class or function.
+When a Python callable class is decorated with `@spl.map`
+a potentially stateful SPL operator is created with a single input port
+and single output port.  For each input tuple the `__call__` function is called,
+and its return value is used to submit zero or more tuples on the output port.
+If the class has instance attributes then they are the state of the
+operator and are private to each invocation of the operator and maintained
+across calls to its `__call__` method.
+
+When a Python function is decorated with `@spl.map`
+a stateless SPL operator is created with a single input port
+and single output port.  For each input tuple the function is called,
+and its return value is used to submit zero or more tuples on the output port. 
+
+TODO: Add more info about parameter passing.
  
 
 ++ \@spl.pipe
-Decorator to create a pipe SPL operator.
+Decorator to create a stateless SPL operator from a Python function.
 When a Python function is decorated with `@spl.pipe`
-a pipe SPL operator is created with a single input port
+a stateless SPL operator is created with a single input port
 and single output port.  For each input tuple the function is called,
 and its return value is used to submit zero or more tuples on the output port. 
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -432,15 +432,15 @@ connections may be created from a single MqttStreams connector.
 	mqs.print()
 
 + Decorating Python Functions as SPL Operators
-SPL operators that call a Python function are created by
+SPL operators that call a Python function or callable class are created by
 decorators provided by this toolkit.
 
 `bin/spl-python-extract.py` is a Python script that creates SPL operators from
-Python functions contained in modules in a toolkit.
+Python functions and classes contained in modules in a toolkit.
 The resulting operators embed the Python runtime to
 allow stream processing using Python.
 
-To create SPL operators from Python functions one or more Python
+To create SPL operators from Python functions or classes one or more Python
 modules are created in the `opt/python/streams` directory
 of an SPL toolkit.
 
@@ -461,9 +461,13 @@ For example:
     def splNamespace():
        return "com.ibm.streamsx.topology.pysamples.mail"
 
-Any Python docstring for the function is copied into the SPL operator's description field in its operator model, providing a description for IDE developers using the toolkit.
+Decorating a Python function produces a stateless SPL operator. The function may reference variables in the module that are effectively state but such variables are shared by all invocations of the operator within the same processing elemen.
 
-Functions in the modules that are not decorated, decorated with `@spl.ignore` or start with `spl` are ignored and will not result in any SPL operator.
+Decorating a Python class produces a stateful SPL operator. The instance attributes of the class are the state for the operator. 
+
+Any Python docstring for the function or class is copied into the SPL operator's description field in its operator model, providing a description for IDE developers using the toolkit.
+
+Functions or classes in the modules that are not decorated, decorated with `@spl.ignore` or start with `spl` are ignored and will not result in any SPL operator.
 
 ++ Conversion between SPL and Python tuples.
 SPL attributes map to Python tuples by position.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -29,15 +29,8 @@ def pipe(wrapped):
     """
     if not inspect.isfunction(wrapped):
         raise TypeError('A function is required')
-          
-    @functools.wraps(wrapped)
-    def _pipe(*args, **kwargs):
-        return wrapped(*args, **kwargs)
-    _pipe.__splpy_optype = OperatorType.Pipe
-    _pipe.__splpy_callable = 'function'
-    _pipe.__splpy_attributes = PassBy.position
-    _pipe.__splpy_file = inspect.getsourcefile(wrapped)
-    return _pipe
+
+    return _wrapforsplop(OperatorType.Pipe, PassBy.position, wrapped)
 
 #
 # Wrap object for an SPL operator, either
@@ -57,6 +50,7 @@ def _wrapforsplop(optype, attributes, wrapped):
         _op_class.__splpy_callable = 'class'
         _op_class.__splpy_attributes = attributes
         _op_class.__splpy_file = inspect.getsourcefile(wrapped)
+        _op_class.__doc__ = wrapped.__doc__
         return _op_class
     if not inspect.isfunction(wrapped):
         raise TypeError('A function or callable class is required')

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -9,26 +9,75 @@ OperatorType = Enum('OperatorType', 'Ignore Source Sink Pipe')
 OperatorType.Pipe.spl_template = 'PythonFunctionPipe'
 OperatorType.Sink.spl_template = 'PythonFunctionSink'
 
-def pipe(wrapped):
-    if inspect.isclass(wrapped):
-      class _pipe_class(object):
-        def __init__(self,*args,**kwargs):
-            self.__splpy_instance = wrapped(*args,**kwargs)
-        def __call__(self, *args,**kwargs):
-            return self.__splpy_instance.__call__(*args, **kwargs)
-      _pipe_class.__splpy_optype = OperatorType.Pipe
-      _pipe_class.__splpy_callable = 'class'
-      _pipe_class.__splpy_file = inspect.getsourcefile(wrapped)
-      return _pipe_class
-    
+PassBy = Enum('PassBy', 'name position')
 
+
+def pipe(wrapped):
+    """
+    Create a SPL operator from a function.
+    
+    A pipe SPL operator with a single input port and a single
+    output port. For each tuple on the input port the
+    function is called passing the contents of the tuple.
+
+    SPL attributes from the tuple are passed by position.
+    
+    The value returned from the function defines what is
+    submitted to the output port. If None is returned then
+    nothing is submitted. If a tuple is returned then it
+    is c
+    """
+    if not inspect.isfunction(wrapped):
+        raise TypeError('A function is required')
+          
     @functools.wraps(wrapped)
     def _pipe(*args, **kwargs):
         return wrapped(*args, **kwargs)
     _pipe.__splpy_optype = OperatorType.Pipe
     _pipe.__splpy_callable = 'function'
+    _pipe.__splpy_attributes = PassBy.position
     _pipe.__splpy_file = inspect.getsourcefile(wrapped)
     return _pipe
+
+class map:
+    """
+    Create a SPL operator from a callable class or function.
+
+    A map SPL operator with a single input port and a single
+    output port. For each tuple on the input port the
+    function is called passing the contents of the tuple.
+    """
+
+    def __init__(self, attributes=PassBy.name):
+        if attributes is not PassBy.position:
+            raise NotImplementedError(attributes)
+        self.attributes = attributes
+
+    def __call__(self, wrapped):
+        if inspect.isclass(wrapped):
+            if not callable(wrapped):
+                raise TypeError('Class must be callable')
+            class _map_class(object):
+                def __init__(self,*args,**kwargs):
+                    self.__splpy_instance = wrapped(*args,**kwargs)
+                def __call__(self, *args,**kwargs):
+                    return self.__splpy_instance.__call__(*args, **kwargs)
+            _map_class.__splpy_optype = OperatorType.Pipe
+            _map_class.__splpy_callable = 'class'
+            _map_class.__splpy_attributes = self.attributes
+            _map_class.__splpy_file = inspect.getsourcefile(wrapped)
+            return _map_class
+        if not inspect.isfunction(wrapped):
+            raise TypeError('A function or callable class is required')
+          
+        @functools.wraps(wrapped)
+        def _map_fn(*args, **kwargs):
+            return wrapped(*args, **kwargs)
+        _map_fn.__splpy_optype = OperatorType.Pipe
+        _map_fn.__splpy_callable = 'function'
+        _map_fn.__splpy_attributes = self.attributes
+        _map_fn.__splpy_file = inspect.getsourcefile(wrapped)
+        return _map_fn
 
 # Allows functions in any module in opt/python/streams to be explicitly ignored.
 def ignore(wrapped):
@@ -47,5 +96,6 @@ def sink(wrapped):
         assert ret == None, "SPL @sink function must not return any value, except None"
         return None
     _sink.__splpy_optype = OperatorType.Sink
+    _sink.__splpy_callable = 'function'
     _sink.__splpy_file = inspect.getsourcefile(wrapped)
     return _sink

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -41,11 +41,17 @@ def _wrapforsplop(optype, attributes, wrapped):
     if inspect.isclass(wrapped):
         if not callable(wrapped):
             raise TypeError('Class must be callable')
+
         class _op_class(object):
+
+            @functools.wraps(wrapped.__init__)
             def __init__(self,*args,**kwargs):
                 self.__splpy_instance = wrapped(*args,**kwargs)
+
+            @functools.wraps(wrapped.__call__)
             def __call__(self, *args,**kwargs):
                 return self.__splpy_instance.__call__(*args, **kwargs)
+
         _op_class.__splpy_optype = optype
         _op_class.__splpy_callable = 'class'
         _op_class.__splpy_attributes = attributes

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -10,10 +10,23 @@ OperatorType.Pipe.spl_template = 'PythonFunctionPipe'
 OperatorType.Sink.spl_template = 'PythonFunctionSink'
 
 def pipe(wrapped):
+    if inspect.isclass(wrapped):
+      class _pipe_class(object):
+        def __init__(self,*args,**kwargs):
+            self.__splpy_instance = wrapped(*args,**kwargs)
+        def __call__(self, *args,**kwargs):
+            return self.__splpy_instance.__call__(*args, **kwargs)
+      _pipe_class.__splpy_optype = OperatorType.Pipe
+      _pipe_class.__splpy_callable = 'class'
+      _pipe_class.__splpy_file = inspect.getsourcefile(wrapped)
+      return _pipe_class
+    
+
     @functools.wraps(wrapped)
     def _pipe(*args, **kwargs):
         return wrapped(*args, **kwargs)
     _pipe.__splpy_optype = OperatorType.Pipe
+    _pipe.__splpy_callable = 'function'
     _pipe.__splpy_file = inspect.getsourcefile(wrapped)
     return _pipe
 

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
@@ -14,4 +14,17 @@
     // Set the function the operator will call as a member field
     function_ =
       streamsx::topology::Splpy::loadFunction("<%=$module%>", "<%=$functionName%>");   
+<%
+    if (splpy_OperatorCallable() eq 'class') {
+%>
+     // At this point function_ is the callable class object
+     // we call it to create an instance of the class
+     // (which itself is callable)
+     PyObject *tmp_instance = PyObject_CallObject(function_, NULL);
+     Py_DECREF(function_);
+     function_ = tmp_instance;
+<%
+    }
+%>
+
     }

--- a/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
@@ -72,7 +72,26 @@ def Noop(*tuple):
     "Pass the tuple along without any change"
     return tuple
 
+# Stateful operator that adds a sequence number
+# as the last attribute of the input tuple.
+# The instance attribute self.seq is the operator's
+# state and is private to the operator invocation.
+#
+# From an SPL point of view the output schema
+# must the input schema plus one additional
+# numeric attribute as the last attribute.
 
+@spl.map(attributes=spl.PassBy.position)
+class AddSeq:
+    "Add a sequence number as the last attribute"
+    def __init__(self):
+        self.seq = 0
+
+    def __call__(self, *tuple):
+        id = self.seq
+        self.seq += 1
+        return tuple + (id,)
+    
 # Filters tuples by only returning a value if
 # the first attribute is less than the second
 # The returned value is a Tuple containing

--- a/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
@@ -69,7 +69,7 @@ def splNamespace():
 
 @spl.pipe
 def Noop(*tuple):
-    "Pass the tuple along without any change"
+    "Pass the tuple along without any change."
     return tuple
 
 # Stateful operator that adds a sequence number
@@ -83,7 +83,7 @@ def Noop(*tuple):
 
 @spl.map(attributes=spl.PassBy.position)
 class AddSeq:
-    "Add a sequence number as the last attribute"
+    "Add a sequence number as the last attribute."
     def __init__(self):
         self.seq = 0
 
@@ -95,10 +95,11 @@ class AddSeq:
 from datetime import datetime
 
 # Stateful sink operator that prints each tuple
-# with the inter-tuple arrival time.
+# with the inter-tuple arrival delay.
 #
 @spl.for_each(attributes=spl.PassBy.position)
 class PrintWithTimeIntervals:
+    "Print tuples with inter-tuple arrival delay."
     def __init__(self):
         self.last = datetime.now()
 
@@ -146,7 +147,7 @@ def SimpleFilter(a,b):
 
 @spl.pipe
 def AddFirstTwoSecondTwo(a,b,c,d):
-    "Add first two and second two attributes"
+    "Add first two and second two attributes."
     return a+b,c+d
 
 # Example where the first attribute is passed by position
@@ -155,7 +156,7 @@ def AddFirstTwoSecondTwo(a,b,c,d):
 #
 @spl.pipe
 def Lowest(threshold, *values):
-    "Find the lowest value above a threshold in all the remaining attributes"
+    "Find the lowest value above a threshold in all the remaining attributes."
     lm = None
     for v in values:
       if v >= threshold:
@@ -171,10 +172,10 @@ def Lowest(threshold, *values):
 #
 @spl.pipe
 def ReturnList(a,b,c):
-    "Demonstrate returning a list of values, each value is submitted as a tuple" 
+    "Demonstrate returning a list of values, each value is submitted as a tuple." 
     return [(a+1,b+1,c+1),(a+2,b+2,c+2),(a+3,b+3,c+3),(a+4,b+4,c+4)]
 
 @spl.sink
 def PrintTuple(*tuple):
-    "Print each tuple to standard out"
+    "Print each tuple to standard out."
     print(tuple, flush=True)

--- a/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
@@ -91,6 +91,23 @@ class AddSeq:
         id = self.seq
         self.seq += 1
         return tuple + (id,)
+
+from datetime import datetime
+
+# Stateful sink operator that prints each tuple
+# with the inter-tuple arrival time.
+#
+@spl.for_each(attributes=spl.PassBy.position)
+class PrintWithTimeIntervals:
+    def __init__(self):
+        self.last = datetime.now()
+
+    def __call__(self, *tuple):
+        now = datetime.now()
+        iat = now - self.last
+        self.last = now
+        print(tuple, " ", iat, " seconds", flush=True)
+
     
 # Filters tuples by only returning a value if
 # the first attribute is less than the second

--- a/test/python/build.xml
+++ b/test/python/build.xml
@@ -19,12 +19,12 @@
 	  <copy file="../../samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py"
 	  	toDir="${testtk}/opt/python/streams"/>
 	  <target name="test.toolkit">
-		   <exec executable="python3" dir="${testtk}">
+		   <exec executable="python3" dir="${testtk}" failonerror="true">
 		     <arg value="${tk}/bin/spl-python-extract.py"/>
 		     <arg value="--directory"/>
 		     <arg value="${testtk}"/>
 		   </exec>
-	   <exec executable="${streams.install}/bin/spl-make-toolkit">
+	   <exec executable="${streams.install}/bin/spl-make-toolkit" failonerror="true">
              <arg value="--make-operator"/>
 	     <arg value="-i"/>
 	     <arg value="${testtk}"/>


### PR DESCRIPTION
Allows a callable class to become a SPL operator by decorating with `@spl.map`.

Class must currently have a __init__ method that takes no arguments (apart from `self`).

Example:

```
@spl.map(attributes=spl.PassBy.position)
class AddSeq:
    "Add a sequence number as the last attribute"
    def __init__(self):
        self.seq = 0

    def __call__(self, *tuple):
        id = self.seq
        self.seq += 1
        return tuple + (id,)
```