### PR TITLE
Allow Topology.source to accept an Iterable instance

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/functions.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/functions.py
@@ -19,3 +19,12 @@ def identity(t):
     :returns: Its argument.
     """
     return t;
+
+# Wraps an iterable instance returning
+# it when called. Allows an iterable
+# instance to be passed directly to Topology.source
+class _IterableInstance(object):
+    def __init__(self, it):
+        self._it = it
+    def __call__(self):
+        return self._it

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -7,6 +7,7 @@ import inspect
 import pickle
 import base64
 import streamsx.topology.dependency
+import streamsx.topology.functions
 import streamsx.topology.param
 from streamsx.topology.schema import CommonSchema
 from streamsx.topology.schema import _stream_schema
@@ -46,8 +47,12 @@ class SPLGraph(object):
             op = SPLInvocation(len(self.operators), kind, function, name, params, self)
         self.operators.append(op)
         if not function is None:
-            if not inspect.isbuiltin(function):
-                self.resolver.add_dependencies(inspect.getmodule(function))
+            dep_instance = function
+            if isinstance(function, streamsx.topology.functions._IterableInstance):
+                dep_instance = type(function._it)
+
+            if not inspect.isbuiltin(dep_instance):
+                self.resolver.add_dependencies(inspect.getmodule(dep_instance))
         return op
     
     def addPassThruOperator(self):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -274,3 +274,4 @@ def dict_in__pickle_iter(callable):
             return None
         return _PickleIterator(irv)
     return _wf
+

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -22,6 +22,7 @@ import threading
 import queue
 import sys
 import time
+import inspect
 from platform import python_version
 from enum import Enum
 
@@ -62,6 +63,13 @@ class Topology(object):
         Returns:
             A Stream whose tuples are the result of the output obtained by invoking the provided callable.
         """
+        if inspect.isroutine(func):
+             pass
+        elif callable(func):
+             pass
+        else:
+             func = streamsx.topology.functions._IterableInstance(func)
+        
         op = self.graph.addOperator(self.opnamespace+"::PyFunctionSource", func)
         oport = op.addOutputPort()
         return Stream(self, oport)


### PR DESCRIPTION
Simplify a source by not requiring a function but instead passing an iterable instance.

E.g.

```
# Passing an iterable from itertools
topo.source(itertools.count())

# Passing a collection
topo.source(["Hello", 2", "the", "World"])
```