### PR TITLE
SPL operator with callables with **kwargs signature.

### DIFF
--- a/com.ibm.streamsx.topology/bin/spl-python-extract.py
+++ b/com.ibm.streamsx.topology/bin/spl-python-extract.py
@@ -158,14 +158,14 @@ def create_op_spldoc(opmodel_xml, name, opobj):
      replaceTokenInFile(opmodel_xml, "__SPLPY__DESCRIPTION__SPLPY__", _opdoc);
 
 def create_ip_spldoc(opmodel_xml, name, opobj):
-     if (opobj.__splpy_style == None):
-         return None
      if (opobj.__splpy_style == 'dictionary'):
-         return None
-     
-     _p0doc = """
+       return """
+       Tuple attribute values are passed by name to the Python callable using `\*\*kwargs`.
+             """
+     if (opobj.__splpy_style == 'tuple'):
+       return """
        Tuple attribute values are passed by position to the Python callable.
-             """;
+             """
  
      replaceTokenInFile(opmodel_xml, "__SPLPY__INPORT_0_DESCRIPTION__SPLPY__", _p0doc);
    

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -120,15 +120,12 @@ def _define_style(wrapped, fn, style):
             raise TypeError("style='name' not supported with single *args parameter.")
         elif pc == 1 and has_kwargs:
             raise TypeError("style='name' not supported with single **kwargs parameter.")
-        # From an implementation point of view the values
-        # are passed as a dictionary and Python does the correct mapping
-        style = 'dictionary'
 
     elif style is not None:
         raise TypeError("style=" + style + " unknown.")
 
     if style is None:
-        if has_kwargs:
+        if pc == 1 and has_kwargs:
             style = 'dictionary'
         elif pc == 1 and has_args:
             style = 'tuple'
@@ -136,14 +133,12 @@ def _define_style(wrapped, fn, style):
             style = 'tuple'
         else:
             # Default to by name
-            # From an implementation point of view the values
-            # are passed as a dictionary and Python does the correct mapping
-            style = 'dictionary'
+            style = 'name'
 
     if style == 'tuple' and has_kwargs:
-         raise TypeError("style='position' not yet implemented with **kwargs parameter.")
+         raise TypeError("style='position' not implemented with **kwargs parameter.")
 
-    if style == 'dictionary':
+    if style == 'name':
          raise TypeError("Not yet implemented!")
     return style
 

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
@@ -2,9 +2,12 @@
    // converts the returned value into
    // Tuples and submits them.
 
-    PyObject * pyReturnVar = PyObject_CallObject(function_, pyTuple);
+    PyObject * pyReturnVar = PyObject_Call(function_, pyTuple, pyDict);
 
     Py_DECREF(pyTuple);
+    if (pyDict != NULL)
+        Py_DECREF(pyDict);
+
     if (pyReturnVar == NULL) {
         SPLAPPLOG(L_ERROR, "Fatal error: function failed: " << "<%=$functionName%>", "python");
        

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_splTupleToFunctionArgs.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_splTupleToFunctionArgs.cgt
@@ -11,7 +11,9 @@
 %>
 // START-Processing passing SPL tuple as a Python tuple
 // Declares: PyObject * pyTuple 
+// Declares: PyObject * pyDict as NULL
 
+    PyObject *pyDict = NULL; 
     PyObject * pyTuple = PyTuple_New(<%=$inputAttrs2Py%>);
     PyObject *pyValue;
 <%
@@ -29,8 +31,10 @@
 %>
 // START-Processing passing SPL tuple as a Python dictionary
 // All attributes are passed in the dictionary
+// Declares: PyObject * pyTuple as empty tuple
 // Declares: PyObject * pyDict
 
+    PyObject * pyTuple = PyTuple_New(0);
     PyObject * pyDict = PyDict_New();
 <%
      for (my $i = 0; $i < $iport->getNumberOfAttributes(); ++$i) {

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_splTupleToFunctionArgs.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_splTupleToFunctionArgs.cgt
@@ -1,8 +1,3 @@
-/*
- * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2015,2016
- */
-
 //
 // Takes the input SPL tuple and converts it to
 // the arguments needed to be passed to a Python
@@ -11,11 +6,11 @@
 
    IPort0Type const & <%=$ituple%> = static_cast<IPort0Type const &>(tuple);
 
-// START-Processing passing SPL tuple as a Python tuple
-// Declares: PyObject * pyTuple 
 <%
     if ($paramStyle eq 'tuple') {
 %>
+// START-Processing passing SPL tuple as a Python tuple
+// Declares: PyObject * pyTuple 
 
     PyObject * pyTuple = PyTuple_New(<%=$inputAttrs2Py%>);
     PyObject *pyValue;
@@ -23,7 +18,28 @@
      for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
          print convertToPythonValueAsTuple($ituple, $i, $itypes[$i], $inames[$i]);
      }
-    }
 %>
 // END-Processing passing SPL tuple as a Python tuple
+<%
+    }
+%>
+
+<%
+    if ($paramStyle eq 'dictionary') {
+%>
+// START-Processing passing SPL tuple as a Python dictionary
+// All attributes are passed in the dictionary
+// Declares: PyObject * pyDict
+
+    PyObject * pyDict = PyDict_New();
+<%
+     for (my $i = 0; $i < $iport->getNumberOfAttributes(); ++$i) {
+         my $la = $iport->getAttributeAt($i);
+         print convertAndAddToPythonDictionaryObject($ituple, $i, $la->getSPLType(), $la->getName());
+     }
+%>
+// END-Processing passing SPL tuple as a Python dictionary
+<%
+    }
+%>
 

--- a/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_kwargs.py
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_kwargs.py
@@ -1,0 +1,45 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016
+
+#
+# SPL Operators that pass the SPL tuple in
+# as a Python dictionary containing all the
+# attributes in the SPL tuple. The attribute
+# name is the key value.
+#
+# This requires that the callable signature
+# has a single **kwargs parameter.
+#
+
+# Import the SPL decorators
+from streamsx.spl import spl
+
+#------------------------------------------------------------------
+# Example functions
+#------------------------------------------------------------------
+
+# Defines the SPL namespace for any functions in this module
+# Multiple modules can map to the same namespace
+def splNamespace():
+    return "com.ibm.streamsx.topology.pysamples.kwargs"
+
+@spl.map()
+class DeltaFilter:
+    "Drops any tuple that is within a delta of the last tuple for the attribute named `value`."
+    def __init__(self, delta):
+        self.delta = delta
+        self.empty = ()
+        self.last_value = None
+
+    # Signature has **kwargs parameter which fixes the
+    # SPL tuple parameter passing style to be dictionary
+    def __call__(self, **tuple):
+        value = tuple["value"]
+        if self.last_value is not None:
+            if abs(value - self.last_value) <= self.delta:
+                self.last_value = value
+                return None
+        self.last_value = value
+        # Empty tuple will cause any matching input attributes
+        # to be carried across to the output tuple
+        return self.empty

--- a/test/python/build.xml
+++ b/test/python/build.xml
@@ -18,6 +18,8 @@
   <target name="all" depends="test.toolkit"/> 
 	  <copy file="../../samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_samples.py"
 	  	toDir="${testtk}/opt/python/streams"/>
+	  <copy file="../../samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_kwargs.py"
+	  	toDir="${testtk}/opt/python/streams"/>
 	  <target name="test.toolkit">
 		   <exec executable="${topology.test.python}" dir="${testtk}" failonerror="true">
 		     <arg value="${tk}/bin/spl-python-extract.py"/>


### PR DESCRIPTION
If the callable signature is `**kwargs` then we pass all the SPL tuple attributes as a Python dictionary with the name of the attribute as the key. E.g.

```
@spl.map()
def myop(**tuple):
    id = tuple["id"]
    value = tuple["value"]
```
