### PR TITLE
test and build changes to allow python 2.7 and python 3 to be used as…

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -175,7 +175,11 @@ namespace streamsx {
         }
 
 
+#if PY_MAJOR_VERSION == 3
         std::string pyLib("libpython3.5m.so");
+#else
+        std::string pyLib("libpython2.7.so");
+#endif
         char * pyHome = getenv("PYTHONHOME");
         if (pyHome != NULL) {
             std::string wk(pyHome);

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -8,8 +8,7 @@ import json
 import subprocess
 import threading
 import sys, traceback
-
-import shutil
+from platform import python_version
 
 #
 # Utilities
@@ -60,6 +59,7 @@ def submit(ctxtype, graph, config = None, username = None, password = None):
     pythonrealfile = os.path.basename(pythonreal)
     pythonconfig = pythondir+"/"+pythonfile+"-config"
     pythonrealconfig = os.path.realpath(pythondir+"/"+pythonrealfile+"-config")
+    pythonversion = python_version()
 
     if config is None:
         config = {}
@@ -67,6 +67,7 @@ def submit(ctxtype, graph, config = None, username = None, password = None):
     # place the fullpaths to the python binary that is running and 
     # the python-config that will used into the config
     config["pythonversion"] = {}
+    config["pythonversion"]["version"] = pythonversion
     config["pythonversion"]["binaries"] = []
     bf = {}
     bf["python"] = pythonreal

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -73,10 +73,6 @@ def submit(ctxtype, graph, config = None, username = None, password = None):
     bf["python"] = pythonreal
     bf["pythonconfig"] = pythonrealconfig
     config["pythonversion"]["binaries"].append(bf)
-    # also write the python-config path to a file that will be used 
-    # from within pyversion.sh 
-    with open('/tmp/'+os.environ['USER']+'.pythonconfig', 'w') as pf:
-      pf.write(pythonrealconfig)
 
     fj = _createFullJSON(graph, config)
     fn = _createJSONFile(fj)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -9,6 +9,8 @@ import subprocess
 import threading
 import sys, traceback
 
+import shutil
+
 #
 # Utilities
 #
@@ -50,8 +52,31 @@ def submit(ctxtype, graph, config = None, username = None, password = None):
     Returns:
         An output stream of bytes if submitting with JUPYTER, otherwise returns None.
     """    
+    # path to python binary
+    pythonbin = sys.executable
+    pythonreal = os.path.realpath(pythonbin)
+    pythondir = os.path.dirname(pythonbin) 
+    pythonfile = os.path.basename(pythonbin)
+    pythonrealfile = os.path.basename(pythonreal)
+    pythonconfig = pythondir+"/"+pythonfile+"-config"
+    pythonrealconfig = os.path.realpath(pythondir+"/"+pythonrealfile+"-config")
+
     if config is None:
         config = {}
+
+    # place the fullpaths to the python binary that is running and 
+    # the python-config that will used into the config
+    config["pythonversion"] = {}
+    config["pythonversion"]["binaries"] = []
+    bf = {}
+    bf["python"] = pythonreal
+    bf["pythonconfig"] = pythonrealconfig
+    config["pythonversion"]["binaries"].append(bf)
+    # also write the python-config path to a file that will be used 
+    # from within pyversion.sh 
+    with open('/tmp/'+os.environ['USER']+'.pythonconfig', 'w') as pf:
+      pf.write(pythonrealconfig)
+
     fj = _createFullJSON(graph, config)
     fn = _createJSONFile(fj)
 

--- a/com.ibm.streamsx.topology/opt/python/templates/common/pyversion.sh
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/pyversion.sh
@@ -1,17 +1,15 @@
 #!/bin/sh
+pythonconfigfile=/tmp/$USER.pythonconfig
+pythonconfig=`cat ${pythonconfigfile}`
 action=$1
-if [ "x$STREAMS_TOPOLOGYX_PYTHON" == "x" ]
-then
-  STREAMS_TOPOLOGYX_PYTHON=python3
-fi
 
 if [ $action = "lib" ]
 then
-    ${STREAMS_TOPOLOGYX_PYTHON}-config --libs | sed -e 's/^-l//;s/ -l/ /g;s/ \+/\n/g'
+    ${pythonconfig} --libs | sed -e 's/^-l//;s/ -l/ /g;s/ \+/\n/g'
 elif [ $action = "libPath" ]
 then
-    echo `${STREAMS_TOPOLOGYX_PYTHON}-config --prefix`/lib
+    echo `${pythonconfig} --prefix`/lib
 elif [ $action = "includePath" ]
 then
-    ${STREAMS_TOPOLOGYX_PYTHON}-config --includes
+    ${pythonconfig} --includes
 fi

--- a/com.ibm.streamsx.topology/opt/python/templates/common/pyversion.sh
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/pyversion.sh
@@ -1,15 +1,13 @@
 #!/bin/sh
-pythonconfigfile=/tmp/$USER.pythonconfig
-pythonconfig=`cat ${pythonconfigfile}`
 action=$1
 
 if [ $action = "lib" ]
 then
-    ${pythonconfig} --libs | sed -e 's/^-l//;s/ -l/ /g;s/ \+/\n/g'
+    python3-config --libs | sed -e 's/^-l//;s/ -l/ /g;s/ \+/\n/g'
 elif [ $action = "libPath" ]
 then
-    echo `${pythonconfig} --prefix`/lib
+    echo `python3-config --prefix`/lib
 elif [ $action = "includePath" ]
 then
-    ${pythonconfig} --includes
+    python3-config --includes
 fi

--- a/com.ibm.streamsx.topology/opt/python/templates/common/pyversion.sh
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/pyversion.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 action=$1
+if [ "x$STREAMS_TOPOLOGYX_PYTHON" == "x" ]
+then
+  STREAMS_TOPOLOGYX_PYTHON=python3
+fi
+
 if [ $action = "lib" ]
 then
-    python3-config --libs | sed -e 's/^-l//;s/ -l/ /g;s/ \+/\n/g'
+    ${STREAMS_TOPOLOGYX_PYTHON}-config --libs | sed -e 's/^-l//;s/ -l/ /g;s/ \+/\n/g'
 elif [ $action = "libPath" ]
 then
-    echo `python3-config --prefix`/lib
+    echo `${STREAMS_TOPOLOGYX_PYTHON}-config --prefix`/lib
 elif [ $action = "includePath" ]
 then
-    python3-config --includes
+    ${STREAMS_TOPOLOGYX_PYTHON}-config --includes
 fi

--- a/common-build.xml
+++ b/common-build.xml
@@ -10,8 +10,6 @@
   <property environment="env"/>
   <fail unless="env.STREAMS_INSTALL" message="STREAMS_INSTALL not set."/>
   <property name="streams.install" value="${env.STREAMS_INSTALL}"/>
-  <property name="env.STREAMS_TOPOLOGYX_PYTHON" value="python3"/>
-  <property name="streams.python" value="${env.STREAMS_TOPOLOGYX_PYTHON}"/>
   <property name="tk.name" value="com.ibm.streamsx.topology"/>
   <property name="tk" location="${streamsx.topology}/${tk.name}"/>
   <property name="tk.opt" location="${tk}/opt"/>
@@ -26,6 +24,7 @@
   <property name="ant.build.javac.target" value="8"/>
 
   <property name="topology.test.root" location="${streamsx.topology}/test"/>
+  <property name="topology.test.python" value="python3"/>
 
   <!-- Use the full class path as scalac doesn't seem to always pick
        up jars theough the manifest, even if -usemanifestcp is set -->

--- a/common-build.xml
+++ b/common-build.xml
@@ -10,6 +10,8 @@
   <property environment="env"/>
   <fail unless="env.STREAMS_INSTALL" message="STREAMS_INSTALL not set."/>
   <property name="streams.install" value="${env.STREAMS_INSTALL}"/>
+  <property name="env.STREAMS_TOPOLOGYX_PYTHON" value="python3"/>
+  <property name="streams.python" value="${env.STREAMS_TOPOLOGYX_PYTHON}"/>
   <property name="tk.name" value="com.ibm.streamsx.topology"/>
   <property name="tk" location="${streamsx.topology}/${tk.name}"/>
   <property name="tk.opt" location="${tk}/opt"/>

--- a/test/python/build.xml
+++ b/test/python/build.xml
@@ -19,7 +19,7 @@
 	  <copy file="../../samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py"
 	  	toDir="${testtk}/opt/python/streams"/>
 	  <target name="test.toolkit">
-		   <exec executable="python3" dir="${testtk}" failonerror="true">
+		   <exec executable="${streams.python}" dir="${testtk}" failonerror="true">
 		     <arg value="${tk}/bin/spl-python-extract.py"/>
 		     <arg value="--directory"/>
 		     <arg value="${testtk}"/>
@@ -32,14 +32,14 @@
 	   </target>
 
 	  <target name="test.application.api">
-		   <exec executable="python3" dir="${topology}" failonerror="true">
+		   <exec executable="${streams.python}" dir="${topology}" failonerror="true">
 		     <env key="PYTHONPATH" value="${topology.toolkit.release}/opt/python/packages"/>
 		     <arg value="test1.py"/>
 		   </exec>
 	   </target>
 	   
 	  <target name="test.mqtt.application.api">
-		   <exec executable="python3" dir="${topology}" failonerror="true">
+		   <exec executable="${streams.python}" dir="${topology}" failonerror="true">
 		     <env key="PYTHONPATH" value="${topology.toolkit.release}/opt/python/packages"/>
 		     <arg value="mqtest1.py"/>
 		   </exec>

--- a/test/python/build.xml
+++ b/test/python/build.xml
@@ -19,7 +19,7 @@
 	  <copy file="../../samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py"
 	  	toDir="${testtk}/opt/python/streams"/>
 	  <target name="test.toolkit">
-		   <exec executable="${streams.python}" dir="${testtk}" failonerror="true">
+		   <exec executable="${topology.test.python}" dir="${testtk}" failonerror="true">
 		     <arg value="${tk}/bin/spl-python-extract.py"/>
 		     <arg value="--directory"/>
 		     <arg value="${testtk}"/>
@@ -32,14 +32,14 @@
 	   </target>
 
 	  <target name="test.application.api">
-		   <exec executable="${streams.python}" dir="${topology}" failonerror="true">
+		   <exec executable="${topology.test.python}" dir="${topology}" failonerror="true">
 		     <env key="PYTHONPATH" value="${topology.toolkit.release}/opt/python/packages"/>
 		     <arg value="test1.py"/>
 		   </exec>
 	   </target>
 	   
 	  <target name="test.mqtt.application.api">
-		   <exec executable="${streams.python}" dir="${topology}" failonerror="true">
+		   <exec executable="${topology.test.python}" dir="${topology}" failonerror="true">
 		     <env key="PYTHONPATH" value="${topology.toolkit.release}/opt/python/packages"/>
 		     <arg value="mqtest1.py"/>
 		   </exec>


### PR DESCRIPTION
basic build and test changes that allows the choosing of the python level (2.7 or 3.5) with the STREAMS_TOPOLOGYX_PYTHON environment variable.