### PR TITLE
add __init__.py for python 2

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/__init__.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/test/python/topology/test_build_archive.py
+++ b/test/python/topology/test_build_archive.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
 import unittest


### PR DESCRIPTION
Created opt/python/packages/streamsx/__init__.py
with this line
   __path__ = extend_path(__path__, __name__) 

I do not think the __path__ extend line is necessary because I also tried this with an empty file. 

I tested with both anaconda2 and anaconda3 using standard tests (decorated and api) 
and a package of mine in directory opt/python/packages/streamsx

 