### PR TITLE
Fix paths in Makefile

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/templates/common/Makefile
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/Makefile
@@ -2,6 +2,6 @@ all:
 	chmod 500 com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyversion.sh
 	chmod 500 com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/pyversion.sh
 	@for toolkit in `cat manifest_tk.txt`; do \
-		spl-make-toolkit -i $${toolkit}; \
+		${STREAMS_INSTALL}/bin/spl-make-toolkit -i $${toolkit}; \
 	done;
-	sc -M `cat main_composite.txt` --rebuild-toolkits --no-toolkit-indexing -t .:${STREAMS_INSTALL}/toolkits
+	${STREAMS_INSTALL}/bin/sc -M `cat main_composite.txt` --rebuild-toolkits --no-toolkit-indexing -t .:${STREAMS_INSTALL}/toolkits

--- a/com.ibm.streamsx.topology/opt/python/templates/common/Makefile
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/Makefile
@@ -4,4 +4,4 @@ all:
 	@for toolkit in `cat manifest_tk.txt`; do \
 		${STREAMS_INSTALL}/bin/spl-make-toolkit -i $${toolkit}; \
 	done;
-	${STREAMS_INSTALL}/bin/sc -M `cat main_composite.txt` --rebuild-toolkits --no-toolkit-indexing -t .:${STREAMS_INSTALL}/toolkits
+	${STREAMS_INSTALL}/bin/sc -M `cat main_composite.txt` --rebuild-toolkits --no-toolkit-indexing -t ${STREAMS_INSTALL}/toolkits


### PR DESCRIPTION
* Fix paths to `spl-make-toolkit` and `sc` to avoid any dependencies on PATH
* Remove '.' from the toolkit path to avoid warning.