### PR TITLE
[Python] When calling submit, allow users to specify the resource url for sws manually.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -63,7 +63,6 @@ def submit(ctxtype, graph, config = None, username = None, password = None, reso
                 process = subprocess.Popen(['streamtool', 'geturl', '--api'],
                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 resource_url = process.stdout.readline().strip().decode('utf-8')
-                raise Exception("some exception in submit")
             except:
                 print_exception("Error getting SWS resource url ")               
                 raise

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -31,7 +31,7 @@ def delete_json(fn):
 # SPL, the toolkit, the bundle and submits it to the relevant
 # environment
 #
-def submit(ctxtype, graph, config = None, username = None, password = None):
+def submit(ctxtype, graph, config = None, username = None, password = None, resource_url = None):
     """
     Submits a topology with the specified context type.
     
@@ -58,12 +58,13 @@ def submit(ctxtype, graph, config = None, username = None, password = None):
     # Create connection to SWS
     if username is not None and password is not None:
         rc = None
-        try:
-            process = subprocess.Popen(['streamtool', 'geturl', '--api'],
-                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            resource_url = process.stdout.readline().strip().decode('utf-8')
-        except:
-            print_exception("Error getting SWS resource url ", username)
+        if resource_url is None:
+            try:
+                process = subprocess.Popen(['streamtool', 'geturl', '--api'],
+                                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                resource_url = process.stdout.readline().strip().decode('utf-8')
+            except:
+                print_exception("Error getting SWS resource url ", username)
 
         for view in graph.get_views():
             view.set_streams_context_config({'username': username, 'password': password, 'resource_url': resource_url})

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -31,7 +31,7 @@ def delete_json(fn):
 # SPL, the toolkit, the bundle and submits it to the relevant
 # environment
 #
-def submit(ctxtype, graph, config = None, username = None, password = None, resource_url = None):
+def submit(ctxtype, graph, config = None, username = None, password = None, rest_api_url = None):
     """
     Submits a topology with the specified context type.
     
@@ -58,17 +58,17 @@ def submit(ctxtype, graph, config = None, username = None, password = None, reso
     # Create connection to SWS
     if username is not None and password is not None:
         rc = None
-        if resource_url is None:
+        if rest_api_url is None:
             try:
                 process = subprocess.Popen(['streamtool', 'geturl', '--api'],
                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                resource_url = process.stdout.readline().strip().decode('utf-8')
+                rest_api_url = process.stdout.readline().strip().decode('utf-8')
             except:
-                print_exception("Error getting SWS resource url ")               
+                print_exception("Error getting SWS rest api url ")               
                 raise
 
         for view in graph.get_views():
-            view.set_streams_context_config({'username': username, 'password': password, 'resource_url': resource_url})
+            view.set_streams_context_config({'username': username, 'password': password, 'rest_api_url': rest_api_url})
     try:
         return _submitUsingJava(ctxtype, fn)
     except:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -63,8 +63,10 @@ def submit(ctxtype, graph, config = None, username = None, password = None, reso
                 process = subprocess.Popen(['streamtool', 'geturl', '--api'],
                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 resource_url = process.stdout.readline().strip().decode('utf-8')
+                raise Exception("some exception in submit")
             except:
-                print_exception("Error getting SWS resource url ", username)
+                print_exception("Error getting SWS resource url ")               
+                raise
 
         for view in graph.get_views():
             view.set_streams_context_config({'username': username, 'password': password, 'resource_url': resource_url})
@@ -73,7 +75,7 @@ def submit(ctxtype, graph, config = None, username = None, password = None, reso
     except:
         print_exception("Error submitting with java")
         delete_json(fn)
-
+        raise
 
 def _createFullJSON(graph, config):
     fj = {}
@@ -97,6 +99,7 @@ def print_process_stdout(process):
             print(line)
     except:
         print_exception("Error reading from process stdout")
+        raise
 
 def print_process_stderr(process, fn):
     try:
@@ -109,6 +112,7 @@ def print_process_stderr(process, fn):
                 delete_json(fn)
     except:
         print_exception("Error reading from process stderr")
+        raise
 
 def _submitUsingJava(ctxtype, fn):
     ctxtype_was = ctxtype
@@ -148,4 +152,4 @@ def _submitUsingJava(ctxtype, fn):
             return process.stdout
     except:
         print_exception("Error starting java subprocess for submission")
-        
+        raise

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -459,7 +459,7 @@ class View(threading.Thread):
         self.sample_size = sample_size
         self.streams_context = None
         self.view_object = None
-        self.streams_context_config = {'username': '', 'password': '', 'resource_url': ''}
+        self.streams_context_config = {'username': '', 'password': '', 'rest_api_url': ''}
 
         self._last_collection_time = -1
         self.is_rest_initialized = False
@@ -473,7 +473,7 @@ class View(threading.Thread):
             from streamsx import rest
             rc = rest.StreamsContext(self.streams_context_config['username'],
                                      self.streams_context_config['password'],
-                                     self.streams_context_config['resource_url'])
+                                     self.streams_context_config['rest_api_url'])
             self.is_rest_initialized = True
             self.set_streams_context(rc)
 


### PR DESCRIPTION
If the user does *not* specify the resource URL, then an attempt is made to invoke `st geturl`. If the geturl call fails, an error is raised.