### PR TITLE
making WindowDefinition.addInput public for Beam Runner

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/core/WindowDefinition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/WindowDefinition.java
@@ -148,7 +148,7 @@ public class WindowDefinition<T,K> extends TopologyItem implements TWindow<T,K> 
         return params;
     }
 
-    private BInputPort addInput(BOperatorInvocation aggOp,
+    public BInputPort addInput(BOperatorInvocation aggOp,
             StreamWindow.Policy triggerPolicy, Object triggerConfig, TimeUnit triggerTimeUnit) {
         BInputPort bi = stream.connectTo(aggOp, true, null);
         


### PR DESCRIPTION
Streams [Beam runner](https://github.ibm.com/streams/streams.beamrunner/tree/v1) needs to access the addInput API to [connect windows to operators](https://github.ibm.com/streams/streams.beamrunner/blob/v1/src/main/java/com/ibm/streams/beamrunner/topology/internal/core/TStreamOps.java#L81).