### PR TITLE
Support lambda functions

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/functions.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/functions.py
@@ -28,3 +28,13 @@ class _IterableInstance(object):
         self._it = it
     def __call__(self):
         return self._it
+
+# Wraps an callable instance 
+# When this is called, the callable is called.
+# Used to wrap a lambda object
+class _Callable(object):
+    def __init__(self, callable):
+        self._callable = callable
+    def __call__(self, *args, **kwargs):
+        return self._callable.__call__(*args, **kwargs)
+

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -1,10 +1,17 @@
 # Licensed Materials - Property of IBM
-# Copyright IBM Corp. 2015
+# Copyright IBM Corp. 2015,2016
 
 import uuid
 import json
 import inspect
 import pickle
+
+try:
+    import dill
+except ImportError:
+    dill = pickle
+
+import types
 import base64
 import streamsx.topology.dependency
 import streamsx.topology.functions
@@ -201,6 +208,10 @@ class SPLInvocation(object):
             return None
         if not hasattr(function, "__call__"):
             raise "argument to _addOperatorFunction is not callable"
+
+        # Wrap a lambda as a callable class instance
+        if isinstance(function, types.LambdaType) and function.__name__ == "<lambda>" :
+            function = streamsx.topology.functions._Callable(function)
                  
         if inspect.isroutine(function):
             # callable is a function
@@ -208,8 +219,8 @@ class SPLInvocation(object):
         else:
             # callable is a callable class instance
             self.params["pyName"] = function.__class__.__name__
-            # pickle format is binary; base64 encode so it is json serializable 
-            self.params["pyCallable"] = base64.b64encode(pickle.dumps(function)).decode("ascii")
+            # dill format is binary; base64 encode so it is json serializable 
+            self.params["pyCallable"] = base64.b64encode(dill.dumps(function)).decode("ascii")
 
         # note: functions in the __main__ module cannot be used as input to operations 
         # function.__module__ will be '__main__', so C++ operators cannot import the module

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -2,6 +2,12 @@
 # Copyright IBM Corp. 2016
 import os
 import pickle
+
+try:
+    import dill
+except ImportError:
+    dill = pickle
+
 import base64
 import sys
 import json
@@ -72,7 +78,7 @@ def _getCallable(f):
     if callable(f):
         return f
     if isinstance(f, str):
-        ci = pickle.loads(base64.b64decode(f))
+        ci = dill.loads(base64.b64decode(f))
         if callable(ci):
             return ci
     return None


### PR DESCRIPTION
Using `dill` I found it easy to support lambda expressions. Basically dill is used to pickle and unpickle the callable but we wrap the lambda object in an instance of a class we provide. By wrapping it we do not have to modify any execution code, as the operators receive an instance of a callable class (`pyCallable`) that will call the de-pickled lamba object.

There most likely are issues with not tracking dependencies from the lamba, but it works for a topology like:

```
    hw = topo.source(("H1", "A", "H2"))
    hw = hw.filter(lambda t : t.startswith("H"))
```

Another step in making it easier to write applications in Jupyter notebooks.

If `dill` is installed then it is always used to pickle the pyCallable. Tuples are still pickled using regular pickle.

If `dill` is not installed then pyCallable is picked using regular pickle and lambdas will not be supported. This maintains backwards compatibility.

`dill` is a BSD licence and is installed in anaconda by default.
