### PR TITLE
Kafka build test

### DIFF
--- a/java/src/com/ibm/streamsx/topology/messaging/kafka/KafkaConsumer.java
+++ b/java/src/com/ibm/streamsx/topology/messaging/kafka/KafkaConsumer.java
@@ -153,7 +153,10 @@ public class KafkaConsumer {
 
         Map<String, Object> params = new HashMap<>();
         params.put("topic", topic);
-        params.put("threadsPerTopic", threadsPerTopic);
+        if (threadsPerTopic instanceof Value && threadsPerTopic.get() == 1)
+            ; // The default is one.
+        else
+            params.put("threadsPerTopic", threadsPerTopic);
         if (!config.isEmpty())
             params.put("kafkaProperty", Util.toKafkaProperty(config));
         

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -199,7 +199,7 @@
        <formatter type="xml"/>
        <batchtest todir="${topology.test.dir}">
           <fileset dir="${basedir}/src" 
-          	 excludes="**/samples/*Test.java,**/test/messaging/mqtt" >
+          	 excludes="**/samples/*Test.java" >
              <include name="${topology.test.base.pattern}"/>
           </fileset>
        </batchtest>

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -270,6 +270,7 @@
 
   <target name="unittest.mqtt.base">
      <echo message="See com.ibm.streamsx.topology.test.messaging.mqtt.package-info.java for required configuration information."/>
+     <property name="topology.test.external.run" value="true"/>
      <property name="topology.test.showoutput" value="yes"/>
      <property name="topology.test.include.name" value="**/mqtt/*Test.java"/>
      <antcall target="unittest.simple"/>

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -199,7 +199,7 @@
        <formatter type="xml"/>
        <batchtest todir="${topology.test.dir}">
           <fileset dir="${basedir}/src" 
-          	 excludes="**/samples/*Test.java,**/test/messaging/" >
+          	 excludes="**/samples/*Test.java,**/test/messaging/mqtt" >
              <include name="${topology.test.base.pattern}"/>
           </fileset>
        </batchtest>
@@ -243,6 +243,7 @@
 
   <target name="unittest.kafka.base">
      <echo message="See com.ibm.streamsx.topology.test.messaging.kafka.package-info.java for required configuration information."/>
+     <property name="topology.test.external.run" value="true"/>
      <property name="topology.test.showoutput" value="yes"/>
      <property name="topology.test.include.name" value="**/kafka/*Test.java"/>
      <antcall target="unittest.simple"/>
@@ -285,6 +286,7 @@
      <property name="topology.test.perf_ok" value="true"/>
      <property name="topology.test.coverage" value="true"/>
      <property name="topology.test.resource_dir" location="resources"/>
+     <property name="topology.test.external.run" value="false"/>
    <jacoco:coverage enabled="${topology.test.coverage}">
      <junit fork="yes" dir="${topology.test.dir}" printsummary="yes" showoutput="${topology.test.showoutput}"
            haltonfailure="${topology.test.haltonfailure}" failureproperty="topology.tests.failed">
@@ -294,6 +296,7 @@
        <sysproperty key="topology.test.perf_ok" value="${topology.test.perf_ok}"/>
        <sysproperty key="topology.test.resource_dir" file="resources"/>
        <sysproperty key="topology.install.compile" value="${topology.install.compile}"/>
+       <sysproperty key="topology.test.external.run" value="${topology.test.external.run}"/>
        <sysproperty key="log4j.configuration" value="${topology.log4j}"/>
        
        <classpath>

--- a/test/java/src/com/ibm/streamsx/topology/test/TestTopology.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/TestTopology.java
@@ -4,10 +4,11 @@
  */
 package com.ibm.streamsx.topology.test;
 
+import static com.ibm.streamsx.topology.context.StreamsContextFactory.getStreamsContext;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -338,5 +339,35 @@ public class TestTopology {
             public Boolean getResult() {
                 return valid();
             }};
+    }
+    
+    /**
+     * Allows a test to perform a IBM Streams BUNDLE build only.
+     * 
+     * If a test requires specific configuration & external setup
+     * to run then it should use this method to test at least
+     * the topology can built into a IBM Streams bundle.
+     * 
+     * When the system property topology.test.external.run is
+     * not set or set to false, then this method will perform
+     * a build and return true.
+     * 
+     * If the property is set to true then any configuration/external
+     * setup is assumed to have been setup and this method will
+     * return false without performing a build.
+     *
+     * Thus the test goes on to build & execute the topology
+     * and test the expected conditions if this method returns false.
+     */
+    protected boolean testBuildOnly(Topology topology) throws Exception {
+        if (!Boolean.getBoolean("topology.test.external.run")) {
+            File bundle = (File) getStreamsContext(Type.BUNDLE).submit(topology, getConfig()).get();
+            assertNotNull(bundle);
+            assertTrue(bundle.exists());
+            assertTrue(bundle.isFile());
+            bundle.delete();
+            return true;
+        }
+        return false;
     }
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/messaging/kafka/KafkaStreamsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/messaging/kafka/KafkaStreamsTest.java
@@ -4,6 +4,7 @@
  */
 package com.ibm.streamsx.topology.test.messaging.kafka;
 
+import static com.ibm.streamsx.topology.messaging.kafka.Util.identifyStreamsxMessagingVer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -20,8 +21,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
-
-import static com.ibm.streamsx.topology.messaging.kafka.Util.identifyStreamsxMessagingVer;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.streamsx.topology.TStream;
@@ -53,6 +52,9 @@ import com.ibm.streamsx.topology.tuple.SimpleMessage;
  * <li>{@code com.ibm.streamsx.topology.test.messaging.kafka.metadata.broker.list} the
  *      Kafka cluster's brokers addresses. Defaults to "localhost:9092".</li>
  * </ul>
+ * 
+ * If topology.test.configured.run is false (or not set) then the topology is built
+ * but not executed. This is to ensure compatibility with toolkits.
  */
 public class KafkaStreamsTest extends TestTopology {
     
@@ -415,6 +417,9 @@ public class KafkaStreamsTest extends TestTopology {
                                             msgToJSONStringFunc());
 
         setupDebug();
+        if (testBuildOnly(top))
+            return;
+            
         completeAndValidate(groupId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
     }
     
@@ -462,6 +467,9 @@ public class KafkaStreamsTest extends TestTopology {
                                             msgToJSONStringFunc());
 
         setupDebug();
+        if (testBuildOnly(top))
+            return;
+
         completeAndValidate(groupId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
     }
     
@@ -505,6 +513,9 @@ public class KafkaStreamsTest extends TestTopology {
                                             msgToJSONStringFunc());
 
         setupDebug();
+        if (testBuildOnly(top))
+            return;
+
         completeAndValidate(groupId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
     }
     
@@ -545,6 +556,9 @@ public class KafkaStreamsTest extends TestTopology {
                                             msgToJSONStringFunc());
 
         setupDebug();
+        if (testBuildOnly(top))
+            return;
+
         completeAndValidate(groupId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
     }
     
@@ -584,6 +598,9 @@ public class KafkaStreamsTest extends TestTopology {
                                             subtypeMsgToJSONStringFunc(topicVal));
 
         setupDebug();
+        if (testBuildOnly(top))
+            return;
+
         completeAndValidate(groupId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
     }
     
@@ -623,6 +640,9 @@ public class KafkaStreamsTest extends TestTopology {
                                             subtypeMsgToJSONStringFunc(null));
 
         setupDebug();
+        if (testBuildOnly(top))
+            return;
+
         completeAndValidate(groupId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
     }
     
@@ -680,6 +700,9 @@ public class KafkaStreamsTest extends TestTopology {
                                             msgToJSONStringFunc());
                                             
         setupDebug();
+        if (testBuildOnly(top))
+            return;
+
         completeAndValidateUnordered(groupId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
     }
         

--- a/test/java/src/com/ibm/streamsx/topology/test/messaging/mqtt/MqttStreamsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/messaging/mqtt/MqttStreamsTest.java
@@ -387,6 +387,9 @@ public class MqttStreamsTest extends TestTopology {
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
         msgs = modifyList(msgs, setTopic(topic));
         List<String> expectedAsString = mapList(msgs, msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
 
         completeAndValidate(subClientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink != null);
@@ -444,6 +447,9 @@ public class MqttStreamsTest extends TestTopology {
         rcvdMsgs.print();
         rcvdMsgs = selectMsgs(rcvdMsgs, mgen.pattern()); // just our msgs
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
 
         completeAndValidate(clientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink != null);
@@ -480,6 +486,9 @@ public class MqttStreamsTest extends TestTopology {
         rcvdMsgs.print();
         rcvdMsgs = selectMsgs(rcvdMsgs, mgen.pattern()); // just our msgs
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
 
         completeAndValidate(subClientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink != null);
@@ -514,6 +523,9 @@ public class MqttStreamsTest extends TestTopology {
         rcvdMsgs.print();
         rcvdMsgs = selectMsgs(rcvdMsgs, mgen.pattern()); // just our msgs
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
 
         completeAndValidate(subClientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink != null);
@@ -550,6 +562,9 @@ public class MqttStreamsTest extends TestTopology {
         rcvdMsgs.print();
         rcvdMsgs = selectMsgs(rcvdMsgs, mgen.pattern()); // just our msgs
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
 
         completeAndValidate(subClientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink != null);
@@ -588,6 +603,9 @@ public class MqttStreamsTest extends TestTopology {
         rcvdMsgs.print();
         rcvdMsgs = selectMsgs(rcvdMsgs, mgen.pattern()); // just our msgs
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
 
         completeAndValidate(subClientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink != null);
@@ -625,6 +643,9 @@ public class MqttStreamsTest extends TestTopology {
         rcvdMsgs.print();
         rcvdMsgs = selectMsgs(rcvdMsgs, mgen.pattern()); // just our msgs
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
 
         completeAndValidate(subClientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink != null);
@@ -667,6 +688,9 @@ public class MqttStreamsTest extends TestTopology {
         rcvdMsgs.print();
         rcvdMsgs = selectMsgs(rcvdMsgs, mgen.pattern()); // just our msgs
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
                                             
         completeAndValidateUnordered(subClientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink != null);
@@ -712,6 +736,9 @@ public class MqttStreamsTest extends TestTopology {
         rcvdMsgs.print();
         rcvdMsgs = selectMsgs(rcvdMsgs, mgen.pattern()); // just our msgs
         TStream<String> rcvdAsString = rcvdMsgs.transform(msgToJSONStringFunc());
+        
+        if (testBuildOnly(top))
+            return;
                                             
         completeAndValidateUnordered(subClientId, top, rcvdAsString, SEC_TIMEOUT, expectedAsString.toArray(new String[0]));
         assertTrue(sink1 != null);


### PR DESCRIPTION
Add a mechanism where a test can perform a simple build check rather than complete running.

This allows a test that requires external dependencies to run to ensure that they continue to build even if the external dependencies are not set up.