### PR TITLE
Consistent region support API

### DIFF
--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1095,12 +1095,20 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
     TStream<T> autonomous();
     
     /**
-     * Set the source operator for this stream to be the start of a consistent region.
+     * Set the source operator for this stream to be the start of a
+     * consistent region to support at least once and exactly once
+     * processing.
      * IBM Streams calculates the boundaries of the consistent region
      * that is based on the reachability graph of this stream.
      * 
+     * <P>
+     * Consistent regions are only supported in distributed contexts.
+     * </P>
+
      * @since v1.5
      * @return this
+     * 
+     * @see com.ibm.streamsx.topology.consistent
      */
     TStream<T> setConsistent(ConsistentRegionConfig config);
     

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import com.ibm.streamsx.topology.builder.BInputPort;
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.builder.BOutput;
+import com.ibm.streamsx.topology.consistent.ConsistentRegionConfig;
 import com.ibm.streamsx.topology.context.Placeable;
 import com.ibm.streamsx.topology.function.BiFunction;
 import com.ibm.streamsx.topology.function.Consumer;
@@ -1092,6 +1093,16 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * @since v1.5
      */
     TStream<T> autonomous();
+    
+    /**
+     * Set the source operator for this stream to be the start of a consistent region.
+     * IBM Streams calculates the boundaries of the consistent region
+     * that is based on the reachability graph of this stream.
+     * 
+     * @since v1.5
+     * @return this
+     */
+    TStream<T> setConsistent(ConsistentRegionConfig config);
     
     /**
      * Internal method.

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1108,7 +1108,7 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * @since v1.5
      * @return this
      * 
-     * @see com.ibm.streamsx.topology.consistent
+     * @see com.ibm.streamsx.topology.consistent.ConsistentRegionConfig
      */
     TStream<T> setConsistent(ConsistentRegionConfig config);
     

--- a/java/src/com/ibm/streamsx/topology/Topology.java
+++ b/java/src/com/ibm/streamsx/topology/Topology.java
@@ -724,7 +724,7 @@ public class Topology implements TopologyElement {
      * Otherwise the function object is taken as immutable.
      * </P>
      * <P>
-     * Checkpointing is only supported is distributed contexts.
+     * Checkpointing is only supported in distributed contexts.
      * </P>
      * 
      * @param period Approximate period for checkpointing.

--- a/java/src/com/ibm/streamsx/topology/consistent/ConsistentRegionConfig.java
+++ b/java/src/com/ibm/streamsx/topology/consistent/ConsistentRegionConfig.java
@@ -6,6 +6,7 @@ package com.ibm.streamsx.topology.consistent;
 
 import java.util.concurrent.TimeUnit;
 
+import com.ibm.streams.domain.aas.model.AuthorizationT.Objects;
 import com.ibm.streamsx.topology.TStream;
 
 /**
@@ -267,5 +268,34 @@ public final class ConsistentRegionConfig {
             throw new IllegalArgumentException("maxConsecutiveResetAttempts must be greater than zero:" + attempts);
 
         return new ConsistentRegionConfig(this, null, null, attempts);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(trigger, period, drain, reset, attempts);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ConsistentRegionConfig other = (ConsistentRegionConfig) obj;
+        if (attempts != other.attempts)
+            return false;
+        if (drain != other.drain)
+            return false;
+        if (period != other.period)
+            return false;
+        if (reset != other.reset)
+            return false;
+        if (trigger != other.trigger)
+            return false;
+        if (unit != other.unit)
+            return false;
+        return true;
     }
 }

--- a/java/src/com/ibm/streamsx/topology/consistent/ConsistentRegionConfig.java
+++ b/java/src/com/ibm/streamsx/topology/consistent/ConsistentRegionConfig.java
@@ -9,7 +9,44 @@ import java.util.concurrent.TimeUnit;
 import com.ibm.streamsx.topology.TStream;
 
 /**
- * Consistent region configuration.
+ * Immutable consistent region configuration.
+ * 
+ * The default values for a {@code ConsistentRegionConfig} are:
+ * <UL>
+ * <LI><b>{@code drainTimeout}</b> - 180 seconds - Indicates the maximum time in
+ * seconds that the drain and checkpoint of the region is allotted to finish
+ * processing. If the process takes longer than the specified time, a failure is
+ * reported and the region is reset to the point of the previously successfully
+ * established consistent state.</LI>
+ * <LI><b>{@code resetTimeout}</b> - 180 seconds - Indicates the maximum time in
+ * seconds that the reset of the region is allotted to finish processing. If the
+ * process takes longer than the specified time, a failure is reported and
+ * another reset of the region is attempted</LI>
+ * <LI>
+ * <b>{@code maxConsecutiveResetAttempts}</b> - 5 - Indicates the maximum
+ * number of consecutive attempts to reset a consistent region. After a failure,
+ * if the maximum number of attempts is reached, the region stops processing new
+ * tuples. After the maximum number of consecutive attempts is reached, a region
+ * can be reset only with manual intervention or with a program with a call to a
+ * method in the consistent region controller.
+ * </LI>
+ * </UL>
+ * <P>
+ * A configuration has {@link #getTimeUnit() time unit} that applies to
+ * {@link #getPeriod()}, {@link #getDrainTimeout()} and {@link #getResetTimeout()}.
+ * The time unit is hard-coded to {@code TimeUnit.SECONDS}, future versions may
+ * allow creating configurations with a different time unit. 
+ * </P>
+ * <P>
+ * <b>Example Use:</b>
+ * <pre>
+ * <code>
+ * // set source to be a the start of a operator driven consistent region
+ * // with a drain timeout of five seconds and a reset timeout of twenty seconds.
+ * source.setConsistent(operatorDriven().drainTimeout(5).resetTimeout(20));
+ * <code>
+ * </pre>
+ * </P>
  * 
  * @see TStream#setConsistent(ConsistentRegionConfig)
  */
@@ -34,63 +71,201 @@ public final class ConsistentRegionConfig {
     private final Trigger trigger;
     private final TimeUnit unit = TimeUnit.SECONDS;
     private final long period ;
-    private long drain = 180;
-    private long reset = 180;
-    private int attempts = 5;
+    private final long drain;
+    private final long reset;
+    private final int attempts;
+    
+    private ConsistentRegionConfig(ConsistentRegionConfig old, Long drain, Long reset, Integer attempts) {
+        this.trigger = old.trigger;
+        this.period = old.period;
+        this.drain = drain == null ? old.drain : drain;
+        this.reset = reset == null ? old.reset : reset;
+        this.attempts = attempts == null ? old.attempts : attempts;       
+    }
+    
+    private ConsistentRegionConfig(Trigger trigger, long period) {
+        this.trigger = trigger;
+        this.period = period;
+        this.drain = 180;
+        this.reset = 180;
+        this.attempts = 5;       
+    }
 
     /**
      * Create a {@link Trigger#OPERATOR_DRIVEN} consistent region configuration.
+     * The source operator drives when a region is drained and checkpointed,
+     * for example a messaging source might drain and checkpoint every ten thousand
+     * messages.
+     * <BR>
      * Configuration values are set to the default values.
      */
     public ConsistentRegionConfig() {
-        this.trigger = Trigger.OPERATOR_DRIVEN;
-        this.period = -1;
+        this(Trigger.OPERATOR_DRIVEN, -1);
+    }
+    
+    /**
+     * Create a {@link Trigger#PERIODIC} consistent region configuration.
+     * The IBM Streams runtime will trigger a drain and checkpoint
+     * the region periodically approximately every {@code period} seconds.
+     * <BR>
+     * Configuration values are set to the default values.
+     * <P>
+     * This is equivalent to {@link #ConsistentRegionConfig()}
+     * but when used as an imported static method can produce clearer code:
+     * <BR>
+     * <pre>
+     * <code>
+     * import static com.ibm.streamsx.topology.consistent.ConsistentRegionConfig.operatorDriven;
+     * ...
+     *     stream.setConsistent(operatorDriven());
+     * </code>
+     * </pre>
+     * </P>
+     * @param period Trigger period in seconds.
+     */
+    public static ConsistentRegionConfig operatorDriven() {
+        return new ConsistentRegionConfig();
+    }
+    
+    /**
+     * Create a {@link Trigger#PERIODIC} consistent region configuration.
+     * The IBM Streams runtime will trigger a drain and checkpoint
+     * the region periodically approximately every {@code period} seconds.
+     * <BR>
+     * Configuration values are set to the default values.
+     * <P>
+     * This is equivalent to {@link #ConsistentRegionConfig(int)}
+     * but when used as an imported static method can produce clearer code:
+     * <BR>
+     * <pre>
+     * <code>
+     * import static com.ibm.streamsx.topology.consistent.ConsistentRegionConfig.periodic;
+     * ...
+     *     stream.setConsistent(periodic(30));
+     * </code>
+     * </pre>
+     * </P>
+     * @param period Trigger period in seconds.
+     */
+    public static ConsistentRegionConfig periodic(int period) {
+        return new ConsistentRegionConfig(period);
     }
 
     /**
      * Create a {@link Trigger#PERIODIC} consistent region configuration.
+     * The IBM Streams runtime will trigger a drain and checkpoint
+     * the region periodically approximately every {@code period} seconds.
+     * <BR>
      * Configuration values are set to the default values.
      * @param period Trigger period in seconds.
      */
-    public ConsistentRegionConfig(long period) {
-        super();
-        this.trigger = Trigger.PERIODIC;
-        this.period = period;
+    public ConsistentRegionConfig(int period) {
+        this(Trigger.PERIODIC, period);
+        if (period <= 0)
+            throw new IllegalArgumentException("period must be greater than zero:" + period); 
     }
 
+    /**
+     * Get the trigger type.
+     * @return trigger type.
+     */
     public Trigger getTrigger() {
         return trigger;
     }
 
+    /**
+     * Get the trigger period.
+     * @return period if {@link #getTrigger()} is {@link Trigger#PERIODIC} otherwise -1.
+     */
     public long getPeriod() {
         return period;
     }
 
+    /**
+     * Get the time unit for {@line #getPeriod()}, {@link #getDrainTimeout()}
+     * and {@link #getResetTimeout()()}.
+     * @return Time unit for this configuration.
+     */
     public TimeUnit getTimeUnit() {
         return unit;
     }
     
+    /**
+     * Get the drain timeout for this configuration.
+     * @return Drain timeout in units of {@link #getTimeUnit()}.
+     */
     public long getDrainTimeout() {
         return drain;
     }
-    ConsistentRegionConfig setDrainTimeout(long drainTimeout) {
-        this.drain = drainTimeout;
-        return this;
+    
+    /**
+     * Return a new configuration changing {@code drainTimeout}.
+     * A new configuration instance is returned that is a copy
+     * of this configuration with only {@code drainTimeout} changed.
+     * <P>
+     * {@code stream.setConsistent(periodic(30).drainTimeout(5))}
+     * </P>
+     * @param drainTimeout Drain timeout to use in seconds, must be greater than 0.
+     * @return New configuration with drain timeout set to {@code drainTimeout}
+     * and the remaining values copied from this configuration.
+     */
+    public ConsistentRegionConfig drainTimeout(long drainTimeout) {
+        if (drainTimeout <= 0)
+            throw new IllegalArgumentException("drainTimeout must be greater than zero:" + drainTimeout);
+            
+        return new ConsistentRegionConfig(this, drainTimeout, null, null);
     }
-
+    
+    /**
+     * Get the reset timeout for this configuration.
+     * @return Reset timeout in units of {@link #getTimeUnit()}.
+     */
     public long getResetTimeout() {
         return reset;
     }
-    ConsistentRegionConfig setResetTimeout(long resetTimeout) {
-        this.reset = resetTimeout;
-        return this;
-    }
+    
+    /**
+     * Return a new configuration changing {@code resetTimeout}.
+     * A new configuration instance is returned that is a copy
+     * of this configuration with only {@code resetTimeout} changed.
+     * <P>
+     * {@code stream.setConsistent(periodic(30).resetTimeout(15))}
+     * </P>
+     * @param resetTimeout Reset timeout to use in seconds, must be greater than 0.
+     * @return New configuration with reset timeout set to {@code resetTimeout}
+     * and the remaining values copied from this configuration.
+     */
+    public ConsistentRegionConfig resetTimeout(long resetTimeout) {
+        if (resetTimeout <= 0)
+            throw new IllegalArgumentException("resetTimeout must be greater than zero:" + resetTimeout);
 
+        return new ConsistentRegionConfig(this, null, resetTimeout, null);
+    }
+    
+
+    /**
+     * Get the maximum number of consecutive reset attempts.
+     * @return Maximum number of consecutive reset attempts.
+     */
     public int getMaxConsecutiveResetAttempts() {
         return attempts;
     }
-    ConsistentRegionConfig setMaxConsecutiveResetAttempts(int attempts) {
-        this.attempts = attempts;
-        return this;
+    
+    /**
+     * Return a new configuration changing {@code maxConsecutiveResetAttempts}.
+     * A new configuration instance is returned that is a copy
+     * of this configuration with only {@code maxConsecutiveResetAttempts} changed.
+     * <P>
+     * {@code stream.setConsistent(periodic(30).maxConsecutiveResetAttempts(7))}
+     * </P>
+     * @param maxConsecutiveResetAttempts Reset timeout to use in seconds, must be greater than 0.
+     * @return New configuration with reset timeout set to {@code maxConsecutiveResetAttempts}
+     * and the remaining values copied from this configuration.
+     */
+    public ConsistentRegionConfig maxConsecutiveResetAttempts(int attempts) {
+        if (attempts <= 0)
+            throw new IllegalArgumentException("maxConsecutiveResetAttempts must be greater than zero:" + attempts);
+
+        return new ConsistentRegionConfig(this, null, null, attempts);
     }
 }

--- a/java/src/com/ibm/streamsx/topology/consistent/ConsistentRegionConfig.java
+++ b/java/src/com/ibm/streamsx/topology/consistent/ConsistentRegionConfig.java
@@ -6,7 +6,6 @@ package com.ibm.streamsx.topology.consistent;
 
 import java.util.concurrent.TimeUnit;
 
-import com.ibm.streams.domain.aas.model.AuthorizationT.Objects;
 import com.ibm.streamsx.topology.TStream;
 
 /**
@@ -105,9 +104,8 @@ public final class ConsistentRegionConfig {
     }
     
     /**
-     * Create a {@link Trigger#PERIODIC} consistent region configuration.
-     * The IBM Streams runtime will trigger a drain and checkpoint
-     * the region periodically approximately every {@code period} seconds.
+     * Create a {@link Trigger#OPERATOR_DRIVEN} consistent region configuration.
+     * The source operator triggers drain and checkpoint cycles for the region.
      * <BR>
      * Configuration values are set to the default values.
      * <P>
@@ -122,7 +120,6 @@ public final class ConsistentRegionConfig {
      * </code>
      * </pre>
      * </P>
-     * @param period Trigger period in seconds.
      */
     public static ConsistentRegionConfig operatorDriven() {
         return new ConsistentRegionConfig();
@@ -183,7 +180,7 @@ public final class ConsistentRegionConfig {
     }
 
     /**
-     * Get the time unit for {@line #getPeriod()}, {@link #getDrainTimeout()}
+     * Get the time unit for {@link #getPeriod()}, {@link #getDrainTimeout()}
      * and {@link #getResetTimeout()()}.
      * @return Time unit for this configuration.
      */
@@ -259,8 +256,8 @@ public final class ConsistentRegionConfig {
      * <P>
      * {@code stream.setConsistent(periodic(30).maxConsecutiveResetAttempts(7))}
      * </P>
-     * @param maxConsecutiveResetAttempts Reset timeout to use in seconds, must be greater than 0.
-     * @return New configuration with reset timeout set to {@code maxConsecutiveResetAttempts}
+     * @param attempts Maximum number of consecutive reset attempts, must be greater than 0.
+     * @return New configuration with maxConsecutiveResetAttempts set to {@code attempts}
      * and the remaining values copied from this configuration.
      */
     public ConsistentRegionConfig maxConsecutiveResetAttempts(int attempts) {

--- a/java/src/com/ibm/streamsx/topology/consistent/ConsistentRegionConfig.java
+++ b/java/src/com/ibm/streamsx/topology/consistent/ConsistentRegionConfig.java
@@ -1,0 +1,96 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016 
+ */
+package com.ibm.streamsx.topology.consistent;
+
+import java.util.concurrent.TimeUnit;
+
+import com.ibm.streamsx.topology.TStream;
+
+/**
+ * Consistent region configuration.
+ * 
+ * @see TStream#setConsistent(ConsistentRegionConfig)
+ */
+public final class ConsistentRegionConfig {
+
+    /**
+     * Defines how the drain-checkpoint cycle of a consistent region is triggered.
+     */
+    public enum Trigger {
+        /**
+         * Region is triggered by the start operator.
+         */
+        OPERATOR_DRIVEN,
+        
+        /**
+         * Region is triggered periodically.
+         */
+        PERIODIC,
+        ;
+    }
+
+    private final Trigger trigger;
+    private final TimeUnit unit = TimeUnit.SECONDS;
+    private final long period ;
+    private long drain = 180;
+    private long reset = 180;
+    private int attempts = 5;
+
+    /**
+     * Create a {@link Trigger#OPERATOR_DRIVEN} consistent region configuration.
+     * Configuration values are set to the default values.
+     */
+    public ConsistentRegionConfig() {
+        this.trigger = Trigger.OPERATOR_DRIVEN;
+        this.period = -1;
+    }
+
+    /**
+     * Create a {@link Trigger#PERIODIC} consistent region configuration.
+     * Configuration values are set to the default values.
+     * @param period Trigger period in seconds.
+     */
+    public ConsistentRegionConfig(long period) {
+        super();
+        this.trigger = Trigger.PERIODIC;
+        this.period = period;
+    }
+
+    public Trigger getTrigger() {
+        return trigger;
+    }
+
+    public long getPeriod() {
+        return period;
+    }
+
+    public TimeUnit getTimeUnit() {
+        return unit;
+    }
+    
+    public long getDrainTimeout() {
+        return drain;
+    }
+    ConsistentRegionConfig setDrainTimeout(long drainTimeout) {
+        this.drain = drainTimeout;
+        return this;
+    }
+
+    public long getResetTimeout() {
+        return reset;
+    }
+    ConsistentRegionConfig setResetTimeout(long resetTimeout) {
+        this.reset = resetTimeout;
+        return this;
+    }
+
+    public int getMaxConsecutiveResetAttempts() {
+        return attempts;
+    }
+    ConsistentRegionConfig setMaxConsecutiveResetAttempts(int attempts) {
+        this.attempts = attempts;
+        return this;
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/consistent/package-info.java
+++ b/java/src/com/ibm/streamsx/topology/consistent/package-info.java
@@ -1,0 +1,88 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016 
+ */
+/**
+ * At least once processing using consistent regions.
+ * 
+ * <H2>Consistent regions</H2>
+ * 
+ * <H3>Overview</H3>
+ * 
+ * Because of business requirements, some applications require that all tuples
+ * in an application are processed at least once. You can use a consistent
+ * region in your streams processing applications to avoid data loss due to
+ * software or hardware failure and meet your requirements for at-least-once
+ * processing.
+ * <P>
+ * A consistent region is a subgraph where the states region (the operators
+ * and transformations within it) become
+ * consistent by processing all the tuples within defined
+ * points on a stream. This enables tuples within the subgraph to be processed
+ * at least once. The consistent region is periodically drained of its current
+ * tuples. All tuples in the consistent region are processed through to the end
+ * of the subgraph. In-memory state of operators are automatically serialized
+ * and stored on checkpoint for each of the operators in the region.
+ * </P>
+ * <P>
+ * If any element in a consistent region fails at run time, IBM Streams detects
+ * the failure and triggers the restart of the element and the reset of the
+ * region. In-memory state of the region is automatically reloaded to
+ * a consistent point.
+ * </P>
+ * <P>
+ * The capability to drain the subgraph, which is coupled with start operators
+ * that can replay their output streams, enables a consistent region to achieve
+ * at-least-once processing.
+ * </P>
+ * <P>
+ * A stream processing application can be defined with zero, one, or more
+ * consistent regions. You can define the start of a consistent region with
+ * the {@link com.ibm.streamsx.topology.TStream#setConsistent(ConsistentRegionConfig) setConsistent()}.}.
+ * IBM Streams then determines
+ * the scope of the consistent region automatically, but you can reduce the
+ * scope of the region with {@link com.ibm.streamsx.topology.TStream#autonomous()}.
+ * </P>
+ * <P>
+ * When a subgraph is a consistent region, IBM Streams enables the
+ * operators in that region to drain and reset. When a region is draining, it
+ * establishes logical divisions in the output streams of each operator in the
+ * region. A drain is successful when all operators in the region establish a
+ * logical division in their output streams, and when all tuples before the
+ * logical division are processed in their input streams. If a drain is
+ * successful, it means that all operators in the region consumed all input
+ * streams up until the established logical division. While the region is
+ * draining or resetting, operators in the region that completed their draining
+ * or resetting cannot submit new tuples. This behavior means that the tuple
+ * flow within the subgraph briefly stops while the region is draining or resetting.
+ * </P>
+* 
+ * <H3>Start of a consistent region</H3>
+ * A consistent region is started by
+ * {@link com.ibm.streamsx.topology.TStream#setConsistent(ConsistentRegionConfig)}.
+ * The source operator for the {@code TStream} must support logic that,
+ * after a failure in the region, can replay tuples since the last checkpoint.
+ * Typically the stream is a source stream that produces tuple from an external system
+ * like Apache Kakfa.
+ * <P>
+ * The logic that produces a replayable stream must be implemented
+ * using IBM Streams Java or C++ primitive operator apis.
+ * <BR>
+ * A functional source
+ * (e.g. {@link com.ibm.streamsx.topology.Topology#source(com.ibm.streamsx.topology.function.Supplier)})
+ * cannot be used as the start of a consistent region,
+ * thus the stream must be from an invocation of an SPL operator through
+ * {@link com.ibm.streamsx.topology.spl.SPL}, 
+ * {@link com.ibm.streamsx.topology.spl.JavaPrimitive}.
+ * Such an invocation may be wrapped by a Java method that provides
+ * a simplified version of the invocation for application developers.
+ * </P>
+ * <H3>Autonomous regions</H3>
+ * By default processing occurs in an autonomous region where
+ * operator checkpointing and recovery from failure is
+ * independent of other operators. A consistent region can be
+ * ended by starting an autonomous region using
+ * {@link com.ibm.streamsx.topology.TStream#autonomous()}.
+ 
+ */
+package com.ibm.streamsx.topology.consistent;

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -30,6 +30,7 @@ import com.ibm.streamsx.topology.builder.BOutput;
 import com.ibm.streamsx.topology.builder.BOutputPort;
 import com.ibm.streamsx.topology.builder.BUnionOutput;
 import com.ibm.streamsx.topology.builder.BVirtualMarker;
+import com.ibm.streamsx.topology.consistent.ConsistentRegionConfig;
 import com.ibm.streamsx.topology.context.Placeable;
 import com.ibm.streamsx.topology.function.BiFunction;
 import com.ibm.streamsx.topology.function.Consumer;
@@ -582,6 +583,13 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     public TStream<T> autonomous() {
         BOutput autonomousOutput = builder().autonomous(output()); 
         return addMatchingStream(autonomousOutput);
+    }
+    
+    @Override
+    public TStream<T> setConsistent(ConsistentRegionConfig config) {
+        //BOperatorInvocation op = operator();
+        throw new UnsupportedOperationException("WIP");
+        //return this;
     }
     
     @Override

--- a/java/src/com/ibm/streamsx/topology/spl/SPLStream.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLStream.java
@@ -10,6 +10,7 @@ import com.ibm.json.java.JSONObject;
 import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.consistent.ConsistentRegionConfig;
 import com.ibm.streamsx.topology.function.Function;
 import com.ibm.streamsx.topology.function.Predicate;
 import com.ibm.streamsx.topology.function.Supplier;
@@ -161,4 +162,10 @@ public interface SPLStream extends TStream<Tuple>, SPLInput {
      */
     @Override
     SPLStream autonomous();
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SPLStream setConsistent(ConsistentRegionConfig config);
 }

--- a/java/src/com/ibm/streamsx/topology/spl/SPLStreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLStreamImpl.java
@@ -18,6 +18,7 @@ import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.TopologyElement;
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.builder.BOutput;
+import com.ibm.streamsx.topology.consistent.ConsistentRegionConfig;
 import com.ibm.streamsx.topology.function.Function;
 import com.ibm.streamsx.topology.function.Predicate;
 import com.ibm.streamsx.topology.function.Supplier;
@@ -124,6 +125,11 @@ class SPLStreamImpl extends StreamImpl<Tuple> implements SPLStream {
     @Override
     public SPLStream autonomous() {
     	return asSPL(super.autonomous());
+    }
+    @Override
+    public SPLStream setConsistent(ConsistentRegionConfig config) {
+        super.setConsistent(config);
+        return this;
     }
        
     private SPLStream asSPL(TStream<Tuple> tupleStream) {

--- a/test/java/src/com/ibm/streamsx/topology/test/consistent/ConsistentRegionConfigTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/consistent/ConsistentRegionConfigTest.java
@@ -1,0 +1,142 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016  
+ */
+package com.ibm.streamsx.topology.test.consistent;
+
+
+import static com.ibm.streamsx.topology.consistent.ConsistentRegionConfig.operatorDriven;
+import static com.ibm.streamsx.topology.consistent.ConsistentRegionConfig.periodic;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.ibm.streamsx.topology.consistent.ConsistentRegionConfig;
+import com.ibm.streamsx.topology.consistent.ConsistentRegionConfig.Trigger;
+import com.ibm.streamsx.topology.test.TestTopology;
+
+public class ConsistentRegionConfigTest extends TestTopology {
+   
+    @Test
+    public void testDefaultOpDriven() {
+        ConsistentRegionConfig config = operatorDriven();
+        checkCRC(config, Trigger.OPERATOR_DRIVEN, -1, 180, 180, 5);
+    }
+    @Test
+    public void testDefaultOpDrivenNew() {
+        ConsistentRegionConfig config = new ConsistentRegionConfig();
+        checkCRC(config, Trigger.OPERATOR_DRIVEN, -1, 180, 180, 5);
+    }
+    
+    @Test
+    public void testDefaultPeriod() {
+        ConsistentRegionConfig config = periodic(37);
+        checkCRC(config, Trigger.PERIODIC, 37, 180, 180, 5);
+    }
+    @Test
+    public void testDefaultPeriodNew() {
+        ConsistentRegionConfig config = new ConsistentRegionConfig(39);
+        checkCRC(config, Trigger.PERIODIC, 39, 180, 180, 5);
+    }
+    
+    @Test
+    public void testChangeDrain() {
+        ConsistentRegionConfig config = operatorDriven().drainTimeout(27);
+        checkCRC(config, Trigger.OPERATOR_DRIVEN, -1, 27, 180, 5);
+    }
+    @Test
+    public void testChangeReset() {
+        ConsistentRegionConfig config = periodic(4).resetTimeout(99);
+        checkCRC(config, Trigger.PERIODIC, 4, 180, 99, 5);
+    }
+    @Test
+    public void testChangeAttempts() {
+        ConsistentRegionConfig config = periodic(9).maxConsecutiveResetAttempts(10);
+        checkCRC(config, Trigger.PERIODIC, 9, 180, 180, 10);
+    }
+    
+    @Test
+    public void testChangeAll() {
+        ConsistentRegionConfig config = operatorDriven().maxConsecutiveResetAttempts(11).drainTimeout(32).resetTimeout(200);
+        checkCRC(config, Trigger.OPERATOR_DRIVEN, -1, 32, 200, 11);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testInvalidDrain0() {
+        operatorDriven().drainTimeout(0);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testInvalidDrainNeg() {
+        operatorDriven().drainTimeout(-214);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testInvalidReset0() {
+        operatorDriven().resetTimeout(0);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testInvalidResetNeg() {
+        operatorDriven().resetTimeout(-2124);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testInvalidAttempts0() {
+        operatorDriven().maxConsecutiveResetAttempts(0);
+    }
+    @Test(expected=IllegalArgumentException.class)
+    public void testInvalidAttemptsNeg() {
+        operatorDriven().maxConsecutiveResetAttempts(-2);
+    }
+    
+    @Test
+    public void testEquals() {
+        
+        assertNotEquals(operatorDriven(), periodic(2));
+        
+        assertEquals(operatorDriven(), new ConsistentRegionConfig());
+        assertEquals(periodic(7), new ConsistentRegionConfig(7));
+        
+        
+        assertEquals(operatorDriven(), operatorDriven());
+        assertEquals(periodic(9), periodic(9));
+        
+        assertNotEquals(operatorDriven(), operatorDriven().drainTimeout(15));
+        assertNotEquals(operatorDriven(), operatorDriven().resetTimeout(16));
+        assertNotEquals(operatorDriven(), operatorDriven().maxConsecutiveResetAttempts(17)); 
+        
+        assertNotEquals(periodic(9), periodic(11));
+    }
+    
+    private static void checkCRC(ConsistentRegionConfig config,
+            Trigger trigger, int period, long drain, long reset, int attempts) {
+        
+        assertNotNull(config.getTrigger());
+        assertTrue(config.getDrainTimeout() > 0);
+        assertTrue(config.getResetTimeout() > 0);
+        assertTrue(config.getMaxConsecutiveResetAttempts() > 0);
+        
+        assertEquals(TimeUnit.SECONDS, config.getTimeUnit());
+        
+        assertEquals(trigger, config.getTrigger());
+        assertEquals(((long) period), config.getPeriod());
+        
+        assertEquals(drain, config.getDrainTimeout());
+        assertEquals(reset, config.getResetTimeout());
+        assertEquals(attempts, config.getMaxConsecutiveResetAttempts()); 
+        
+        assertEquals(config, config);
+        
+        ConsistentRegionConfig dup;
+        if (config.getTrigger() == Trigger.OPERATOR_DRIVEN)
+            dup = operatorDriven();
+        else
+            dup = periodic(period);
+        
+        dup = dup.drainTimeout(drain).resetTimeout(reset).maxConsecutiveResetAttempts(attempts);
+        assertEquals(config, dup);
+        assertEquals(config.hashCode(), dup.hashCode());
+    }
+}

--- a/test/java/src/com/ibm/streamsx/topology/test/consistent/ConsistentRegionConfigTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/consistent/ConsistentRegionConfigTest.java
@@ -8,7 +8,7 @@ package com.ibm.streamsx.topology.test.consistent;
 import static com.ibm.streamsx.topology.consistent.ConsistentRegionConfig.operatorDriven;
 import static com.ibm.streamsx.topology.consistent.ConsistentRegionConfig.periodic;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -94,7 +94,7 @@ public class ConsistentRegionConfigTest extends TestTopology {
     @Test
     public void testEquals() {
         
-        assertNotEquals(operatorDriven(), periodic(2));
+        assertFalse(operatorDriven().equals(periodic(2)));
         
         assertEquals(operatorDriven(), new ConsistentRegionConfig());
         assertEquals(periodic(7), new ConsistentRegionConfig(7));
@@ -103,11 +103,11 @@ public class ConsistentRegionConfigTest extends TestTopology {
         assertEquals(operatorDriven(), operatorDriven());
         assertEquals(periodic(9), periodic(9));
         
-        assertNotEquals(operatorDriven(), operatorDriven().drainTimeout(15));
-        assertNotEquals(operatorDriven(), operatorDriven().resetTimeout(16));
-        assertNotEquals(operatorDriven(), operatorDriven().maxConsecutiveResetAttempts(17)); 
+        assertFalse(operatorDriven().equals(operatorDriven().drainTimeout(15)));
+        assertFalse(operatorDriven().equals(operatorDriven().resetTimeout(16)));
+        assertFalse(operatorDriven().equals(operatorDriven().maxConsecutiveResetAttempts(17))); 
         
-        assertNotEquals(periodic(9), periodic(11));
+        assertFalse(periodic(9).equals(periodic(11)));
     }
     
     private static void checkCRC(ConsistentRegionConfig config,


### PR DESCRIPTION
Adds Java API for supporting consistent regions (starting at a source) in a topology:

* `TStream.setConsistent`
* new Java package `com.ibm.streamsx.topology.consistent`

API only, support is not yet implemented.