### PR TITLE
[WIP] Rewrite generator to use Gson and not IBM JSON4J

### DIFF
--- a/java/src/com/ibm/streamsx/topology/builder/JOperator.java
+++ b/java/src/com/ibm/streamsx/topology/builder/JOperator.java
@@ -43,17 +43,17 @@ public class JOperator {
     /**
      * Attribute for an explicit colocation identifier.
      */
-    public static final Object PLACEMENT_EXPLICIT_COLOCATE_ID = "explicitColocate";
+    public static final String PLACEMENT_EXPLICIT_COLOCATE_ID = "explicitColocate";
 
     /**
      * Attribute for low latency region identifier.
      */
-    public static final Object PLACEMENT_LOW_LATENCY_REGION_ID = "lowLatencyRegion";
+    public static final String PLACEMENT_LOW_LATENCY_REGION_ID = "lowLatencyRegion";
 
     /**
      * Attribute for an resource tags, a list of tags.
      */
-    public static final Object PLACEMENT_RESOURCE_TAGS = "resourceTags";
+    public static final String PLACEMENT_RESOURCE_TAGS = "resourceTags";
 
 
     

--- a/java/src/com/ibm/streamsx/topology/generator/spl/AutonomousRegions.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/AutonomousRegions.java
@@ -2,6 +2,7 @@ package com.ibm.streamsx.topology.generator.spl;
 
 import java.util.List;
 
+import com.google.gson.JsonObject;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streamsx.topology.builder.BVirtualMarker;
 
@@ -40,9 +41,8 @@ class AutonomousRegions {
     /**
      * Add in the annotation.
      */
-    static void autonomousAnnotation(JSONObject op, StringBuilder sb) {
-    	Boolean set = (Boolean) op.get(AUTONOMOUS);
-    	if (set != null && set)
+    static void autonomousAnnotation(JsonObject op, StringBuilder sb) {
+    	if (op.has(AUTONOMOUS) && op.get(AUTONOMOUS).getAsBoolean())
     		sb.append("@autonomous\n");
     }
 }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/GraphUtilities.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GraphUtilities.java
@@ -25,6 +25,73 @@ import com.ibm.streamsx.topology.builder.BVirtualMarker;
 import com.ibm.streamsx.topology.function.Consumer;
 
 public class GraphUtilities {
+    
+    /**
+     * Perform an action on every JsonObject in an array.
+     */
+    static void objectArray(JsonObject object, String property, Consumer<JsonObject> action) {
+        JsonArray array = array(object, property);
+        if (array == null)
+            return;
+        array.forEach(e -> action.accept(e.getAsJsonObject()));
+    }
+    
+    /**
+     * Perform an action on every String in an array.
+     */
+    static void stringArray(JsonObject object, String property, Consumer<String> action) {
+        JsonArray array = array(object, property);
+        if (array == null)
+            return;
+        array.forEach(e -> action.accept(e.getAsString()));
+    }
+    
+    /**
+     * Return a Json array.
+     * Returns null if the array is empty or not present.
+     */
+    static JsonArray array(JsonObject object, String property) {
+        if (object.has(property)) {
+            JsonElement je = object.get(property);
+            if (je.isJsonNull())
+                return null;
+            return je.getAsJsonArray();
+        }
+        return null;
+    }
+    /**
+     * Return a Json object.
+     * Returns null if the object is not present or null.
+     */
+    static JsonObject object(JsonObject object, String property) {
+        if (object.has(property)) {
+            JsonElement je = object.get(property);
+            if (je.isJsonNull())
+                return null;
+            return je.getAsJsonObject();
+        }
+        return null;
+    }
+    static String jstring(JsonObject object, String property) {
+        if (object.has(property)) {
+            JsonElement je = object.get(property);
+            if (je.isJsonNull())
+                return null;
+            return je.getAsString();
+        }
+        return null;
+    }
+    static boolean jboolean(JsonObject object, String property) {
+        if (object.has(property)) {
+            JsonElement je = object.get(property);
+            if (je.isJsonNull())
+                return false;
+            return je.getAsBoolean();
+        }
+        return false;
+    }
+ 
+    
     static ArrayList<JSONObject> findStarts(JSONObject graph) {
         ArrayList<JSONObject> starts = new ArrayList<JSONObject>();
         JSONArray ops = (JSONArray) graph.get("operators");

--- a/java/src/com/ibm/streamsx/topology/generator/spl/GraphValidation.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GraphValidation.java
@@ -15,22 +15,22 @@ public class GraphValidation {
         checkValidEndParallel(graph);
     }
     
-    private void checkValidEndParallel(JSONObject graph){
-        List<JSONObject> endParallels = GraphUtilities.findOperatorByKind(BVirtualMarker.END_PARALLEL, graph);	
+    private void checkValidEndParallel(JSONObject graph) {
+        List<JSONObject> endParallels = GraphUtilities.findOperatorByKind(BVirtualMarker.END_PARALLEL, graph);
 
-        for(JSONObject endParallel : endParallels){
-	    List<JSONObject> endParallelParents = null;
-	    // Setting up loop
-	    JSONObject endParallelParent = endParallel;
-            do{
-		endParallelParents = GraphUtilities.getUpstream(endParallelParent, graph);
-		if(endParallelParents.size() != 1){
-		    throw new IllegalStateException("Cannot union multiple streams before invoking endParallel()");
-		}
-		endParallelParent = endParallelParents.get(0);
-	    } while(((String)endParallelParent.get("kind")).startsWith("$"));
+        for (JSONObject endParallel : endParallels) {
+            List<JSONObject> endParallelParents = null;
+            // Setting up loop
+            JSONObject endParallelParent = endParallel;
+            do {
+                endParallelParents = GraphUtilities.getUpstream(endParallelParent, graph);
+                if (endParallelParents.size() != 1) {
+                    throw new IllegalStateException("Cannot union multiple streams before invoking endParallel()");
+                }
+                endParallelParent = endParallelParents.get(0);
+            } while (((String) endParallelParent.get("kind")).startsWith("$"));
             List<JSONObject> endParallelParentChildren = GraphUtilities.getDownstream(endParallelParent, graph);
-            if(endParallelParentChildren.size() != 1){
+            if (endParallelParentChildren.size() != 1) {
                 throw new IllegalStateException("Cannot fanout a stream before invoking endParallel()");
             }
         }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -6,6 +6,7 @@ package com.ibm.streamsx.topology.generator.spl;
 
 import static com.ibm.streamsx.topology.builder.JParamTypes.TYPE_SUBMISSION_PARAMETER;
 import static com.ibm.streamsx.topology.generator.spl.GraphUtilities.gson;
+import static com.ibm.streamsx.topology.generator.spl.GraphUtilities.jboolean;
 import static com.ibm.streamsx.topology.generator.spl.SPLGenerator.splBasename;
 import static com.ibm.streamsx.topology.internal.functional.ops.SubmissionParameterManager.NAME_SUBMISSION_PARAM_NAMES;
 import static com.ibm.streamsx.topology.internal.functional.ops.SubmissionParameterManager.NAME_SUBMISSION_PARAM_VALUES;
@@ -16,8 +17,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.ibm.json.java.JSONArray;
-import com.ibm.json.java.JSONArtifact;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streams.operator.window.StreamWindow;
 import com.ibm.streams.operator.window.StreamWindow.Type;
@@ -35,111 +38,106 @@ class OperatorGenerator {
         this.stvHelper = splGenerator.stvHelper();
     }
 
-    String generate(JSONObject graphConfig, JSONObject op)
+    String generate(JSONObject graphConfig, JSONObject _op)
             throws IOException {
+        JsonObject op = gson(_op);
         StringBuilder sb = new StringBuilder();
         noteAnnotations(op, sb);
         parallelAnnotation(op, sb);
 	viewAnnotation(op, sb);
         AutonomousRegions.autonomousAnnotation(op, sb);
-        outputClause(op, sb);
-        operatorNameAndKind(op, sb);
-        inputClause(op, sb);
+        outputClause(_op, sb);
+        operatorNameAndKind(_op, sb);
+        inputClause(_op, sb);
 
         sb.append("  {\n");
-        windowClause(op, sb);
-        paramClause(graphConfig, op, sb);
-        configClause(graphConfig, op, sb);
+        windowClause(_op, sb);
+        paramClause(graphConfig, _op, sb);
+        configClause(graphConfig, _op, sb);
         sb.append("  }\n");
 
         return sb.toString();
     }
 
-    private static void noteAnnotations(JSONObject op, StringBuilder sb)
+    private static void noteAnnotations(JsonObject op, StringBuilder sb)
             throws IOException {
         
         sourceLocationNote(op, sb);
         portTypesNote(op, sb);
     }
     
-    private static void sourceLocationNote(JSONObject op, StringBuilder sb) throws IOException {
-        JSONArray ja = (JSONArray) op.get("sourcelocation");
-        if (ja == null || ja.isEmpty())
+    private static void sourceLocationNote(JsonObject op, StringBuilder sb) throws IOException {
+        
+        JsonArray ja = GraphUtilities.array(op, "sourcelocation");
+        if (ja == null)
             return;
 
-        JSONArtifact jsource = ja.size() == 1 ? (JSONArtifact) ja.get(0) : ja;
+        JsonElement jsource = ja.size() == 1 ? (JsonElement) ja.get(0) : ja;
 
         sb.append("@spl_note(id=\"__spl_sourcelocation\"");
         sb.append(", text=");
-        String sourceInfo = jsource.serialize();
+        String sourceInfo = jsource.toString();
         SPLGenerator.stringLiteral(sb, sourceInfo);
         sb.append(")\n");
     }
     
-    private static void portTypesNote(JSONObject op, StringBuilder sb) {
-        JSONArray ja = (JSONArray) op.get("outputs");
-        if (ja == null || ja.isEmpty())
-            return;
-        for (int i = 0 ; i < ja.size(); i++) {
-            JSONObject output = (JSONObject) ja.get(i);
-            String type = (String) output.get("type.native");
+    private static void portTypesNote(JsonObject op, StringBuilder sb) {
+        
+        int[] id = new int[1];
+        GraphUtilities.objectArray(op, "outputs",
+                output -> {
+                    
+            String type = GraphUtilities.jstring(output, "type.native");
             if (type == null || type.isEmpty())
-                continue;
-            sb.append("@spl_note(id=\"__spl_nativeType_output_" + i + "\"");
+                return;
+            sb.append("@spl_note(id=\"__spl_nativeType_output_" + id[0]++ + "\"");
             sb.append(", text=");
             SPLGenerator.stringLiteral(sb, type);
             sb.append(")\n");
-        }
+        });
     }
 
-    private void viewAnnotation(JSONObject op, StringBuilder sb){
-	JSONObject config = (JSONObject)op.get("config");
-	if(config == null)
-	    return;
-
-        JSONArray viewConfigs = (JSONArray) config.get("viewConfigs");
-        if (viewConfigs == null || viewConfigs.isEmpty()) {
+    private void viewAnnotation(JsonObject op, StringBuilder sb) {
+        
+        JsonObject config = GraphUtilities.object(op, "config");
+        if (config == null)
             return;
-        }
+        
+        GraphUtilities.objectArray(config, "viewConfigs", viewConfig -> {
 
-	for (int i = 0; i < viewConfigs.size(); i++) {
-            JSONObject viewConfig = (JSONObject) viewConfigs.get(i);
-	    String name = (String)viewConfig.get("name");
-	    String port = (String)viewConfig.get("port");
-	    Double bufferTime = ((Number)viewConfig.get("bufferTime")).doubleValue();
-	    Long sampleSize = ((Number)viewConfig.get("sampleSize")).longValue();
-	    sb.append("@view(name = \"");
-	    sb.append(splBasename(name));
-	    sb.append("\", port = " + port);
-	    sb.append(", bufferTime = " + bufferTime + ", ");
-	    sb.append("sampleSize = " + sampleSize + ", ");
-	    sb.append("activateOption = firstAccess)\n");
-	}	
+            String name = viewConfig.get("name").getAsString();
+            String port = viewConfig.get("port").getAsString();
+            Double bufferTime = viewConfig.get("bufferTime").getAsDouble();
+            Long sampleSize = viewConfig.get("sampleSize").getAsLong();
+            sb.append("@view(name = \"");
+            sb.append(splBasename(name));
+            sb.append("\", port = " + port);
+            sb.append(", bufferTime = " + bufferTime + ", ");
+            sb.append("sampleSize = " + sampleSize + ", ");
+            sb.append("activateOption = firstAccess)\n");
+        });
     }
 
-    private void parallelAnnotation(JSONObject op, StringBuilder sb) {
-        Boolean parallel = (Boolean) op.get("parallelOperator");
-        if (parallel != null && parallel) {
+    private void parallelAnnotation(JsonObject op, StringBuilder sb) {
+        boolean parallel = jboolean(op, "parallelOperator");
+        
+        if (parallel) {
             sb.append("@parallel(width=");
-            Object width = op.get("width");
-            if (width instanceof Integer) {
-                sb.append(Integer.toString((int) width));
+            JsonElement width = op.get("width");
+            if (width.isJsonPrimitive()) {
+                sb.append(width.getAsString());
         	}
-        	else if (width instanceof Long) {        		
-            	sb.append(Integer.toString(((Long)width).intValue()));
-            }
             else {
-                JSONObject jo = (JSONObject) width;
-                String jsonType = (String) jo.get("type");
+                JsonObject jo = width.getAsJsonObject();
+                String jsonType = jo.get("type").getAsString();
                 if (TYPE_SUBMISSION_PARAMETER.equals(jsonType))
-                    sb.append(SubmissionTimeValue.generateCompParamName(gson((JSONObject) jo.get("value"))));
+                    sb.append(SubmissionTimeValue.generateCompParamName(jo.get("value").getAsJsonObject()));
                 else
                     throw new IllegalArgumentException("Unsupported parallel width specification: " + jo);
             }
-            Boolean partitioned = (Boolean) op.get("partitioned");
-            if (partitioned != null && partitioned) {
-                String parallelInputPortName = (String) op
-                        .get("parallelInputPortName");
+            boolean partitioned = jboolean(op, "partitioned");
+            if (partitioned) {
+                String parallelInputPortName = op.get("parallelInputPortName").getAsString();
                 parallelInputPortName = splBasename(parallelInputPortName);
                 sb.append(", partitionBy=[{port=" + parallelInputPortName
                         + ", attributes=[__spl_hash]}]");

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -5,6 +5,7 @@
 package com.ibm.streamsx.topology.generator.spl;
 
 import static com.ibm.streamsx.topology.builder.JParamTypes.TYPE_SUBMISSION_PARAMETER;
+import static com.ibm.streamsx.topology.generator.spl.GraphUtilities.gson;
 import static com.ibm.streamsx.topology.generator.spl.SPLGenerator.splBasename;
 import static com.ibm.streamsx.topology.internal.functional.ops.SubmissionParameterManager.NAME_SUBMISSION_PARAM_NAMES;
 import static com.ibm.streamsx.topology.internal.functional.ops.SubmissionParameterManager.NAME_SUBMISSION_PARAM_VALUES;
@@ -131,7 +132,7 @@ class OperatorGenerator {
                 JSONObject jo = (JSONObject) width;
                 String jsonType = (String) jo.get("type");
                 if (TYPE_SUBMISSION_PARAMETER.equals(jsonType))
-                    sb.append(stvHelper.generateCompParamName((JSONObject) jo.get("value")));
+                    sb.append(SubmissionTimeValue.generateCompParamName(gson((JSONObject) jo.get("value"))));
                 else
                     throw new IllegalArgumentException("Unsupported parallel width specification: " + jo);
             }
@@ -435,7 +436,7 @@ class OperatorGenerator {
         Object value = param.get("value");
         Object type = param.get("type");
         if (TYPE_SUBMISSION_PARAMETER.equals(type)) {
-            sb.append(stvHelper.generateCompParamName((JSONObject) value));
+            sb.append(SubmissionTimeValue.generateCompParamName(gson((JSONObject) value)));
             return;
         } else if (value instanceof String && !PARAM_TYPES_TOSTRING.contains(type)) {
             SPLGenerator.stringLiteral(sb, value.toString());

--- a/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
@@ -4,6 +4,8 @@
  */
 package com.ibm.streamsx.topology.generator.spl;
 
+import static com.ibm.streamsx.topology.generator.spl.GraphUtilities.gson;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -119,8 +121,8 @@ class Preprocessor {
         
         JSONObject parallelStart = children.get(0);
         
-        String inputPortName = GraphUtilities.getInputPortName(hashAdder, 0);
-        String parallelInputPortName = GraphUtilities.getInputPortName(parallelStart, 0);
+        String inputPortName = GraphUtilities.getInputPortName(gson(hashAdder), 0);
+        String parallelInputPortName = GraphUtilities.getInputPortName(gson(parallelStart), 0);
         
         List<JSONObject> unparallelParents = new ArrayList<>();
         List<JSONObject> nonUnparallelParents = new ArrayList<>();

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -116,9 +116,9 @@ public class SPLGenerator {
                 Object value = param.get("value");
                 if (TYPE_SUBMISSION_PARAMETER.equals(type)) {
                     sb.append("  ");
-                    if (isMainComposite)
-                        stvHelper.generateMainDef((JSONObject)value, sb);
-                    else
+                    if (isMainComposite) {
+                        stvHelper.generateMainDef(GraphUtilities.gson((JSONObject)value), sb);
+                    } else
                         stvHelper.generateInnerDef((JSONObject)value, sb);
                     sb.append(";\n");
                 }
@@ -536,7 +536,7 @@ public class SPLGenerator {
     /**
      * Get the string value of an "unsigned" Byte, Short, Integer or Long.
      */
-    public static String unsignedString(Object integerValue) {
+    public static String unsignedString(Number integerValue) {
 // java8 impl
 //        if (integerValue instanceof Long)
 //            return Long.toUnsignedString((Long) integerValue);

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SubmissionTimeValue.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SubmissionTimeValue.java
@@ -7,6 +7,7 @@ package com.ibm.streamsx.topology.generator.spl;
 import static com.ibm.streamsx.topology.internal.functional.ops.FunctionFunctor.FUNCTIONAL_LOGIC_PARAM;
 import static com.ibm.streamsx.topology.builder.JParamTypes.TYPE_SUBMISSION_PARAMETER;
 import static com.ibm.streamsx.topology.generator.spl.GraphUtilities.gson;
+import static com.ibm.streamsx.topology.generator.spl.GraphUtilities.json4j;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -169,7 +170,8 @@ public class SubmissionTimeValue {
                     }
                 }
                 if (addAll && !addedAll) {
-                    spParams.putAll(allSubmissionParams);
+                    for (String key : allSubmissionParams.keySet())
+                        spParams.put(key, json4j(allSubmissionParams.get(key)));
                     addedAll = true;
                 }
             }

--- a/java/src/com/ibm/streamsx/topology/internal/core/SubmissionParameter.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/SubmissionParameter.java
@@ -158,7 +158,8 @@ public class SubmissionParameter<T> implements Supplier<T>, JSONAble {
         jo.put("value", jv);
         jv.put("name", name);
         jv.put("metaType", metaType.name());
-        jv.put("defaultValue", defaultValue);
+        if (defaultValue != null)
+            jv.put("defaultValue", defaultValue);
         return jo;
     }
 

--- a/java/src/com/ibm/streamsx/topology/spl/SPLValue.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLValue.java
@@ -43,7 +43,7 @@ class SPLValue<T> {
     @Override
     public String toString() {
         if (isUnsignedInt(metaType))
-            return SPLGenerator.unsignedString(value);
+            return SPLGenerator.unsignedString((Number) value);
         return value.toString();
     }
     

--- a/test/java/src/com/ibm/streamsx/topology/test/spl/SPLOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/spl/SPLOperatorsTest.java
@@ -285,7 +285,7 @@ public class SPLOperatorsTest extends TestTopology {
         String metaType = (String) value.get("metaType");
         Object v = value.get("value");
         if (metaType.startsWith("UINT"))
-            return SPLGenerator.unsignedString(v);
+            return SPLGenerator.unsignedString((Number) v);
         else
             return v.toString();
     }


### PR DESCRIPTION
Trying this incrementally to ensure nothing becomes broken.

Currently portions of code are rewritten to use Gson  (`JsonObject`) while the graph is maintained as a whole with JSON4J objects `JSONObject`.

Converted code creates a temp Gson representation of the graph and works against that.