### PR TITLE
fix java python test to use selected version of python

### DIFF
--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -47,6 +47,8 @@
    <property name="topology.toolkit.jar" location="${topology.toolkit.release}/lib/com.ibm.streamsx.topology.jar"/>
    <property name="topology.samples.jar" location="${topology.toolkit.release}/../samples/java/functional/functionalsamples.jar"/>
 
+   <echo message="Topology test python: ${topology.test.python}"/>
+
    <echo message="Topology toolkit jar: ${topology.toolkit.jar}"/>
    <echo message="Topology toolkit samples jar: ${topology.samples.jar}"/>
 
@@ -188,6 +190,7 @@
        <sysproperty key="topology.test.sc_ok" value="${topology.test.sc_ok}"/>
        <sysproperty key="topology.test.perf_ok" value="${topology.test.perf_ok}"/>
        <sysproperty key="topology.test.resource_dir" file="resources"/>
+       <sysproperty key="topology.test.python" value="${topology.test.python}"/>
        <sysproperty key="topology.toolkit.release" value="${topology.toolkit.release}"/>
        <sysproperty key="topology.install.compile" value="${topology.install.compile}"/>
        <sysproperty key="log4j.configuration" value="${topology.log4j}"/>

--- a/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribePython.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/python/PublishSubscribePython.java
@@ -46,8 +46,10 @@ abstract class PublishSubscribePython extends TestTopology {
     	
     	Path pyPackages = Paths.get(System.getProperty("topology.toolkit.release"),
     			"opt", "python", "packages").toAbsolutePath();
+
+      String pythonversion = System.getProperty("topology.test.python"); 
     	    	
-		ProcessBuilder pb = new ProcessBuilder("python3", module, pyTk.toAbsolutePath().toString());		
+		ProcessBuilder pb = new ProcessBuilder(pythonversion, module, pyTk.toAbsolutePath().toString());		
 		pb.redirectOutput(Redirect.INHERIT);
 		pb.redirectError(Redirect.INHERIT);
 		


### PR DESCRIPTION
this fixes the python version used in the java distributed tests

test com.ibm.streamsx.topology.test.python.SubscribeSPLDictTest works correctly now but the other two still fail. I will continue to investigate these -- 

com.ibm.streamsx.topology.test.python.PublishSubscribeStringPythonTest
com.ibm.streamsx.topology.test.python.PublishSubscribeJsonPythonTest

