### PR TITLE
provide python2 operator model namespace setup

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionFilter/PyFunctionFilter.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionFilter/PyFunctionFilter.xml
@@ -28,7 +28,7 @@
         <library>
           <cmn:description>Python libraries</cmn:description>
           <cmn:managedLibrary>
-            <cmn:command>../../opt/python/templates/common/pyversion.sh</cmn:command>
+            <cmn:command>../pyversion.sh</cmn:command>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionHashAdder/PyFunctionHashAdder.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionHashAdder/PyFunctionHashAdder.xml
@@ -28,7 +28,7 @@
         <library>
           <cmn:description>Python libraries</cmn:description>
           <cmn:managedLibrary>
-            <cmn:command>../../opt/python/templates/common/pyversion.sh</cmn:command>
+            <cmn:command>../pyversion.sh</cmn:command>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionMultiTransform/PyFunctionMultiTransform.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionMultiTransform/PyFunctionMultiTransform.xml
@@ -28,7 +28,7 @@
         <library>
           <cmn:description>Python libraries</cmn:description>
           <cmn:managedLibrary>
-            <cmn:command>../../opt/python/templates/common/pyversion.sh</cmn:command>
+            <cmn:command>../pyversion.sh</cmn:command>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionSink/PyFunctionSink.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionSink/PyFunctionSink.xml
@@ -25,7 +25,7 @@
         <library>
           <cmn:description>Python libraries</cmn:description>
           <cmn:managedLibrary>
-            <cmn:command>../../opt/python/templates/common/pyversion.sh</cmn:command>
+            <cmn:command>../pyversion.sh</cmn:command>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionSource/PyFunctionSource.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionSource/PyFunctionSource.xml
@@ -25,7 +25,7 @@
         <library>
           <cmn:description>Python libraries</cmn:description>
           <cmn:managedLibrary>
-            <cmn:command>../../opt/python/templates/common/pyversion.sh</cmn:command>
+            <cmn:command>../pyversion.sh</cmn:command>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionTransform/PyFunctionTransform.xml
@@ -28,7 +28,7 @@
         <library>
           <cmn:description>Python libraries</cmn:description>
           <cmn:managedLibrary>
-            <cmn:command>../../opt/python/templates/common/pyversion.sh</cmn:command>
+            <cmn:command>../pyversion.sh</cmn:command>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyversion.sh
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyversion.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# python3 version
+action=$1
+
+if [ $action = "lib" ]
+then
+    python3-config --libs | sed -e 's/^-l//;s/ -l/ /g;s/ \+/\n/g'
+elif [ $action = "libPath" ]
+then
+    echo `python3-config --prefix`/lib
+elif [ $action = "includePath" ]
+then
+    python3-config --includes
+fi

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/namespace-info.spl
@@ -1,0 +1,13 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+ 
+/**
+* These operators are invoked by the Python Application API
+* and are not intended for direct use by SPL developers.
+* @exclude
+*/
+
+namespace com.ibm.streamsx.topology.functional.python2;
+

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/pyversion.sh
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/pyversion.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# python2 version
+action=$1
+
+if [ $action = "lib" ]
+then
+    python-config --libs | sed -e 's/^-l//;s/ -l/ /g;s/ \+/\n/g'
+elif [ $action = "libPath" ]
+then
+    echo `python-config --prefix`/lib
+elif [ $action = "includePath" ]
+then
+    python-config --includes
+fi

--- a/toolkit/build.xml
+++ b/toolkit/build.xml
@@ -30,11 +30,8 @@
 
    <copy todir="${tk}/com.ibm.streamsx.topology.functional.python2">
      <fileset dir="${tk}/com.ibm.streamsx.topology.functional.python" 
-         excludes="namespace-info.spl" />
-     <fileset dir="${tk}/com.ibm.streamsx.topology.functional.python" 
-         excludes="pyversion.sh" />
-     <fileset dir="${tk}/com.ibm.streamsx.topology.functional.python" 
-         includes="*" />
+         excludes="namespace-info.spl pyversion.sh"
+         includes="**" />
    </copy>      
 
    <exec executable="${streams.install}/bin/spl-make-toolkit" failonerror="true">

--- a/toolkit/build.xml
+++ b/toolkit/build.xml
@@ -28,6 +28,15 @@
    <mkdir dir="${tk}/license"/>
    <copy file="${streamsx.topology}/LICENSE" todir="${tk}/license"/>
 
+   <copy todir="${tk}/com.ibm.streamsx.topology.functional.python2">
+     <fileset dir="${tk}/com.ibm.streamsx.topology.functional.python" 
+         excludes="namespace-info.spl" />
+     <fileset dir="${tk}/com.ibm.streamsx.topology.functional.python" 
+         excludes="pyversion.sh" />
+     <fileset dir="${tk}/com.ibm.streamsx.topology.functional.python" 
+         includes="*" />
+   </copy>      
+
    <exec executable="${streams.install}/bin/spl-make-toolkit" failonerror="true">
      <arg value="--make-operator"/>
      <arg value="-i"/>
@@ -51,10 +60,15 @@
     <delete>
        <fileset dir="${tk}">
           <include name="com.ibm.streamsx.topology.functional.java/**"/>
+          <include name="com.ibm.streamsx.topology.functional.python2/**"/>
           <include name="com.ibm.streamsx.topology.file/**"/>
           <include name="com.ibm.streamsx.topology.testing/**"/>
+          <exclude name="com.ibm.streamsx.topology.functional.python2/pyversion.sh"/>
           <exclude name="**/namespace-info.spl"/>
        </fileset>
+       <dirset dir="${tk}">
+          <include name="com.ibm.streamsx.topology.functional.python2/PyFunction*"/>
+       </dirset>
     </delete>
   </target>
 </project>


### PR DESCRIPTION
To support using python 2.7 provide a com.ibm.streamsx.topology.functional.python2 namespace for application topology operators. 
toolkit/build.xml was modified to copy files from com.ibm.streamsx.topology.functional.python
modified topology.py to use the appropriate namespace -- based on python version -- when adding operators to the graph