### PR TITLE
Documentation and improvements for parameter passing.

### DIFF
--- a/com.ibm.streamsx.topology/bin/spl-python-extract.py
+++ b/com.ibm.streamsx.topology/bin/spl-python-extract.py
@@ -136,7 +136,11 @@ def copyCGT(opdir, ns, name, funcTuple):
 ##
 import html
 def create_op_spldoc(opmodel_xml, name, opobj):
-     _opdoc = html.escape(inspect.getdoc(opobj))
+     _opdoc = inspect.getdoc(opobj)
+     if _opdoc is None:
+         _opdoc = 'Callable: ' + name + "\n"
+
+     _opdoc = html.escape(_opdoc)
 
      # Optionally include the Python source code
      if opobj.__splpy_docpy:
@@ -164,7 +168,6 @@ def create_ip_spldoc(opmodel_xml, name, opobj):
        Tuple attribute values are passed by position to the Python callable.
              """;
  
-     _oc = html.escape(inspect.getdoc(opobj))
      replaceTokenInFile(opmodel_xml, "__SPLPY__INPORT_0_DESCRIPTION__SPLPY__", _p0doc);
    
 # Write information about the Python function parameters.

--- a/com.ibm.streamsx.topology/bin/spl-python-extract.py
+++ b/com.ibm.streamsx.topology/bin/spl-python-extract.py
@@ -104,14 +104,13 @@ _OP_PARAM_TEMPLATE ="""
 def create_op_parameters(opmodel_xml, name, opObj):
     opparam_xml = ''
     if opObj.__splpy_callable == 'class':
-        init_sig = inspect.signature(opObj.__init__)
-        seenSelf = False;
-        for pn in init_sig.parameters:
-            pmd = init_sig.parameters[pn]
-            # first argument to __init__ is self (instance ref)
-            if not seenSelf:
-                 seenSelf = True
-                 continue
+        pmds = init_sig = inspect.signature(opObj.__init__).parameters
+        itpmds = iter(pmds)
+        # first argument to __init__ is self (instance ref)
+        next(itpmds)
+        
+        for pn in itpmds:
+            pmd = pmds[pn]
             px = _OP_PARAM_TEMPLATE
             px = px.replace('__SPLPY__PARAM_NAME__SPLPY__', pn)
             px = px.replace('__SPLPY__PARAM_OPT__SPLPY__', 'false' if pmd.default== inspect.Parameter.empty else 'true' )
@@ -182,15 +181,14 @@ def write_style_info(cfgfile, opobj):
         sig = inspect.signature(opfn)
         fixedCount = 0
         if opobj.__splpy_style == 'tuple':
-            params = sig.parameters
-            seenFirst = False
-            for pname in params:
-                 if not seenFirst:
-                     # Skip 'self' for classes
-                     seenFirst = True
-                     if is_class:
-                         continue
-                 param = params[pname]
+            pmds = sig.parameters
+            itpmds = iter(pmds)
+            # Skip 'self' for classes
+            if is_class:
+                next(itpmds)
+            
+            for pn in itpmds:
+                 param = pmds[pn]
                  if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
                      fixedCount += 1
                  if param.kind == inspect.Parameter.VAR_POSITIONAL:

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -431,7 +431,7 @@ connections may be created from a single MqttStreams connector.
 	mqs = mqstream.subscribe(topic) 
 	mqs.print()
 
-+ Decorating Python Functions as SPL Operators
++ Creating SPL Operators from Python code
 SPL operators that call a Python function or callable class are created by
 decorators provided by this toolkit.
 
@@ -461,36 +461,260 @@ For example:
     def splNamespace():
        return "com.ibm.streamsx.topology.pysamples.mail"
 
-Decorating a Python function produces a stateless SPL operator. The function may reference variables in the module that are effectively state but such variables are shared by all invocations of the operator within the same processing elemen.
-
 Decorating a Python class produces a stateful SPL operator. The instance attributes of the class are the state for the operator. 
+
+Decorating a Python function produces a stateless SPL operator. The function may reference variables in the module that are effectively state but such variables are shared by all invocations of the operator within the same processing elemen.
 
 Any Python docstring for the function or class is copied into the SPL operator's description field in its operator model, providing a description for IDE developers using the toolkit.
 
 Functions or classes in the modules that are not decorated, decorated with `@spl.ignore` or start with `spl` are ignored and will not result in any SPL operator.
 
-++ Conversion between SPL and Python tuples.
-SPL attributes map to Python tuples by position.
-# SPL Tuple passed into a Python function
-When an SPL tuple is passed into a Python function through its SPL operator
-its attributes are passed by position. The first attribute is
-the first positional parameter in the Python function. For example:
-    # SPL input schema: tuple<int32 id, float64 reading>
-    \@spl.sink
-    def myfunc(a,b):
-      # a is set to: id
-      # b is set to: reading
+++ Processing SPL tuples in Python
 
-If more SPL attributes exist than specified parameters then the additional attributes are ignored.
+SPL tuples are converted to Python objects and passed to a decorated callable.
 
-A Python variable argument can be used to capture all of the remaining attributes, for example:
-    # SPL input schema: tuple<int32 id, float64 reading, float lat, float lon>
-    \@spl.sink
-    def myvarargfunc(a, *values)
-      # a is set to: id
-      # values is set to the values of: reading, lat, lon
+# Overview
 
-# Python function return conversion to SPL Tuples
+For each SPL tuple arriving at an input port a Python function is called with
+the SPL tuple converted to Python values suitable for the function call.
+How the tuple is passed is defined by the tuple passing style.
+
+# Tuple Passing Styles
+An input tuple can be passed to Python function using a number of different styles:
+* *dictionary* **not yet implemented**
+* *tuple*
+* *attributes by name* **not yet implemented**
+* *attributes by position*
+* *named tuple* **not yet implemented**
+
+# Dictionary
+(**not yet implemented**)
+
+Passing the SPL tuple as a Python dictionary is flexible
+and makes the operator independent of any schema.
+A disadvantage is the reduction in code readability
+for Python function by not having formal parameters,
+though getters such as `tuple\['id'\]` mitigate that to some extent.
+If the function is general purpose and can derive meaning
+from the keys that are the attribute names then `\*\*kwargs` can be useful.
+
+When the only function parameter is `\*\*kwargs`,
+e.g. `def myfunc(\*\*tuple):`, then the passing style is *dictionary*.
+
+All of the attributes are passed in the dictionary
+using the attribute name as the key.
+
+# Tuple
+
+Passing the SPL tuple as a Python tuple is flexible
+and makes the operator independent of any schema
+but is brittle to changes in the SPL schema.
+Another disadvantage is the reduction in code readability
+for Python function by not having formal parameters.
+However if the function is general purpose and independent
+of the tuple contents `\*args` can be useful.
+
+When the only function parameter is `\*args`
+(e.g. `def myfunc(\*tuple):`) then the passing style is *tuple*.
+
+All of the attributes are passed as a Python tuple
+with the order of values matching the order of the SPL schema.
+
+# Attributes by name
+(**not yet implemented**)
+
+Passing attributes by name can be robust against changes
+in the SPL scheme, e.g. additional attributes being added in
+the middle of the schema, but does require that the SPL schema
+has matching attribute names.
+
+When *attributes by name* is used then SPL tuple attributes
+are passed to the function by name for formal parameters.
+Order of the attributes and parameters need not match.
+This is supported for function parameters of
+kind `POSITIONAL_OR_KEYWORD` and `KEYWORD_ONLY`.
+
+If the function signature also contains a parameter of the form
+`\*\*kwargs` (`VAR_KEYWORD`) then any attributes not bound to formal parameters
+are passed in its dictionary using the attribute name as the key.
+
+If the function signature also contains an arbitrary argument
+list `\*args` then any attributes not bound to formal parameters
+or to `\*\*kwargs` are passed in order of the SPL schema.
+
+If there are only formal parameters any non-bound attributes
+are not passed into the function.
+
+# Attributes by position
+
+Passing attributes by position allows the SPL operator to
+be independent of the SPL schema but is brittle to
+changes in the SPL schema. For example a function expecting
+an identifier and a sensor reading as the first two attributes
+would break if an attribute representing region was added as
+the first SPL attribute.
+
+When *attributes by position* is used then SPL tuple attributes are
+passed to the function by position for formal parameters.
+The first SPL attribute in the tuple is passed as the first parameter.
+This is supported for function parameters of
+kind `POSITIONAL_ONLY` and `POSITIONAL_OR_KEYWORD`.
+
+If the function signature also contains an arbitrary argument
+list `\*args` (`VAR_POSITIONAL`) then any attributes not bound
+to formal parameters are passed in order of the SPL schema.
+
+If the function signature also contains a parameter of the form
+`\*\*kwargs` (`VAR_KEYWORD`) then any attributes not bound to formal parameters
+are passed in its dictionary using the attribute name as the key.
+(**not yet implemented**)
+
+If there are only formal parameters any non-bound attributes
+are not passed into the function.
+
+The SPL schema must have at least the number of positional arguments
+the function requires.
+
+# Selecting the style
+
+For signatures only containing parameters of the form 
+\*args` or `\*\*kwargs` the style is implicitly defined:
+
+* `def f(\*\*tuple)` - *dictionary* - `tuple` will contain a dictionary of all of the SPL tuple attribute's values with the keys being the attribute names.
+* `def f(\*tuple)` - *tuple* - `tuple` will contain all of the SPL tuple attribute's values in order of the SPL schema definition.
+* `def f(\*empty, \*\*tuple)` - *dictionary* - `tuple` will contain a dictionary of all of the SPL tuple attribute's values with the keys being the attribute names. `empty` will be an empty Python tuple `empty = ()`.
+
+Otherwise the style is set by the `style` parameter to the decorator,
+defaulting to *attributes by name*. The style value can be set to:
+  * `'name'` - *attributes by name*
+  * `'position'` - *attributes by position*
+
+**Note**: For backwards compatibility `\@spl.pipe` and `\@spl.sink`
+**always** use *attributes by position* and do not support `\*\*kwargs`.
+They do not support the `style` parameter.
+
+# Examples
+
+These examples how a SPL tuple with the schema and value:
+
+    tuple<rstring id, float64 temp, boolean increase>
+    {id='battery', temp=23.7, increase=true}
+
+is passed into a variety of functions by showing the effective Python call and the resulting values of the function's parameters.
+
+*Dictionary* consuming all attributes by `\*\*kwargs`:
+    \@spl.map
+    def f(**tuple)
+        pass
+    # f(id='battery', temp=23.7, increase=True)
+    # tuple={'id':'battery', 'temp':23.7, 'increase':True}
+
+*Tuple* consuming all attributes by `\*args`:
+    \@spl.map
+    def f(*tuple)
+        pass
+    # f('battery', 23.7, True)
+    # tuple=('battery',23.7, True)
+
+*Attributes by name* consuming all attributes:
+    \@spl.map
+    def f(id, temp, increase)
+        pass
+    # f(id='battery', temp=23.7, increase=True)
+    # id='battery'
+    # temp=23.7
+    # increase=True
+
+*Attributes by name* consuming a subset of attributes:
+    \@spl.map
+    def f(id, temp)
+        pass
+    # f(id='battery', temp=23.7)
+    # id='battery'
+    # temp=23.7
+
+*Attributes by name* consuming a subset of attributes in a different order:
+    \@spl.map
+    def f(increase, temp)
+        pass
+    # f(temp=23.7, increase=True)
+    # increase=True
+    # temp=23.7
+
+*Attributes by name* consuming `id` by name and remaining attributes by `\*\*kwargs`:
+    \@spl.map
+    def f(id, **tuple)
+        pass
+    # f(id='battery', temp=23.7, increase=True)
+    # id='battery'
+    # tuple={'temp':23.7, 'increase':True}
+
+*Attributes by name* consuming `id` by name and remaining attributes by `\*args`:
+    \@spl.map
+    def f(id, *tuple)
+        pass
+    # f(id='battery', 23.7, True)
+    # id='battery'
+    # tuple=(23.7, True)
+
+*Attributes by position* consuming all attributes:
+    \@spl.map(style='position')
+    def f(key, value, up)
+         pass
+    # f('battery', 23.7, True)
+    #
+    # key='battery'
+    # value=23.7
+    # up=True
+
+*Attributes by position* consuming a subset of attributes:
+    \@spl.map
+    def f(a, b)
+       pass
+    # f('battery', 23.7)
+    # a='battery'
+    # b=23.7
+
+*Attributes by position* `id`, `temp` by position and all remaining attributes by `\*\*kwargs`:
+    \@spl.map
+    def f(key, value, **tuple)
+        pass
+    # f('battery', 23.7, increase=True)
+    # key=battery
+    # value=23.7
+    # tuple={'increase':True}
+
+*Attributes by position* consuming `id` by position and remaining attributes by `\*args`:
+    \@spl.map
+    def f(key, *tuple)
+        pass
+    # f('battery', 23.7, True)
+    # key='battery'
+    # tuple=(23.7, True)
+
+In all cases the SPL tuple must be able to provide all parameters
+required by the function. If the SPL schema is insufficient then
+an error will result, typically a SPL compile time error.
+
+The SPL schema can provide a subset of the formal parameters if the
+remaining attributes are optional (having a default).
+
+*Attributes by name* consuming a subset of attributes with an optional parameter not matched by the schema:
+    \@spl.map
+    def f(id, temp, pressure=None)
+       pass
+    # f(id='battery', temp=23.7)
+    # id='battery'
+    # temp=23.7
+    # pressure=None
+
+Use of `\*args` and `\*\*kwargs` in a function signature will always
+result in `\*args` being passed an empty tuple.
+
+++ Submission of SPL tuples from Python
+
+The return from a decorated callable results in submission of SPL tuples on the associated outut port.
+
 A Python function must return `None`, a Python tuple or a list of Python tuples.
 When `None` is return then no tuple will be submitted to the operator's output port. When a single tuple is returned is is converted to an SPL tuple and submitted to the output port. When a list of tuples is returned, each tuple is converted to a tuple and submitted to the output port, in order of the list starting with the first tuple (position 0).
 
@@ -510,7 +734,7 @@ When a returned tuple has less values than attributes in the SPL output schema t
 
 When a returned tuple has more values than attributes in the SPL output schema then the additional values are ignored.
 
-# Supported SPL types
+++ Supported SPL types
 
 A limited set of SPL types are supported.
 
@@ -531,34 +755,71 @@ For an output port only primitive types are supported.
 ++ \@spl.map
 Decorator to create a stateful or stateless SPL map operator from a Python callable class or function.
 
-When a Python callable class is decorated with `@spl.map`
+# Decorated callable class
+
+When a Python *callable class* is decorated with `@spl.map`
 a potentially stateful SPL operator is created with a single input port
-and single output port.  For each input tuple the `__call__` function is called,
+and single output port. 
+
+    \@spl.map
+    class AddSeq:
+        "Add a sequence number as the last attribute."
+        def __init__(self):
+            self.seq = 0
+    
+        def __call__(self, *tuple):
+            id = self.seq
+            self.seq += 1
+            return tuple + (id,)
+
+When the SPL operator is initialized `__init__` is called to create
+an instance of the class. Subsequent tuple arrivals result in calls
+to the `__call__` function of this instance.
+
+For each tuple arriving at the input port `__call__` is called
 and its return value is used to submit zero or more tuples on the output port.
+
 If the class has instance attributes then they are the state of the
 operator and are private to each invocation of the operator and maintained
 across calls to its `__call__` method.
 
-When a Python function is decorated with `@spl.map`
+# Decorated function
+
+When a Python *function* is decorated with `@spl.map`
 a stateless SPL operator is created with a single input port
-and single output port.  For each input tuple the function is called,
+and single output port.
+
+    \@spl.map
+    def Noop(*tuple):
+        "Pass the tuple along without any change."
+        return tuple
+
+For each tuple arriving at the input port the decorated function is called
 and its return value is used to submit zero or more tuples on the output port. 
+
+# Examples
 
 TODO: Add more info about parameter passing.
  
 ++ \@spl.for_each
 Decorator to create a stateful or stateless SPL sink operator from a Python callable class or function.
 
-When a Python callable class is decorated with `@spl.for_each`
+# Callable class
+
+When a Python *callable class* is decorated with `@spl.for_each`
 a potentially stateful SPL operator is created with a single input port
-and no output ports.  For each input tuple the `__call__` function is called.
+and no output ports.  For each input tuple the `__call__` function is called
+passing the tuple.
 If the class has instance attributes then they are the state of the
 operator and are private to each invocation of the operator and maintained
 across calls to its `__call__` method.
 
-When a Python function is decorated with `@spl.for_each`
+# Function
+
+When a Python *function* is decorated with `@spl.for_each`
 a stateless SPL operator is created with a single input port
-and no output ports. For each input tuple the function is called.
+and no output ports. For each input tuple the function is called
+passing the tuple.
 
 TODO: Add more info about parameter passing.
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -485,7 +485,6 @@ An input tuple can be passed to Python function using a number of different styl
 * *tuple*
 * *attributes by name* **not yet implemented**
 * *attributes by position*
-* *named tuple* **not yet implemented**
 
 # Dictionary
 (**not yet implemented**)
@@ -557,17 +556,14 @@ the first SPL attribute.
 When *attributes by position* is used then SPL tuple attributes are
 passed to the function by position for formal parameters.
 The first SPL attribute in the tuple is passed as the first parameter.
-This is supported for function parameters of
-kind `POSITIONAL_ONLY` and `POSITIONAL_OR_KEYWORD`.
+This is supported for function parameters of kind `POSITIONAL_OR_KEYWORD`.
 
 If the function signature also contains an arbitrary argument
 list `\*args` (`VAR_POSITIONAL`) then any attributes not bound
 to formal parameters are passed in order of the SPL schema.
 
-If the function signature also contains a parameter of the form
-`\*\*kwargs` (`VAR_KEYWORD`) then any attributes not bound to formal parameters
-are passed in its dictionary using the attribute name as the key.
-(**not yet implemented**)
+The function signature must not contain a parameter of the form
+`\*\*kwargs` (`VAR_KEYWORD`).
 
 If there are only formal parameters any non-bound attributes
 are not passed into the function.
@@ -577,12 +573,11 @@ the function requires.
 
 # Selecting the style
 
-For signatures only containing parameters of the form 
+For signatures only containing a parameter of the form 
 \*args` or `\*\*kwargs` the style is implicitly defined:
 
 * `def f(\*\*tuple)` - *dictionary* - `tuple` will contain a dictionary of all of the SPL tuple attribute's values with the keys being the attribute names.
 * `def f(\*tuple)` - *tuple* - `tuple` will contain all of the SPL tuple attribute's values in order of the SPL schema definition.
-* `def f(\*empty, \*\*tuple)` - *dictionary* - `tuple` will contain a dictionary of all of the SPL tuple attribute's values with the keys being the attribute names. `empty` will be an empty Python tuple `empty = ()`.
 
 Otherwise the style is set by the `style` parameter to the decorator,
 defaulting to *attributes by name*. The style value can be set to:
@@ -603,21 +598,21 @@ These examples how a SPL tuple with the schema and value:
 is passed into a variety of functions by showing the effective Python call and the resulting values of the function's parameters.
 
 *Dictionary* consuming all attributes by `\*\*kwargs`:
-    \@spl.map
+    \@spl.map()
     def f(**tuple)
         pass
     # f(id='battery', temp=23.7, increase=True)
     # tuple={'id':'battery', 'temp':23.7, 'increase':True}
 
 *Tuple* consuming all attributes by `\*args`:
-    \@spl.map
+    \@spl.map()
     def f(*tuple)
         pass
     # f('battery', 23.7, True)
     # tuple=('battery',23.7, True)
 
 *Attributes by name* consuming all attributes:
-    \@spl.map
+    \@spl.map()
     def f(id, temp, increase)
         pass
     # f(id='battery', temp=23.7, increase=True)
@@ -626,7 +621,7 @@ is passed into a variety of functions by showing the effective Python call and t
     # increase=True
 
 *Attributes by name* consuming a subset of attributes:
-    \@spl.map
+    \@spl.map()
     def f(id, temp)
         pass
     # f(id='battery', temp=23.7)
@@ -634,7 +629,7 @@ is passed into a variety of functions by showing the effective Python call and t
     # temp=23.7
 
 *Attributes by name* consuming a subset of attributes in a different order:
-    \@spl.map
+    \@spl.map()
     def f(increase, temp)
         pass
     # f(temp=23.7, increase=True)
@@ -642,7 +637,7 @@ is passed into a variety of functions by showing the effective Python call and t
     # temp=23.7
 
 *Attributes by name* consuming `id` by name and remaining attributes by `\*\*kwargs`:
-    \@spl.map
+    \@spl.map()
     def f(id, **tuple)
         pass
     # f(id='battery', temp=23.7, increase=True)
@@ -650,7 +645,7 @@ is passed into a variety of functions by showing the effective Python call and t
     # tuple={'temp':23.7, 'increase':True}
 
 *Attributes by name* consuming `id` by name and remaining attributes by `\*args`:
-    \@spl.map
+    \@spl.map()
     def f(id, *tuple)
         pass
     # f(id='battery', 23.7, True)
@@ -668,24 +663,15 @@ is passed into a variety of functions by showing the effective Python call and t
     # up=True
 
 *Attributes by position* consuming a subset of attributes:
-    \@spl.map
+    \@spl.map(style='position')
     def f(a, b)
        pass
     # f('battery', 23.7)
     # a='battery'
     # b=23.7
 
-*Attributes by position* `id`, `temp` by position and all remaining attributes by `\*\*kwargs`:
-    \@spl.map
-    def f(key, value, **tuple)
-        pass
-    # f('battery', 23.7, increase=True)
-    # key=battery
-    # value=23.7
-    # tuple={'increase':True}
-
 *Attributes by position* consuming `id` by position and remaining attributes by `\*args`:
-    \@spl.map
+    \@spl.map(style='position')
     def f(key, *tuple)
         pass
     # f('battery', 23.7, True)
@@ -707,9 +693,6 @@ remaining attributes are optional (having a default).
     # id='battery'
     # temp=23.7
     # pressure=None
-
-Use of `\*args` and `\*\*kwargs` in a function signature will always
-result in `\*args` being passed an empty tuple.
 
 ++ Submission of SPL tuples from Python
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -752,6 +752,56 @@ For an input port all the above types are supported.
 
 For an output port only primitive types are supported.
 
+++ \@spl decorator options
+\@spl decorators support an number of options.
+
+* `style` - Parameter passing style.
+* `docpy` - Include Python code in operator model for SPLDOC.
+
+Options are passed as parameters to the decorators, for example:
+
+    # a,b,c will map to the first three attributes in the SPL tuple
+    # SPLDOC for f will not include the source code in its description
+    
+    \@spl.map(style='position', docpy=False)
+    def f(a, b, c):
+        pass
+
+**Note**: For backwards compatibility `\@spl.pipe` and `\@spl.sink`
+do **not** support these options, defaulting to *attributes by position*
+and not including Python code in the function.
+
+`\@spl.ignore` does not accept any options.
+
+# `style`
+Defines how the SPL tuple is passed into the decorated callable.
+
+Can be set to:
+
+* `'position'` - Pass using *attributes by position*.
+* `'name'` - Pass using *attributes by name*.
+
+Defaults to `None`, the passing style is defined by the callable's signature
+where possible, otherwise *attributes by name* will be used,
+equivalent to 'name'
+
+Passing style *dictionary* is selected by having a callable signature
+with a single `\*\*kwargs` parameter.
+
+Passing style *tuple* is selected by having a callable signature
+with a single `\*args` parameter.
+
+# `docpy`
+Include the Python callable source code in the operator model.
+
+Can be set to:
+
+* `True` - Include the source code in the operator model, the default.
+* `False` - Do not include the source code.
+
+The source code is then included in the operator description when creating
+SPLDOC for the toolkit using `spl-make-doc`.
+
 ++ \@spl.map
 Decorator to create a stateful or stateless SPL map operator from a Python callable class or function.
 
@@ -799,7 +849,7 @@ and its return value is used to submit zero or more tuples on the output port.
 
 # Examples
 
-TODO: Add more info about parameter passing.
+TODO: Add examples
  
 ++ \@spl.for_each
 Decorator to create a stateful or stateless SPL sink operator from a Python callable class or function.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -70,23 +70,23 @@ def _wrapforsplop(optype, wrapped, style, docpy):
     _op_fn.__splpy_docpy = docpy
     return _op_fn
 
-# define the SPL tuple passing style
+# define the SPL tuple passing style based
+# upon the function signature and the decorator
+# style parameter
 def _define_style(wrapped, fn, style):
-    seenSelf = False
-
     has_args = False
     has_kwargs = False
     has_positional = False
     req_named = False
      
-    pc = 0
     pmds = inspect.signature(fn).parameters
-    for pn in pmds:
-        # first argument to __init__ is self (instance ref)
-        if not seenSelf:
-            seenSelf = True
-            if inspect.isclass(wrapped):
-                continue
+    itpmds = iter(pmds)
+    # Skip self
+    if inspect.isclass(wrapped):
+        next(itpmds)
+
+    pc = 0
+    for pn in itpmds:
         pmd = pmds[pn]
         if pmd.kind == inspect.Parameter.POSITIONAL_ONLY:
             raise TypeError('Positional only parameters are not supported:' + pn)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -9,9 +9,6 @@ OperatorType = Enum('OperatorType', 'Ignore Source Sink Pipe')
 OperatorType.Pipe.spl_template = 'PythonFunctionPipe'
 OperatorType.Sink.spl_template = 'PythonFunctionSink'
 
-PassBy = Enum('PassBy', 'name position')
-
-
 def pipe(wrapped):
     """
     Create a SPL operator from a function.
@@ -30,13 +27,13 @@ def pipe(wrapped):
     if not inspect.isfunction(wrapped):
         raise TypeError('A function is required')
 
-    return _wrapforsplop(OperatorType.Pipe, wrapped, PassBy.position, False)
+    return _wrapforsplop(OperatorType.Pipe, wrapped, 'position', False)
 
 #
 # Wrap object for an SPL operator, either
 # a callable class or function.
 #
-def _wrapforsplop(optype, wrapped, attributes, docpy):
+def _wrapforsplop(optype, wrapped, style, docpy):
 
     if inspect.isclass(wrapped):
         if not callable(wrapped):
@@ -56,7 +53,7 @@ def _wrapforsplop(optype, wrapped, attributes, docpy):
         _op_class.__doc__ = wrapped.__doc__
         _op_class.__splpy_optype = optype
         _op_class.__splpy_callable = 'class'
-        _op_class.__splpy_attributes = attributes
+        _op_class.__splpy_style = _define_style(wrapped, wrapped.__call__, style)
         _op_class.__splpy_file = inspect.getsourcefile(wrapped)
         _op_class.__splpy_docpy = docpy
         return _op_class
@@ -68,10 +65,87 @@ def _wrapforsplop(optype, wrapped, attributes, docpy):
         return wrapped(*args, **kwargs)
     _op_fn.__splpy_optype = optype
     _op_fn.__splpy_callable = 'function'
-    _op_fn.__splpy_attributes = attributes
+    _op_fn.__splpy_style = _define_style(wrapped, wrapped, style)
     _op_fn.__splpy_file = inspect.getsourcefile(wrapped)
     _op_fn.__splpy_docpy = docpy
     return _op_fn
+
+# define the SPL tuple passing style
+def _define_style(wrapped, fn, style):
+    seenSelf = False
+
+    has_args = False
+    has_kwargs = False
+    has_positional = False
+    req_named = False
+     
+    pc = 0
+    pmds = inspect.signature(fn).parameters
+    for pn in pmds:
+        # first argument to __init__ is self (instance ref)
+        if not seenSelf:
+            seenSelf = True
+            if inspect.isclass(wrapped):
+                continue
+        pmd = pmds[pn]
+        if pmd.kind == inspect.Parameter.POSITIONAL_ONLY:
+            raise TypeError('Positional only parameters are not supported:' + pn)
+        elif pmd.kind == inspect.Parameter.VAR_POSITIONAL:
+            has_args = True
+        elif pmd.kind == inspect.Parameter.VAR_KEYWORD:
+            has_kwargs = True
+        elif pmd.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
+            has_positional = True
+        elif pmd.kind == inspect.Parameter.KEYWORD_ONLY:
+            if pmd.default is inspect.Parameter.empty:
+                req_named = True
+        pc +=1
+               
+    # See if the requested style matches the signature.
+    if style == 'position':
+        if req_named:
+             raise TypeError("style='position' not supported with a required named parameter.")
+        elif pc == 1 and has_kwargs:
+            raise TypeError("style='position' not supported with single **kwargs parameter.")
+        elif pc == 1 and has_args:
+            pass
+        elif not has_positional:
+            raise TypeError("style='position' not supported as no positional parameters exist.")
+        # From an implementation point of view the values
+        # are passed as a tuple and Python does the correct mapping
+        style = 'tuple'
+
+    elif style == 'name':
+        if pc == 1 and has_args:
+            raise TypeError("style='name' not supported with single *args parameter.")
+        elif pc == 1 and has_kwargs:
+            raise TypeError("style='name' not supported with single **kwargs parameter.")
+        # From an implementation point of view the values
+        # are passed as a dictionary and Python does the correct mapping
+        style = 'dictionary'
+
+    elif style is not None:
+        raise TypeError("style=" + style + " unknown.")
+
+    if style is None:
+        if has_kwargs:
+            style = 'dictionary'
+        elif pc == 1 and has_args:
+            style = 'tuple'
+        elif pc == 0:
+            style = 'tuple'
+        else:
+            # Default to by name
+            # From an implementation point of view the values
+            # are passed as a dictionary and Python does the correct mapping
+            style = 'dictionary'
+
+    if style == 'tuple' and has_kwargs:
+         raise TypeError("style='position' not yet implemented with **kwargs parameter.")
+
+    if style == 'dictionary':
+         raise TypeError("Not yet implemented!")
+    return style
 
 class map:
     """
@@ -81,15 +155,12 @@ class map:
     output port. For each tuple on the input port the
     function is called passing the contents of the tuple.
     """
-
-    def __init__(self, attributes=PassBy.name, docpy=True):
-        if attributes is not PassBy.position:
-            raise NotImplementedError(attributes)
-        self.attributes = attributes
+    def __init__(self, style=None, docpy=True):
+        self.style = style
         self.docpy = docpy
-
+    
     def __call__(self, wrapped):
-        return _wrapforsplop(OperatorType.Pipe, wrapped, self.attributes, self.docpy)
+        return _wrapforsplop(OperatorType.Pipe, wrapped, self.style, self.docpy)
 
 # Allows functions in any module in opt/python/streams to be explicitly ignored.
 def ignore(wrapped):
@@ -105,7 +176,7 @@ def sink(wrapped):
     if not inspect.isfunction(wrapped):
         raise TypeError('A function is required')
 
-    return _wrapforsplop(OperatorType.Sink, wrapped, PassBy.position, False)
+    return _wrapforsplop(OperatorType.Sink, wrapped, 'position', False)
 
 # Defines a function as a sink operator
 class for_each:
@@ -116,11 +187,9 @@ class for_each:
     For each tuple on the input port the
     class or function is called passing the contents of the tuple.
     """
-    def __init__(self, attributes=PassBy.name, docpy=True):
-        if attributes is not PassBy.position:
-            raise NotImplementedError(attributes)
-        self.attributes = attributes
+    def __init__(self, style=None, docpy=True):
+        self.style = style
         self.docpy = docpy
 
     def __call__(self, wrapped):
-        return _wrapforsplop(OperatorType.Sink, wrapped, self.attributes, self.docpy)
+        return _wrapforsplop(OperatorType.Sink, wrapped, self.style, self.docpy)

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe.xml
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe.xml
@@ -6,7 +6,9 @@
 <operatorModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ibm.com/xmlns/prod/streams/spl/operator" xmlns:cmn="http://www.ibm.com/xmlns/prod/streams/spl/common" xsi:schemaLocation="http://www.ibm.com/xmlns/prod/streams/spl/operator operatorModel.xsd">
   <cppOperatorModel>
     <context>
-      <description>__SPLPY__DESCRIPTION__SPLPY__</description>
+      <description>
+__SPLPY__DESCRIPTION__SPLPY__
+      </description>
       <iconUri size="16">../../opt/.__splpy/icons/python-powered16.gif</iconUri>
       <iconUri size="32">../../opt/.__splpy/icons/python-powered32.gif</iconUri>
       <metrics>
@@ -35,6 +37,9 @@
     </parameters>
     <inputPorts>
       <inputPortSet>
+        <description>
+__SPLPY__INPORT_0_DESCRIPTION__SPLPY__
+        </description>
         <tupleMutationAllowed>false</tupleMutationAllowed>
         <windowingMode>NonWindowed</windowingMode>
         <windowPunctuationInputMode>Oblivious</windowPunctuationInputMode>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -22,6 +22,7 @@
 
  my $module = splpy_Module();
  my $functionName = splpy_FunctionName();
+ my $paramStyle = splpy_ParamStyle();
  my $fixedParam = splpy_FixedParam();
  
  my $iport = $model->getInputPortAt(0);
@@ -32,6 +33,11 @@
  my $inputAttrs2Py = $iport->getNumberOfAttributes();
  if ($fixedParam != -1) {
     $inputAttrs2Py = $fixedParam;
+ }
+
+ if ($fixedParam > $iport->getNumberOfAttributes()) {
+   SPL::CodeGen::exitln('%s requires at least %i attributes in input port but schema is %s',
+           $model->getContext()->getKind(), $fixedParam, $iport->getSPLTupleType());
  }
  
   my $oport = $model->getOutputPortAt(0);
@@ -82,6 +88,9 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
    std::vector<OPort0Type> output_tuples;  
    {
     streamsx::topology::PyGILLock lock;
+<%
+    if ($paramStyle eq 'tuple') {
+%>
 
     PyObject * pyTuple = PyTuple_New(<%=$inputAttrs2Py%>); 
     PyObject *pyValue;
@@ -89,6 +98,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
      for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
          print convertToPythonValueAsTuple($ituple, $i, $itypes[$i], $inames[$i]);
      }
+    }
 %>
 
  @include  "../../opt/.__splpy/common/py_functionReturnToTuples.cgt"

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink.xml
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink.xml
@@ -6,7 +6,9 @@
 <operatorModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ibm.com/xmlns/prod/streams/spl/operator" xmlns:cmn="http://www.ibm.com/xmlns/prod/streams/spl/common" xsi:schemaLocation="http://www.ibm.com/xmlns/prod/streams/spl/operator operatorModel.xsd">
   <cppOperatorModel>
     <context>
-      <description>__SPLPY__DESCRIPTION__SPLPY__</description>
+      <description>
+__SPLPY__DESCRIPTION__SPLPY__
+      </description>
       <iconUri size="16">../../opt/.__splpy/icons/python-powered16.gif</iconUri>
       <iconUri size="32">../../opt/.__splpy/icons/python-powered32.gif</iconUri>
       <metrics>
@@ -35,6 +37,9 @@
     </parameters>
     <inputPorts>
       <inputPortSet>
+        <description>
+__SPLPY__INPORT_0__DESCRIPTION__SPLPY__
+        </description>
         <tupleMutationAllowed>false</tupleMutationAllowed>
         <windowingMode>NonWindowed</windowingMode>
         <windowPunctuationInputMode>Oblivious</windowPunctuationInputMode>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
@@ -22,6 +22,7 @@
 
  my $module = splpy_Module();
  my $functionName = splpy_FunctionName();
+ my $paramStyle = splpy_ParamStyle();
  my $fixedParam = splpy_FixedParam();
  
  my $iport = $model->getInputPortAt(0);
@@ -32,6 +33,10 @@
  my $inputAttrs2Py = $iport->getNumberOfAttributes();
  if ($fixedParam != -1) {
     $inputAttrs2Py = $fixedParam;
+ }
+ if ($fixedParam > $iport->getNumberOfAttributes()) {
+   SPL::CodeGen::exitln('%s requires at least %i attributes in input port but schema is %s',
+           $model->getContext()->getKind(), $fixedParam, $iport->getSPLTupleType());
  }
  
   my $ituple = $iport->getCppTupleName();
@@ -74,6 +79,9 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
    IPort0Type const & <%=$ituple%> = static_cast<IPort0Type const &>(tuple);
 
    streamsx::topology::PyGILLock lock;
+<%
+    if ($paramStyle eq 'tuple') {
+%>
    
     PyObject * pyTuple = PyTuple_New(<%=$inputAttrs2Py%>); 
     PyObject *pyValue;
@@ -81,6 +89,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
      for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
          print convertToPythonValueAsTuple($ituple, $i, $itypes[$i], $inames[$i]);
      }
+    }
 %>
   
     PyObject * pyReturnNone = PyObject_CallObject(function_, pyTuple);

--- a/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_mailsample.py
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_mailsample.py
@@ -25,7 +25,6 @@ def simplesendmail(from_addr, to_addrs, msg):
     "Send a simple email."
     server.sendmail(from_addr, to_addrs, msg)
 
-
 # Example of a function that is explicitly ignored by the SPL extractor (spl-extract.py)
 @spl.ignore
 def thisIsNotAnOperator(a):

--- a/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py
@@ -67,7 +67,7 @@ def splNamespace():
 #
 # See Test01.spl
 
-@spl.pipe
+@spl.map()
 def Noop(*tuple):
     "Pass the tuple along without any change."
     return tuple
@@ -81,7 +81,7 @@ def Noop(*tuple):
 # must the input schema plus one additional
 # numeric attribute as the last attribute.
 
-@spl.map(attributes=spl.PassBy.position)
+@spl.map()
 class AddSeq:
     "Add a sequence number as the last attribute."
     def __init__(self):
@@ -97,7 +97,7 @@ from datetime import datetime
 # Stateful sink operator that prints each tuple
 # with the inter-tuple arrival delay.
 #
-@spl.for_each(attributes=spl.PassBy.position)
+@spl.for_each
 class PrintWithTimeIntervals:
     "Print tuples with inter-tuple arrival delay."
     def __init__(self):

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonExtractTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonExtractTest.java
@@ -132,9 +132,15 @@ public class PythonExtractTest extends TestTopology {
     public static class TestGeneratedOpArtifacts implements Consumer<File> {
 
         private final String op;
+        private final boolean pm;
 
         public TestGeneratedOpArtifacts(String op) {
             this.op = op;
+            this.pm = false;
+        }
+        public TestGeneratedOpArtifacts(String op, boolean pm) {
+            this.op = op;
+            this.pm = pm;
         }
 
         @Override
@@ -150,6 +156,27 @@ public class PythonExtractTest extends TestTopology {
             assertTrue(opdir.isDirectory());
             assertTrue(opdir.exists());
             
+            File opFile = new File(opdir, op + ".xml");
+            assertTrue(opFile.toString(), opFile.isFile());
+            assertTrue(opFile.toString(), opFile.exists());
+            
+            opFile = new File(opdir, op + "_cpp.cgt");
+            assertTrue(opFile.toString(), opFile.isFile());
+            assertTrue(opFile.toString(), opFile.exists());
+
+            opFile = new File(opdir, op + "_h.cgt");
+            assertTrue(opFile.toString(), opFile.isFile());
+            assertTrue(opFile.toString(), opFile.exists());
+
+            if (pm) {
+                opFile = new File(opdir, op + "_cpp.pm");
+                assertTrue(opFile.toString(), opFile.isFile());
+                assertTrue(opFile.toString(), opFile.exists());
+
+                opFile = new File(opdir, op + "_h.pm");
+                assertTrue(opFile.toString(), opFile.isFile());
+                assertTrue(opFile.toString(), opFile.exists());
+            }
             
         }
 
@@ -171,7 +198,7 @@ public class PythonExtractTest extends TestTopology {
                 "def f2(*tuple):\n",
                 "  pass\n"
         };
-        _testToolkit(Arrays.asList(code), true, new TestGeneratedOpArtifacts("f2"));
+        _testToolkit(Arrays.asList(code), true, new TestGeneratedOpArtifacts("f2", true));
     }
     
     

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonExtractTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonExtractTest.java
@@ -1,0 +1,187 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.test.splpy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import com.ibm.streamsx.topology.internal.process.ProcessOutputToLogger;
+import com.ibm.streamsx.topology.test.TestTopology;
+
+public class PythonExtractTest extends TestTopology {
+    
+    static Logger trace = Logger.getLogger(PythonExtractTest.class.getName());
+    
+    public static int extract(File tkDir, boolean tkMake) throws Exception {
+        
+        String topoTk = System.getProperty("topology.toolkit.release");
+        String streams = System.getProperty("topology.install.compile");
+        
+        File expy = new File(topoTk, "bin/spl-python-extract.py");
+
+        List<String> commands = new ArrayList<String>();
+
+        commands.add("python3");
+        commands.add(expy.getAbsolutePath());
+        commands.add("--directory");
+        commands.add(tkDir.getAbsolutePath());
+        if (tkMake)
+            commands.add("--make-toolkit");
+
+        ProcessBuilder pb = new ProcessBuilder(commands);
+               
+        // Set STREAMS_INSTALL in case it was overriden for compilation
+        pb.environment().put("STREAMS_INSTALL", streams);
+
+        Process exProcess = pb.start();
+        ProcessOutputToLogger.log(trace, exProcess);
+        exProcess.getOutputStream().close();
+        int rc = exProcess.waitFor();
+        trace.info("spl-python-extract.py complete: return code=" + rc);
+               
+        return rc;
+    }
+    
+    
+    public static File createPyTk(String namespace, List<String> pythonCode) throws Exception {
+        File tkdir = Files.createTempDirectory("testpyex").toFile();
+
+        File pystreams = new File(tkdir, "opt/python/streams");
+        pystreams.mkdirs();
+        if (namespace != null || pythonCode != null) {
+            Path python = Files.createTempFile(pystreams.toPath(), "tpx", ".py");
+            Files.write(python, Collections.singletonList("from streamsx.spl import spl\n"), StandardCharsets.UTF_8);
+            if (namespace != null) {
+                List<String> nsfn = new ArrayList<>();
+                nsfn.add("def splNamespace():");
+                nsfn.add("  return '" + namespace + "'\n");
+                Files.write(python, nsfn, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+            }
+            
+            if (pythonCode != null)
+                Files.write(python, pythonCode, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+        }
+
+        return tkdir;
+    }
+    
+    @Test
+    public void testEmptyToolkit() throws Exception {
+        _testEmptyToolkit(false);
+    }
+    @Test
+    public void testEmptyToolkitMake() throws Exception {
+        _testEmptyToolkit(true);
+    }
+    
+    private void _testEmptyToolkit(boolean make) throws Exception {
+        
+        File tkdir = Files.createTempDirectory("testpyex").toFile();
+        try {
+             assertEquals(0, extract(tkdir, make)); 
+        } finally {
+            tkdir.delete();
+        }
+    }
+
+    @Test
+    public void testEmptyToolkitDir() throws Exception {
+        _testEmptyToolkitWithDir(false);
+    }
+    @Test
+    public void testEmptyToolkitDirMake() throws Exception {
+        _testEmptyToolkitWithDir(true);
+    }
+    
+    static final String NS = "testpy.extract";
+    
+    private void _testEmptyToolkitWithDir(boolean make) throws Exception {        
+        File tkdir = createPyTk(null, null);
+        try {
+             assertEquals(0, extract(tkdir, make)); 
+        } finally {
+            tkdir.delete();
+        }
+    }
+    
+    @Test
+    public void testEmptyPython() throws Exception {
+        _testToolkit(Collections.emptyList(), false, tkdir->{});
+    }
+    @Test
+    public void testEmptyPythonMake() throws Exception {
+        _testToolkit(Collections.emptyList(), true, tkdir->{});
+    }
+    
+    public static class TestGeneratedOpArtifacts implements Consumer<File> {
+
+        private final String op;
+
+        public TestGeneratedOpArtifacts(String op) {
+            this.op = op;
+        }
+
+        @Override
+        public void accept(File tkdir) {
+            assertTrue(tkdir.isDirectory());
+            assertTrue(tkdir.exists());
+            
+            File nsdir = new File(tkdir, NS);
+            assertTrue(nsdir.isDirectory());
+            assertTrue(nsdir.exists());
+            
+            File opdir = new File(nsdir, op);
+            assertTrue(opdir.isDirectory());
+            assertTrue(opdir.exists());
+            
+            
+        }
+
+    }
+    
+    @Test
+    public void testPythonMap() throws Exception {
+        String[] code = {
+                "@spl.map()\n",
+                "def f1(*tuple):\n",
+                "  pass\n"
+        };
+        _testToolkit(Arrays.asList(code), false, new TestGeneratedOpArtifacts("f1"));
+    }
+    @Test
+    public void testPythonMapMake() throws Exception {
+        String[] code = {
+                "@spl.map()\n",
+                "def f2(*tuple):\n",
+                "  pass\n"
+        };
+        _testToolkit(Arrays.asList(code), true, new TestGeneratedOpArtifacts("f2"));
+    }
+    
+    
+    public static void _testToolkit(List<String> lines, boolean make, Consumer<File> tester) throws Exception {        
+        File tkdir = createPyTk(NS, lines);
+        try {
+             assertEquals(0, extract(tkdir, make)); 
+             tester.accept(tkdir);
+        } finally {
+            tkdir.delete();
+        }
+    }
+}

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonInvalidFunctionalOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonInvalidFunctionalOperatorsTest.java
@@ -1,0 +1,50 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.test.splpy;
+
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.ibm.streamsx.topology.test.TestTopology;
+
+public class PythonInvalidFunctionalOperatorsTest extends TestTopology {
+    
+    @Test
+    public void testInvalidStyle() throws Exception {
+        String[] code = {
+                "@spl.map(style='fred')\n",
+                "def f2(*tuple):\n",
+                "  pass\n"
+        };
+        _testInvalidToolkit(Arrays.asList(code));
+    }
+    @Test
+    public void testMismatchedStyle1() throws Exception {
+        String[] code = {
+                "@spl.map(style='name')\n",
+                "def f2(*tuple):\n",
+                "  pass\n"
+        };
+        _testInvalidToolkit(Arrays.asList(code));
+    }
+    
+    public static void _testInvalidToolkit(String[] code) throws Exception {        
+        _testInvalidToolkit(Arrays.asList(code));
+    }    
+    
+    public static void _testInvalidToolkit(List<String> code) throws Exception {        
+        File tkdir = PythonExtractTest.createPyTk(PythonExtractTest.NS, code);
+        try {
+             assertFalse(PythonExtractTest.extract(tkdir, false) == 0); 
+        } finally {
+            tkdir.delete();
+        }
+    }
+}

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonInvalidFunctionalOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonInvalidFunctionalOperatorsTest.java
@@ -20,7 +20,7 @@ public class PythonInvalidFunctionalOperatorsTest extends TestTopology {
     public void testInvalidStyle() throws Exception {
         String[] code = {
                 "@spl.map(style='fred')\n",
-                "def f2(*tuple):\n",
+                "def inv1(*tuple):\n",
                 "  pass\n"
         };
         _testInvalidToolkit(Arrays.asList(code));
@@ -29,7 +29,16 @@ public class PythonInvalidFunctionalOperatorsTest extends TestTopology {
     public void testMismatchedStyle1() throws Exception {
         String[] code = {
                 "@spl.map(style='name')\n",
-                "def f2(*tuple):\n",
+                "def inv2(*tuple):\n",
+                "  pass\n"
+        };
+        _testInvalidToolkit(Arrays.asList(code));
+    }
+    @Test
+    public void testKwargsAndPositional() throws Exception {
+        String[] code = {
+                "@spl.map(style='positional')\n",
+                "def inv3(a,b,c,**tuple):\n",
                 "  pass\n"
         };
         _testInvalidToolkit(Arrays.asList(code));

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonInvalidFunctionalOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonInvalidFunctionalOperatorsTest.java
@@ -43,6 +43,15 @@ public class PythonInvalidFunctionalOperatorsTest extends TestTopology {
         };
         _testInvalidToolkit(Arrays.asList(code));
     }
+    @Test
+    public void testPositionalWithKeywordOnly() throws Exception {
+        String[] code = {
+                "@spl.map(style='positional')\n",
+                "def inv4(a,b,c,**tuple,d):\n",
+                "  pass\n"
+        };
+        _testInvalidToolkit(Arrays.asList(code));
+    }
     
     public static void _testInvalidToolkit(String[] code) throws Exception {        
         _testInvalidToolkit(Arrays.asList(code));


### PR DESCRIPTION
Documents the expected behaviour for passing SPL tuples into operators including by name and dictionary (though not yet supported).

Cleanup the parameter passing style code in anticipation of supporting name and dictionary.

Add some testing for the extract process.