### PR TITLE
do not include anaconda pre-loaded packages in SAB

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -87,7 +87,7 @@ def submit(ctxtype, graph, config = None, username = None, password = None, rest
     # Allows a graph or topology to be passed
     graph = graph.graph
 
-    fj = _createFullJSON(graph, config, os.path.dirname(pythondir))
+    fj = _createFullJSON(graph, config)
     fn = _createJSONFile(fj)
 
     # Create connection to SWS
@@ -111,10 +111,10 @@ def submit(ctxtype, graph, config = None, username = None, password = None, rest
         _delete_json(fn)
         raise
 
-def _createFullJSON(graph, config, pythondir):
+def _createFullJSON(graph, config):
     fj = {}
     fj["deploy"] = config
-    fj["graph"] = graph.generateSPLGraph(pythondir)
+    fj["graph"] = graph.generateSPLGraph()
     return fj
    
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -87,7 +87,7 @@ def submit(ctxtype, graph, config = None, username = None, password = None, rest
     # Allows a graph or topology to be passed
     graph = graph.graph
 
-    fj = _createFullJSON(graph, config)
+    fj = _createFullJSON(graph, config, os.path.dirname(pythondir))
     fn = _createJSONFile(fj)
 
     # Create connection to SWS
@@ -111,10 +111,10 @@ def submit(ctxtype, graph, config = None, username = None, password = None, rest
         _delete_json(fn)
         raise
 
-def _createFullJSON(graph, config):
+def _createFullJSON(graph, config, pythondir):
     fj = {}
     fj["deploy"] = config
-    fj["graph"] = graph.generateSPLGraph()
+    fj["graph"] = graph.generateSPLGraph(pythondir)
     return fj
    
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -30,6 +30,7 @@ class SPLGraph(object):
         self.operators = []
         self.resolver = streamsx.topology.dependency._DependencyResolver()
         self._views = []
+        self._pythondir = ""
 
     def get_views(self):
         return self._views
@@ -70,7 +71,8 @@ class SPLGraph(object):
         self.operators.append(op)
         return op
 
-    def generateSPLGraph(self):
+    def generateSPLGraph(self, pythondir):
+        self._pythondir = pythondir
         _graph = {}
         _graph["name"] = self.name
         _graph["namespace"] = self.name
@@ -88,18 +90,29 @@ class SPLGraph(object):
    
     def addPackages(self, includes):
         for package_path in self.resolver.packages:
-           mf = {}
-           mf["source"] = package_path
-           mf["target"] = "opt/python/packages"
-           includes.append(mf)
+          if self._include_source(package_path):
+             mf = {}
+             mf["source"] = package_path
+             mf["target"] = "opt/python/packages"
+             includes.append(mf)
 
     def addModules(self, includes):
         for module_path in self.resolver.modules:
-           mf = {}
-           mf["source"] = module_path
-           mf["target"] = "opt/python/modules"
-           includes.append(mf)
-           
+          if self._include_source(package_path):
+             mf = {}
+             mf["source"] = module_path
+             mf["target"] = "opt/python/modules"
+             includes.append(mf)
+
+    def _include_source(self, package_path):         
+      if not "/anaconda" in self._pythondir:
+        return True
+
+      if not package_path.startswith(self._pythondir):
+        return True
+
+      return False
+
     def getLastOperator(self):
         return self.operators[len(self.operators) -1]      
         

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -1,6 +1,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2015,2016
 
+import sys
 import uuid
 import json
 import inspect
@@ -105,7 +106,7 @@ class SPLGraph(object):
              includes.append(mf)
 
     def _include_source(self, package_path):         
-      if not "/anaconda" in self._pythondir:
+      if not "Anaconda" in sys.version:
         return True
 
       if not package_path.startswith(self._pythondir):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -31,7 +31,6 @@ class SPLGraph(object):
         self.operators = []
         self.resolver = streamsx.topology.dependency._DependencyResolver()
         self._views = []
-        self._pythondir = ""
 
     def get_views(self):
         return self._views
@@ -72,8 +71,7 @@ class SPLGraph(object):
         self.operators.append(op)
         return op
 
-    def generateSPLGraph(self, pythondir):
-        self._pythondir = pythondir
+    def generateSPLGraph(self):
         _graph = {}
         _graph["name"] = self.name
         _graph["namespace"] = self.name
@@ -91,28 +89,17 @@ class SPLGraph(object):
    
     def addPackages(self, includes):
         for package_path in self.resolver.packages:
-          if self._include_source(package_path):
-             mf = {}
-             mf["source"] = package_path
-             mf["target"] = "opt/python/packages"
-             includes.append(mf)
+           mf = {}
+           mf["source"] = package_path
+           mf["target"] = "opt/python/packages"
+           includes.append(mf)
 
     def addModules(self, includes):
         for module_path in self.resolver.modules:
-          if self._include_source(package_path):
-             mf = {}
-             mf["source"] = module_path
-             mf["target"] = "opt/python/modules"
-             includes.append(mf)
-
-    def _include_source(self, package_path):         
-      if not "Anaconda" in sys.version:
-        return True
-
-      if not package_path.startswith(self._pythondir):
-        return True
-
-      return False
+           mf = {}
+           mf["source"] = module_path
+           mf["target"] = "opt/python/modules"
+           includes.append(mf)
 
     def getLastOperator(self):
         return self.operators[len(self.operators) -1]      

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -19,17 +19,18 @@ import streamsx.topology.functions
 import streamsx.topology.param
 from streamsx.topology.schema import CommonSchema
 from streamsx.topology.schema import _stream_schema
+from streamsx.topology.topologypackages import TopologyPackages
 
 class SPLGraph(object):
 
-    def __init__(self, name=None):
+    def __init__(self, name=None, packages=None):
         if name is None:
             name = str(uuid.uuid1()).replace("-", "")
         # Allows Topology or SPLGraph to be passed to submit
         self.graph = self
         self.name = name
         self.operators = []
-        self.resolver = streamsx.topology.dependency._DependencyResolver()
+        self.resolver = streamsx.topology.dependency._DependencyResolver(packages)
         self._views = []
 
     def get_views(self):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -16,6 +16,7 @@ except (ImportError,NameError):
 import random
 from streamsx.topology import graph
 from streamsx.topology import schema
+from streamsx.topology import topologypackages
 import streamsx.topology.functions
 import json
 import threading
@@ -25,7 +26,6 @@ import time
 import inspect
 from platform import python_version
 from enum import Enum
-
 
 class Topology(object):
     """Topology that contains graph + operators"""
@@ -38,7 +38,8 @@ class Topology(object):
           self.opnamespace = "com.ibm.streamsx.topology.functional.python2"
         else:
           raise ValueError("Python version not supported.")
-        self.graph = graph.SPLGraph(name)
+        self.dependent_packages = topologypackages.TopologyPackages()
+        self.graph = graph.SPLGraph(name, self.dependent_packages)
         if files is not None:
             self.files = files
         else:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topologypackages.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topologypackages.py
@@ -1,0 +1,35 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from builtins import range
+try:
+  from future import standard_library
+  standard_library.install_aliases()
+except (ImportError,NameError):
+  # nothing to do here
+  pass 
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015
+
+import sys 
+
+class TopologyPackages(object):
+  def __init__(self): 
+    self._conda_packages_to_exclude = set(["numpy", "scipy", "matplotlib", "h5py"])
+    self.include_packages = set() 
+    self._conda = "Anaconda" in sys.version
+    if "Anaconda" in sys.version:
+      self.exclude_packages = self._conda_packages_to_exclude
+    else: 
+      self.exclude_packages = set() 
+
+  def add_excluded_packages(self, packages):
+    # place holder for future
+    True
+
+  def add_included_packages(self, packages):
+    # place holder for future
+    True
+


### PR DESCRIPTION
if the running python directory indicates anaconda is being used then exclude from the SAB packages/modules that reside in the anaconda installation tree