### PR TITLE
[WIP] Use Gson for SPL code generation

### DIFF
--- a/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
@@ -17,6 +17,7 @@ import com.ibm.streams.flow.declare.OutputPortDeclaration;
 import com.ibm.streams.operator.Attribute;
 import com.ibm.streams.operator.Operator;
 import com.ibm.streams.operator.StreamSchema;
+import com.ibm.streams.operator.Type.MetaType;
 import com.ibm.streams.operator.model.Namespace;
 import com.ibm.streams.operator.model.PrimitiveOperator;
 import com.ibm.streamsx.topology.function.Supplier;
@@ -164,18 +165,30 @@ public class BOperatorInvocation extends BOperator {
                 
         if (value instanceof String) {
             op.setStringParameter(name, (String) value);
+            if (jsonType == null)
+                jsonType = MetaType.RSTRING.name();
         } else if (value instanceof Byte) {
             op.setByteParameter(name, (Byte) value);
+            if (jsonType == null)
+                jsonType = MetaType.INT8.name();
         } else if (value instanceof Short) {
             op.setShortParameter(name, (Short) value);
+            if (jsonType == null)
+                jsonType = MetaType.INT16.name();
         } else if (value instanceof Integer) {
             op.setIntParameter(name, (Integer) value);
+            if (jsonType == null)
+                jsonType = MetaType.INT32.name();
         } else if (value instanceof Long) {
             op.setLongParameter(name, (Long) value);
+            if (jsonType == null)
+                jsonType = MetaType.INT64.name();
         } else if (value instanceof Float) {
             op.setFloatParameter(name, (Float) value);
+            jsonType = MetaType.FLOAT32.name();
         } else if (value instanceof Double) {
             op.setDoubleParameter(name, (Double) value);
+            jsonType = MetaType.FLOAT64.name();
         } else if (value instanceof Boolean) {
             op.setBooleanParameter(name, (Boolean) value);
         } else if (value instanceof BigDecimal) {

--- a/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
+++ b/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
@@ -127,7 +127,7 @@ public class GraphBuilder extends BJSONObject {
         for (BOperator operator : operators) {
             JSONObject jop = operator.complete();
             GraphUtilities.visitOnce(visitController,
-                    Collections.singletonList(jop), graph,
+                    Collections.singleton(jop), graph,
                 new Consumer<JSONObject>() {
                     private static final long serialVersionUID = 1L;
                     @Override

--- a/java/src/com/ibm/streamsx/topology/builder/JOperator.java
+++ b/java/src/com/ibm/streamsx/topology/builder/JOperator.java
@@ -43,17 +43,17 @@ public class JOperator {
     /**
      * Attribute for an explicit colocation identifier.
      */
-    public static final Object PLACEMENT_EXPLICIT_COLOCATE_ID = "explicitColocate";
+    public static final String PLACEMENT_EXPLICIT_COLOCATE_ID = "explicitColocate";
 
     /**
      * Attribute for low latency region identifier.
      */
-    public static final Object PLACEMENT_LOW_LATENCY_REGION_ID = "lowLatencyRegion";
+    public static final String PLACEMENT_LOW_LATENCY_REGION_ID = "lowLatencyRegion";
 
     /**
      * Attribute for an resource tags, a list of tags.
      */
-    public static final Object PLACEMENT_RESOURCE_TAGS = "resourceTags";
+    public static final String PLACEMENT_RESOURCE_TAGS = "resourceTags";
 
 
     

--- a/java/src/com/ibm/streamsx/topology/generator/spl/AutonomousRegions.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/AutonomousRegions.java
@@ -2,6 +2,7 @@ package com.ibm.streamsx.topology.generator.spl;
 
 import java.util.List;
 
+import com.google.gson.JsonObject;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streamsx.topology.builder.BVirtualMarker;
 
@@ -40,9 +41,9 @@ class AutonomousRegions {
     /**
      * Add in the annotation.
      */
-    static void autonomousAnnotation(JSONObject op, StringBuilder sb) {
-    	Boolean set = (Boolean) op.get(AUTONOMOUS);
-    	if (set != null && set)
+    static void autonomousAnnotation(JsonObject op, StringBuilder sb) {
+    	boolean set = GsonUtilities.jboolean(op, AUTONOMOUS);
+    	if (set)
     		sb.append("@autonomous\n");
     }
 }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/AutonomousRegions.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/AutonomousRegions.java
@@ -1,6 +1,9 @@
 package com.ibm.streamsx.topology.generator.spl;
 
+import static com.ibm.streamsx.topology.generator.spl.GraphUtilities.getDownstream;
+
 import java.util.List;
+import java.util.Set;
 
 import com.google.gson.JsonObject;
 import com.ibm.json.java.JSONObject;
@@ -24,12 +27,11 @@ class AutonomousRegions {
 	 */
     static void preprocessAutonomousRegions(JSONObject graph) {
 
-        List<JSONObject> autonomousOperators = GraphUtilities.findOperatorByKind(
+        Set<JSONObject> autonomousOperators = GraphUtilities.findOperatorByKind(
                 BVirtualMarker.AUTONOMOUS, graph);
 
         for (JSONObject autonomous : autonomousOperators) {
-        	List<JSONObject> startAutonomous = GraphUtilities.getDownstream(autonomous, graph);
-        	for (JSONObject sa : startAutonomous) {
+        	for (JSONObject sa : getDownstream(autonomous, graph)) {
         		if (!sa.containsKey(AUTONOMOUS))
         		    sa.put(AUTONOMOUS, Boolean.TRUE);
         	}

--- a/java/src/com/ibm/streamsx/topology/generator/spl/GraphUtilities.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GraphUtilities.java
@@ -13,6 +13,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streamsx.topology.builder.BVirtualMarker;
@@ -510,6 +512,19 @@ public class GraphUtilities {
             if(conn.equals(oportName)){
                 inputConns.set(inputConns.indexOf(conn), opOportName);
             }
+        }
+    }
+    
+    /**
+     * TEMP
+     * 
+     */
+    
+    static JsonObject gson(JSONObject object) {
+        try {
+            return new JsonParser().parse(object.serialize()).getAsJsonObject();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/GraphValidation.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GraphValidation.java
@@ -5,6 +5,7 @@
 package com.ibm.streamsx.topology.generator.spl;
 
 import java.util.List;
+import java.util.Set;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.streamsx.topology.builder.BVirtualMarker;
@@ -16,10 +17,10 @@ public class GraphValidation {
     }
     
     private void checkValidEndParallel(JSONObject graph){
-        List<JSONObject> endParallels = GraphUtilities.findOperatorByKind(BVirtualMarker.END_PARALLEL, graph);	
+        Set<JSONObject> endParallels = GraphUtilities.findOperatorByKind(BVirtualMarker.END_PARALLEL, graph);	
 
         for(JSONObject endParallel : endParallels){
-	    List<JSONObject> endParallelParents = null;
+	    Set<JSONObject> endParallelParents = null;
 	    // Setting up loop
 	    JSONObject endParallelParent = endParallel;
             do{
@@ -27,9 +28,9 @@ public class GraphValidation {
 		if(endParallelParents.size() != 1){
 		    throw new IllegalStateException("Cannot union multiple streams before invoking endParallel()");
 		}
-		endParallelParent = endParallelParents.get(0);
+		endParallelParent = endParallelParents.toArray(new JSONObject[1])[0];
 	    } while(((String)endParallelParent.get("kind")).startsWith("$"));
-            List<JSONObject> endParallelParentChildren = GraphUtilities.getDownstream(endParallelParent, graph);
+            Set<JSONObject> endParallelParentChildren = GraphUtilities.getDownstream(endParallelParent, graph);
             if(endParallelParentChildren.size() != 1){
                 throw new IllegalStateException("Cannot fanout a stream before invoking endParallel()");
             }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/GsonUtilities.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GsonUtilities.java
@@ -69,7 +69,7 @@ public class GsonUtilities {
         return object == null || object.isJsonNull() || object.entrySet().isEmpty();
     }
     static boolean jisEmpty(JsonArray array) {
-        return array == null || array.isJsonNull() || array.size() == 0;
+        return array == null || array.size() == 0;
     }
     
     static void gclear(JsonArray array) {

--- a/java/src/com/ibm/streamsx/topology/generator/spl/GsonUtilities.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GsonUtilities.java
@@ -1,0 +1,77 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016  
+ */
+package com.ibm.streamsx.topology.generator.spl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.ibm.streamsx.topology.function.Consumer;
+
+public class GsonUtilities {
+    /**
+     * Perform an action on every JsonObject in an array.
+     */
+    static void objectArray(JsonObject object, String property, Consumer<JsonObject> action) {
+        JsonArray array = array(object, property);
+        if (array == null)
+            return;
+        array.forEach(e -> action.accept(e.getAsJsonObject()));
+    }
+    
+    /**
+     * Perform an action on every String in an array.
+     */
+    static void stringArray(JsonObject object, String property, Consumer<String> action) {
+        JsonArray array = array(object, property);
+        if (array == null)
+            return;
+        array.forEach(e -> action.accept(e.getAsString()));
+    }
+    
+    /**
+     * Return a Json array.
+     * Returns null if the array is empty or not present.
+     */
+    static JsonArray array(JsonObject object, String property) {
+        if (object.has(property)) {
+            JsonElement je = object.get(property);
+            if (je.isJsonNull())
+                return null;
+            return je.getAsJsonArray();
+        }
+        return null;
+    }
+    /**
+     * Return a Json object.
+     * Returns null if the object is not present or null.
+     */
+    static JsonObject jobject(JsonObject object, String property) {
+        if (object.has(property)) {
+            JsonElement je = object.get(property);
+            if (je.isJsonNull())
+                return null;
+            return je.getAsJsonObject();
+        }
+        return null;
+    }
+    static String jstring(JsonObject object, String property) {
+        if (object.has(property)) {
+            JsonElement je = object.get(property);
+            if (je.isJsonNull())
+                return null;
+            return je.getAsString();
+        }
+        return null;
+    }
+    static boolean jboolean(JsonObject object, String property) {
+        if (object.has(property)) {
+            JsonElement je = object.get(property);
+            if (je.isJsonNull())
+                return false;
+            return je.getAsBoolean();
+        }
+        return false;
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/generator/spl/GsonUtilities.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GsonUtilities.java
@@ -4,6 +4,8 @@
  */
 package com.ibm.streamsx.topology.generator.spl;
 
+import java.util.Iterator;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -31,7 +33,9 @@ public class GsonUtilities {
     }
     
     /**
-     * Return a Json array.
+     * Return a Json array. If the value is not
+     * an array then an array containing the single
+     * value is returned.
      * Returns null if the array is empty or not present.
      */
     static JsonArray array(JsonObject object, String property) {
@@ -39,7 +43,11 @@ public class GsonUtilities {
             JsonElement je = object.get(property);
             if (je.isJsonNull())
                 return null;
-            return je.getAsJsonArray();
+            if (je.isJsonArray())
+                return je.getAsJsonArray();
+            JsonArray array = new JsonArray();
+            array.add(je);
+            return array;
         }
         return null;
     }
@@ -56,6 +64,21 @@ public class GsonUtilities {
         }
         return null;
     }
+    
+    static boolean jisEmpty(JsonObject object) {
+        return object == null || object.isJsonNull() || object.entrySet().isEmpty();
+    }
+    static boolean jisEmpty(JsonArray array) {
+        return array == null || array.isJsonNull() || array.size() == 0;
+    }
+    
+    static void gclear(JsonArray array) {
+        Iterator<JsonElement> it = array.iterator();
+        while(it.hasNext())
+            it.remove();
+    }
+    
+    
     static String jstring(JsonObject object, String property) {
         if (object.has(property)) {
             JsonElement je = object.get(property);

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -5,6 +5,7 @@
 package com.ibm.streamsx.topology.generator.spl;
 
 import static com.ibm.streamsx.topology.builder.JParamTypes.TYPE_SUBMISSION_PARAMETER;
+import static com.ibm.streamsx.topology.generator.spl.GsonUtilities.jobject;
 import static com.ibm.streamsx.topology.generator.spl.GsonUtilities.jstring;
 import static com.ibm.streamsx.topology.generator.spl.GsonUtilities.objectArray;
 import static com.ibm.streamsx.topology.generator.spl.SPLGenerator.splBasename;
@@ -44,7 +45,7 @@ class OperatorGenerator {
         StringBuilder sb = new StringBuilder();
         noteAnnotations(_op, sb);
         parallelAnnotation(op, sb);
-	viewAnnotation(op, sb);
+        viewAnnotation(_op, sb);
         AutonomousRegions.autonomousAnnotation(_op, sb);
         outputClause(_op, sb);
         operatorNameAndKind(_op, sb);
@@ -97,29 +98,25 @@ class OperatorGenerator {
         });
     }
 
-    private void viewAnnotation(JSONObject op, StringBuilder sb){
-	JSONObject config = (JSONObject)op.get("config");
-	if(config == null)
-	    return;
-
-        JSONArray viewConfigs = (JSONArray) config.get("viewConfigs");
-        if (viewConfigs == null || viewConfigs.isEmpty()) {
+    private void viewAnnotation(JsonObject op, StringBuilder sb) {
+        
+        JsonObject config = jobject(op, "config");
+        if (config == null)
             return;
-        }
+        
+        objectArray(config, "viewConfigs", viewConfig -> {
 
-	for (int i = 0; i < viewConfigs.size(); i++) {
-            JSONObject viewConfig = (JSONObject) viewConfigs.get(i);
-	    String name = (String)viewConfig.get("name");
-	    String port = (String)viewConfig.get("port");
-	    Double bufferTime = ((Number)viewConfig.get("bufferTime")).doubleValue();
-	    Long sampleSize = ((Number)viewConfig.get("sampleSize")).longValue();
-	    sb.append("@view(name = \"");
-	    sb.append(splBasename(name));
-	    sb.append("\", port = " + port);
-	    sb.append(", bufferTime = " + bufferTime + ", ");
-	    sb.append("sampleSize = " + sampleSize + ", ");
-	    sb.append("activateOption = firstAccess)\n");
-	}	
+            String name = viewConfig.get("name").getAsString();
+            String port = viewConfig.get("port").getAsString();
+            Double bufferTime = viewConfig.get("bufferTime").getAsDouble();
+            Long sampleSize = viewConfig.get("sampleSize").getAsLong();
+            sb.append("@view(name = \"");
+            sb.append(splBasename(name));
+            sb.append("\", port = " + port);
+            sb.append(", bufferTime = " + bufferTime + ", ");
+            sb.append("sampleSize = " + sampleSize + ", ");
+            sb.append("activateOption = firstAccess)\n");
+        });
     }
 
     private void parallelAnnotation(JSONObject op, StringBuilder sb) {

--- a/java/src/com/ibm/streamsx/topology/generator/spl/PEPlacement.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/PEPlacement.java
@@ -6,6 +6,7 @@ package com.ibm.streamsx.topology.generator.spl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +37,7 @@ class PEPlacement {
     }
     
     @SuppressWarnings("serial")
-    private void assignIsolateRegionIds(JSONObject isolate, List<JSONObject> starts,
+    private void assignIsolateRegionIds(JSONObject isolate, Set<JSONObject> starts,
             JSONObject graph) {
 
         final String isolationRegionId = newIsolateRegionId();
@@ -73,9 +74,9 @@ class PEPlacement {
      */
     @SuppressWarnings("serial")
     private void checkValidColocationRegion(JSONObject isolate, JSONObject graph) {
-        final List<JSONObject> isolateChildren = GraphUtilities.getDownstream(
+        final Set<JSONObject> isolateChildren = GraphUtilities.getDownstream(
                 isolate, graph);
-        List<JSONObject> isoParents = GraphUtilities.getUpstream(isolate, graph);
+        Set<JSONObject> isoParents = GraphUtilities.getUpstream(isolate, graph);
 
         assertNotIsolated(isoParents);
 
@@ -97,7 +98,7 @@ class PEPlacement {
 
     void tagIsolationRegions(JSONObject graph) {
         // Check whether graph is valid for colocations
-        List<JSONObject> isolateOperators = GraphUtilities.findOperatorByKind(
+        Set<JSONObject> isolateOperators = GraphUtilities.findOperatorByKind(
                 BVirtualMarker.ISOLATE, graph);
         
         for (JSONObject jso : isolateOperators) {
@@ -118,7 +119,7 @@ class PEPlacement {
     
     @SuppressWarnings("serial")
     private void tagIslandIsolatedRegions(JSONObject graph){
-        List<JSONObject> starts = GraphUtilities.findStarts(graph);   
+        Set<JSONObject> starts = GraphUtilities.findStarts(graph);   
         
         for(JSONObject start : starts){
             final String colocationTag = newIsolateRegionId();
@@ -130,8 +131,7 @@ class PEPlacement {
                 continue;
             }
             
-            List<JSONObject> startList = new ArrayList<>();
-            startList.add(start);
+            Set<JSONObject> startList = Collections.singleton(start);
             
             Set<BVirtualMarker> boundaries = EnumSet.of(BVirtualMarker.ISOLATE);
             
@@ -160,9 +160,9 @@ class PEPlacement {
     }
     
     void tagLowLatencyRegions(JSONObject graph) {
-        List<JSONObject> lowLatencyStartOperators = GraphUtilities
+        Set<JSONObject> lowLatencyStartOperators = GraphUtilities
                 .findOperatorByKind(BVirtualMarker.LOW_LATENCY, graph);
-        List<JSONObject> lowLatencyEndOperators = GraphUtilities
+        Set<JSONObject> lowLatencyEndOperators = GraphUtilities
                 .findOperatorByKind(BVirtualMarker.END_LOW_LATENCY, graph);
 
         // Assign isolation regions their lowLatency tag
@@ -180,7 +180,7 @@ class PEPlacement {
 
     @SuppressWarnings("serial")
     private void assignLowLatency(JSONObject llStart,
-            List<JSONObject> llStartChildren, JSONObject graph) {
+            Set<JSONObject> llStartChildren, JSONObject graph) {
 
         final String lowLatencyTag = "LowLatencyRegion"
                 + Integer.toString(lowLatencyRegionCount++);

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -46,7 +46,7 @@ public class SPLGenerator {
         comp.put("parameters", graph.get("parameters"));
         comp.put("__spl_mainComposite", true);
 
-        ArrayList<JSONObject> starts = GraphUtilities.findStarts(graph);
+        Set<JSONObject> starts = GraphUtilities.findStarts(graph);
         separateIntoComposites(starts, comp, graph);
         StringBuilder sb = new StringBuilder();
         generateGraph(graph, sb);
@@ -231,7 +231,7 @@ public class SPLGenerator {
      *            Necessary to pass it to the GraphUtilities.getChildren
      *            function.
      */
-    JSONObject separateIntoComposites(List<JSONObject> starts,
+    JSONObject separateIntoComposites(Set<JSONObject> starts,
             JSONObject comp, JSONObject graph) {
         // Contains all ops which have been reached by graph traversal,
         // regardless of whether they are 'special' operators, such as the ones
@@ -266,7 +266,7 @@ public class SPLGenerator {
             // If the operator is not a special operator, add it to the
             // visited list.
             if (!isParallelStart(visitOp) && !isParallelEnd(visitOp)) {
-                List<JSONObject> children = GraphUtilities.getDownstream(
+                Set<JSONObject> children = GraphUtilities.getDownstream(
                         visitOp, graph);
                 unvisited.addAll(children);
                 visited.add(visitOp);
@@ -330,7 +330,7 @@ public class SPLGenerator {
 
                 // Get the start operators in the parallel region -- the ones
                 // immediately downstream from the $Parallel operator
-                List<JSONObject> parallelStarts = GraphUtilities
+                Set<JSONObject> parallelStarts = GraphUtilities
                         .getDownstream(visitOp, graph);
 
                 // Once you have the start operators, recursively call the
@@ -358,7 +358,7 @@ public class SPLGenerator {
                 }
 
                 if (parallelEnd != null) {
-                    List<JSONObject> children = GraphUtilities
+                    Set<JSONObject> children = GraphUtilities
                             .getDownstream(parallelEnd, graph);
                     unvisited.addAll(children);
                     compOperator.put("outputs", parallelEnd.get("outputs"));
@@ -368,7 +368,7 @@ public class SPLGenerator {
                     // parallel composite.
                     JSONObject paraEndIn = (JSONObject)((JSONArray)parallelEnd.get("inputs")).get(0);
                     String parallelEndInputPortName = (String)(paraEndIn.get("name"));
-                    List<JSONObject> parallelOutParents = GraphUtilities.getUpstream(parallelEnd, graph);
+                    Set<JSONObject> parallelOutParents = GraphUtilities.getUpstream(parallelEnd, graph);
                     for(JSONObject end : parallelOutParents){
 			if(((String)end.get("kind")).equals("com.ibm.streamsx.topology.functional.java::HashAdder")){
 			    String endType = (String)((JSONObject)((JSONArray)end.get("outputs")).get(0)).get("type");

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -14,10 +14,15 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streamsx.topology.builder.BVirtualMarker;
 import com.ibm.streamsx.topology.builder.JGraph;
+import com.ibm.streamsx.topology.builder.JParamTypes;
 
 public class SPLGenerator {
     // Needed for composite name generation
@@ -471,6 +476,82 @@ public class SPLGenerator {
     static String splBasename(String name) {
         return getSPLCompatibleName(basename(name));
     }
+    
+    /**
+     * Add an arbitrary SPL value.
+     * JsonObject has a type and a value. 
+     */
+    static void value(StringBuilder sb, JsonObject tv) {
+        
+        JsonElement value = tv.get("value");
+        
+        String type = JParamTypes.TYPE_SPL_EXPRESSION;
+        if (tv.has("type")) {
+            type = tv.get("type").getAsString();          
+        } else {
+            if (value.isJsonPrimitive()) {
+                JsonPrimitive pv = value.getAsJsonPrimitive();               
+                if (pv.isString())
+                    type = "RSTRING";
+            }
+            else if (value.isJsonArray()) {
+                type = "RSTRING";
+            }
+        }
+               
+        if (value.isJsonArray()) {
+            JsonArray array = value.getAsJsonArray();
+            
+           for (int i = 0; i < array.size(); i++) {
+                if (i != 0)
+                    sb.append(", ");
+                value(sb, type, array.get(i));
+            }
+        }
+        else
+        {
+            value(sb, type, value);
+        }
+    }
+    
+    /**
+     * Add a single value of a known type.
+     */
+    static void value(StringBuilder sb, String type, JsonElement value) {
+        switch (type) {
+        case "UINT8":
+        case "UINT16":
+        case "UINT32":
+        case "UINT64":
+        case "INT8":
+        case "INT16":
+        case "INT32":
+        case "INT64":
+        case "FLOAT32":
+        case "FLOAT64":
+            numberLiteral(sb, value.getAsJsonPrimitive(), type);
+            break;
+        case "RSTRING":
+            stringLiteral(sb, value.getAsString());
+            break;
+        case "USTRING":
+            stringLiteral(sb, value.getAsString());
+            sb.append("u");
+            break;
+            
+        case "BOOLEAN":
+            sb.append(value.getAsBoolean());
+            break;
+            
+        default:
+        case JParamTypes.TYPE_ENUM:
+        case JParamTypes.TYPE_SPLTYPE:
+        case JParamTypes.TYPE_ATTRIBUTE:
+        case JParamTypes.TYPE_SPL_EXPRESSION:
+            sb.append(value.getAsString());
+            break;
+        }
+    }
 
     
     static String stringLiteral(String value) {
@@ -500,7 +581,50 @@ public class SPLGenerator {
      * Append the value with the correct SPL suffix. Integer & Double do not
      * require a suffix
      */
-    static void numberLiteral(StringBuilder sb, Number value, Object type) {
+    static void numberLiteral(StringBuilder sb, JsonPrimitive value, String type) {
+        String suffix = "";
+        
+        switch (type) {
+        case "INT8": suffix = "b"; break;
+        case "INT16": suffix = "h"; break;
+        case "INT32": break;
+        case "INT64": suffix = "l"; break;
+        
+        case "UINT8": suffix = "ub"; break;
+        case "UINT16": suffix = "uh"; break;
+        case "UINT32": suffix = "uw"; break;
+        case "UINT64": suffix = "ul"; break;
+        
+        case "FLOAT32": suffix = "w"; break; // word, meaning 32 bits
+        case "FLOAT64": break;
+        }
+
+        String literal;
+
+        if (value.isNumber() && isUnsignedInt(type)) {
+            Number nv = value.getAsNumber();
+
+            if ("UINT64".equals(type))
+                literal = Long.toUnsignedString(nv.longValue());
+            else if ("UINT32".equals(type))
+                literal = Integer.toUnsignedString(nv.intValue());
+            else if ("UINT16".equals(type))
+                literal = Integer.toUnsignedString(Short.toUnsignedInt(nv.shortValue()));
+            else
+                literal = Integer.toUnsignedString(Byte.toUnsignedInt(nv.byteValue()));
+        } else {
+            literal = value.getAsNumber().toString();
+        }
+        
+        sb.append(literal);
+        sb.append(suffix);
+    }
+
+    /**
+     * Append the value with the correct SPL suffix. Integer & Double do not
+     * require a suffix
+     */
+    static void numberLiteral(StringBuilder sb, Number value, String type) {
         Object val = value;
         String suffix = "";
         boolean isUnsignedInt = isUnsignedInt(type); 
@@ -526,7 +650,7 @@ public class SPLGenerator {
         sb.append(suffix);
     }
     
-    private static boolean isUnsignedInt(Object type) {
+    private static boolean isUnsignedInt(String type) {
         return "UINT8".equals(type)
                 || "UINT16".equals(type)
                 || "UINT32".equals(type)

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SubmissionTimeValue.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SubmissionTimeValue.java
@@ -10,6 +10,7 @@ import static com.ibm.streamsx.topology.builder.JParamTypes.TYPE_SUBMISSION_PARA
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.gson.JsonObject;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streams.operator.Type.MetaType;
@@ -108,7 +109,7 @@ public class SubmissionTimeValue {
                 valuesSb.append(", ");
             }
             namesSb.append(SPLGenerator.stringLiteral(opParamName));
-            valuesSb.append("(rstring) ").append(generateCompParamName(spval));
+            valuesSb.append("(rstring) ").append(generateCompParamName(GraphUtilities.gson(spval)));
         }
 
         return new ParamsInfo(namesSb.toString(), valuesSb.toString());
@@ -260,7 +261,7 @@ public class SubmissionTimeValue {
      * @param sb
      */
     void generateMainDef(JSONObject spval, StringBuilder sb) {
-        String paramName = generateCompParamName(spval);
+        String paramName = generateCompParamName(GraphUtilities.gson(spval));
         String spName = SPLGenerator.stringLiteral((String) spval.get("name"));
         String metaType = (String) spval.get("metaType");
         String splType = MetaType.valueOf(metaType).getLanguageType();
@@ -289,7 +290,7 @@ public class SubmissionTimeValue {
      * @param sb
      */
     void generateInnerDef(JSONObject spval, StringBuilder sb) {
-        String paramName = generateCompParamName(spval);
+        String paramName = generateCompParamName(GraphUtilities.gson(spval));
         String metaType = (String) spval.get("metaType");
         String splType = MetaType.valueOf(metaType).getLanguageType();
         sb.append(String.format("expression<%s> %s", splType, paramName));
@@ -308,8 +309,8 @@ public class SubmissionTimeValue {
      * @param spval JSONObject for the submission parameter's value
      * @return the name
      */
-    String generateCompParamName(JSONObject spval) {
-        return "$" + mkOpParamName((String)spval.get("name"));
+    String generateCompParamName(JsonObject spval) {
+        return "$" + mkOpParamName(spval.get("name").getAsString());
     }
 
 }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SubmissionTimeValue.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SubmissionTimeValue.java
@@ -309,7 +309,7 @@ public class SubmissionTimeValue {
      * @param spval JSONObject for the submission parameter's value
      * @return the name
      */
-    String generateCompParamName(JsonObject spval) {
+    static String generateCompParamName(JsonObject spval) {
         return "$" + mkOpParamName(spval.get("name").getAsString());
     }
 

--- a/java/src/com/ibm/streamsx/topology/generator/spl/ThreadingModel.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/ThreadingModel.java
@@ -4,8 +4,11 @@
  */
 package com.ibm.streamsx.topology.generator.spl;
 
+import static com.ibm.streamsx.topology.generator.spl.GraphUtilities.getUpstream;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
@@ -26,7 +29,7 @@ class ThreadingModel {
         // Added threaded port configuration if the operator is non-functional
         // and it has a threaded port.
         
-        ArrayList<JSONObject> starts = GraphUtilities.findStarts(graph);
+        Set<JSONObject> starts = GraphUtilities.findStarts(graph);
         GraphUtilities.visitOnce(starts, null, graph, new Consumer<JSONObject>(){
 
             @Override
@@ -75,8 +78,7 @@ class ThreadingModel {
                     colocTag = (String) placement.get(JOperator.PLACEMENT_ISOLATE_REGION_ID);
                 }
 
-                List<JSONObject> parents = GraphUtilities.getUpstream(op, graph);
-                for(JSONObject parent : parents){
+                for(JSONObject parent : getUpstream(op, graph)){
                     JSONObject parentPlacement = JOperatorConfig.getJSONItem(parent, JOperatorConfig.PLACEMENT);
                     String parentColocTag = null;
                     if (parentPlacement != null)

--- a/java/src/com/ibm/streamsx/topology/internal/core/PlacementInfo.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/PlacementInfo.java
@@ -118,16 +118,16 @@ class PlacementInfo {
     private void disallowColocateIsolatedOpWithParent(Placeable<?> first, Placeable<?> ... toFuse) {
         JSONObject graph = first.builder().complete();
         JSONObject colocateOp = first.operator().complete();
-        List<JSONObject> parents = GraphUtilities.getUpstream(colocateOp, graph);
+        Set<JSONObject> parents = GraphUtilities.getUpstream(colocateOp, graph);
         if (!parents.isEmpty()) {
-            JSONObject isolate = parents.get(0);
+            JSONObject isolate = parents.iterator().next();
             String kind = (String) isolate.get("kind");
             if (!ISOLATE.kind().equals(kind))
                 return;
             parents = GraphUtilities.getUpstream(isolate, graph);
             if (parents.isEmpty())
                 return;
-            JSONObject isolateParentOp = parents.get(0);
+            JSONObject isolateParentOp = parents.iterator().next();
             for (Placeable<?> placeable : toFuse) {
                 JSONObject tgtOp = placeable.operator().complete();
                 if (tgtOp == isolateParentOp)


### PR DESCRIPTION
1. Use gson for generation of SPL values or expression. Gson is different to JSON4J in that the original type of the object (Long, Integer etc.) is lost, so the SPL type must be entered as meta-data when created (based upon the object type).