### PR TITLE
ZippedToolkitContext now works for build farm submission.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/templates/common/Makefile
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/Makefile
@@ -1,6 +1,6 @@
 all:
-	chmod 777 com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyversion.sh
-	chmod 777 com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/pyversion.sh
+	chmod 500 com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyversion.sh
+	chmod 500 com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/pyversion.sh
 	@for toolkit in `cat manifest_tk.txt`; do \
 		spl-make-toolkit -i $${toolkit}; \
 	done;

--- a/com.ibm.streamsx.topology/opt/python/templates/common/Makefile
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/Makefile
@@ -1,0 +1,7 @@
+all:
+	chmod 777 com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyversion.sh
+	chmod 777 com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/pyversion.sh
+	@for toolkit in `cat manifest_tk.txt`; do \
+		spl-make-toolkit -i $${toolkit}; \
+	done;
+	sc -M `cat main_composite.txt` --rebuild-toolkits --no-toolkit-indexing -t .:${STREAMS_INSTALL}/toolkits

--- a/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
@@ -99,8 +99,8 @@ public class ZippedToolkitStreamsContext extends ToolkitStreamsContext {
 		paths.add(folder);
 		
 		addAllToZippedArchive(paths, zipFilePath);	
-		new File(paths.get(1).toString()).delete();
-		new File(paths.get(2).toString()).delete();
+		paths.get(1).toFile().delete();
+		paths.get(2).toFile().delete();
 		
 	    return zipFilePath;
 	}

--- a/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
@@ -99,9 +99,8 @@ public class ZippedToolkitStreamsContext extends ToolkitStreamsContext {
 		paths.add(folder);
 		
 		addAllToZippedArchive(paths, zipFilePath);	
-		JSONObject jso = new OrderedJSONObject();
-		super.deleteToolkit(new File(paths.get(1).toString()), jso);
-		super.deleteToolkit(new File(paths.get(2).toString()), jso);
+		new File(paths.get(1).toString()).delete();
+		new File(paths.get(2).toString()).delete();
 		
 	    return zipFilePath;
 	}

--- a/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
@@ -3,12 +3,18 @@ package com.ibm.streamsx.topology.internal.context;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.net.URISyntaxException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.zip.ZipEntry;
@@ -29,7 +35,12 @@ public class ZippedToolkitStreamsContext extends ToolkitStreamsContext {
 	@Override
 	public Future<File> submit(Topology app, Map<String, Object> config) throws Exception {        
         File toolkitRoot = super.submit(app, config).get();
-        Path zipOutPath = pack(toolkitRoot.toPath());
+        
+        String namespace = (String) app.builder().json().get("namespace");
+        String name = (String) app.builder().json().get("name");
+        String tkName = toolkitRoot.toPath().toAbsolutePath().getFileName().toString();
+        
+        Path zipOutPath = pack(toolkitRoot.toPath(), namespace, name, tkName);
         
         JSONObject jso = new JSONObject();
         addConfigToJSON(jso, config);  
@@ -40,7 +51,13 @@ public class ZippedToolkitStreamsContext extends ToolkitStreamsContext {
 	@Override
 	public Future<File> submit(JSONObject submission) throws Exception {
         File toolkitRoot = super.submit(submission).get();
-        Path zipOutPath = pack(toolkitRoot.toPath());
+        
+        JSONObject jsonGraph = (JSONObject) submission.get(SUBMISSION_GRAPH);
+        String namespace = jsonGraph.get("namespace").toString();
+        String name = jsonGraph.get("name").toString();
+        String tkName = toolkitRoot.toPath().toAbsolutePath().getFileName().toString();
+        
+        Path zipOutPath = pack(toolkitRoot.toPath(), namespace, name, tkName);
         
         return deleteToolkitAndProduceCompletedFuture(toolkitRoot, (JSONObject)submission.get(SUBMISSION_DEPLOY), zipOutPath);
 	}
@@ -51,30 +68,74 @@ public class ZippedToolkitStreamsContext extends ToolkitStreamsContext {
         return new CompletedFuture<File>(zipOutPath.toFile());
 	}
 	
-	public static Path pack(final Path folder) throws IOException {
+	public Path pack(final Path folder, String namespace, String name, String tkName) throws IOException, URISyntaxException {
 		Path zipFilePath = Paths.get(folder.toAbsolutePath().toString() + ".zip");
-		String folderName = folder.getFileName().toString();
-	    try (
-	            FileOutputStream fos = new FileOutputStream(zipFilePath.toFile());
-	            ZipOutputStream zos = new ZipOutputStream(fos)
-	    ) {
-	        Files.walkFileTree(folder, new SimpleFileVisitor<Path>() {
-	            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-	                zos.putNextEntry(new ZipEntry(folderName + "/" + folder.relativize(file).toString()));
-	                Files.copy(file, zos);
-	                zos.closeEntry();
-	                return FileVisitResult.CONTINUE;
-	            }
-
-	            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-	                zos.putNextEntry(new ZipEntry(folderName + "/" + folder.relativize(dir).toString() + "/"));
-	                zos.closeEntry();
-	                return FileVisitResult.CONTINUE;
-	            }
-	        });
-	    }
+		String workingDir = zipFilePath.getParent().toString();
+		// com.ibm.streamsx.topology/lib/com.ibm.streamsx.topology.jar
+		File jarLocation = new File(ZippedToolkitStreamsContext.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
+		// com.ibm.streamsx.topology/lib/
+		File libDir = new File(jarLocation.getParent());
+		// com.ibm.streamsx.topology
+		File topologyToolkit = new File(libDir.getParent());	
+		
+		// tkManifest is the list of toolkits contained in the archive
+		PrintWriter tkManifest = new PrintWriter("manifest_tk.txt", "UTF-8");
+		
+		// mainComposite is a string of the namespace and the main composite.
+		// This is used by the Makefile
+		PrintWriter mainComposite = new PrintWriter("main_composite.txt", "UTF-8");
+		
+		tkManifest.println(tkName);
+		tkManifest.println("com.ibm.streamsx.topology");
+		
+		mainComposite.print(namespace + "::" + name);
+		
+		tkManifest.close();
+		mainComposite.close();
+		
+		List<Path> paths = new ArrayList<Path>();
+		paths.add(Paths.get(topologyToolkit.getAbsolutePath()));
+		paths.add(Paths.get(workingDir + "/manifest_tk.txt"));
+		paths.add(Paths.get(workingDir + "/main_composite.txt"));
+		paths.add(Paths.get(topologyToolkit.getAbsolutePath() + "/opt/python/templates/common/Makefile"));
+		paths.add(folder);
+		
+		addAllToZippedArchive(paths, zipFilePath);	
+		JSONObject jso = new OrderedJSONObject();
+		super.deleteToolkit(new File(paths.get(1).toString()), jso);
+		super.deleteToolkit(new File(paths.get(2).toString()), jso);
+		
 	    return zipFilePath;
 	}
+	
+	protected static void addAllToZippedArchive(List<Path> starts, Path zipFilePath) throws IOException {
+		try (FileOutputStream fos = new FileOutputStream(zipFilePath.toFile());
+				ZipOutputStream zos = new ZipOutputStream(fos)) {
+			for (Path start : starts) {
+				String startName = start.getFileName().toString();
+				Files.walkFileTree(start, new SimpleFileVisitor<Path>() {
+					public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+						String entryName = startName;
+						String relativePath = start.relativize(file).toString();
+						if(relativePath.length() != 0){
+							entryName = entryName + "/" + relativePath;
+						}
+						zos.putNextEntry(new ZipEntry(entryName));
+						Files.copy(file, zos);
+						zos.closeEntry();
+						return FileVisitResult.CONTINUE;
+					}
+
+					public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+						zos.putNextEntry(new ZipEntry(startName + "/" + start.relativize(dir).toString() + "/"));
+						zos.closeEntry();
+						return FileVisitResult.CONTINUE;
+					}
+				});
+			}
+		}
+	}
+	
 	
 	@Override
     protected void makeToolkit(JSONObject deployInfo, File toolkitRoot) throws InterruptedException, Exception{

--- a/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -21,9 +19,9 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import com.ibm.json.java.JSONObject;
+import com.ibm.json.java.OrderedJSONObject;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.internal.process.CompletedFuture;
-import com.ibm.streamsx.topology.internal.streams.InvokeMakeToolkit;
 
 public class ZippedToolkitStreamsContext extends ToolkitStreamsContext {
 	


### PR DESCRIPTION
The ZippedToolkitContext will create a zip file containing the following:
  * The topology toolkit
  * The generated toolkit with user code
  * A makefile which will build the .sab file when invoked
  * A manifest of the toolkits in the archive (currently just two mentioned)
  * A "main compostite" file, containing the name of the main composite, and its namespace.