### PR TITLE
Add support for sparse tuples.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -785,20 +785,63 @@ When a list of Python tuples is returned, each Python tuple is converted to an S
 
 The values of a Python tuple are assigned to an output SPL tuple by position, so the first value in the Python tuple is assigned to the first attribute in the SPL tuple.
 
+    # SPL input schema: tuple<int32 x, float64 y>
     # SPL output schema: tuple<int32 x, float64 y, float32 z>
     \@spl.pipe
     def myfunc(a,b):
-       return a,b,a+b
+       return (a,b,a+b)
 
     # The SPL output will be:
-    # x is set to: a
-    # y is set to: b 
-    # z is set to: a+b
+    # All values explictly set by returned Python tuple
+    # based on the x,y values from the input tuple
+    # x is set to: x 
+    # y is set to: y
+    # z is set to: x+y
+
+The returned tuple may be *sparse*, any attribute value in the tuple
+that is `None` will be set to their SPL default or copied from the input tuple, depending on the operator type.
+    
+    # SPL input schema: tuple<int32 x, float64 x>
+    # SPL output schema: tuple<int32 x, float64 y, float32 z>
+    \@spl.pipe
+    def myfunc(a,b):
+       return (a,None,a+b)
+
+    # The SPL output will be:
+    # x is set to: x (explictly set by returned Python tuple)
+    # y is set to: y (set by matching input SPL attribute)
+    # z is set to: x+y
 
 When a returned tuple has less values than attributes in the SPL output schema the attributes not set by the Python function will be set to their SPL default or copied from the input tuple, depending on the operator type.
+    
+    # SPL input schema: tuple<int32 x, float64 x>
+    # SPL output schema: tuple<int32 x, float64 y, float32 z>
+    \@spl.pipe
+    def myfunc(a,b):
+       return a,
+
+    # The SPL output will be:
+    # x is set to: x (explictly set by returned Python tuple)
+    # y is set to: y (set by matching input SPL attribute)
+    # z is set to: 0 (default int32 value)
 
 When a returned tuple has more values than attributes in the SPL output schema then the additional values are ignored.
 
+    # SPL input schema: tuple<int32 x, float64 x>
+    # SPL output schema: tuple<int32 x, float64 y, float32 z>
+    \@spl.pipe
+    def myfunc(a,b):
+       return (a,b,a+b,a/b)
+
+    # The SPL output will be:
+    # All values explictly set by returned Python tuple
+    # based on the x,y values from the input tuple
+    # x is set to: x
+    # y is set to: y
+    # z is set to: x+y
+    #
+    # The fourth value in the tuple a/b = x/y is ignored.
+ 
 ++ Supported SPL types
 
 A limited set of SPL types are supported.

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
@@ -17,6 +17,10 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
   Py_ssize_t frs = PyTuple_Size(pyTuple); 
     
 <%
+  if (defined $iport) {
+    print 'bool setAttr = false;';
+  }
+
   for (my $ai = 0; $ai < $oport->getNumberOfAttributes(); ++$ai) {
     
     my $attribute = $oport->getAttributeAt($ai);
@@ -46,11 +50,18 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
       $atype = "list";
     }
 
+    if (defined $iport) {
+             print 'setAttr = false;';
+    }
 %>
     if (<%=$ai%> < frs) {
          // Value from the Python function
          PyObject *pyAttrValue = PyTuple_GET_ITEM(pyTuple, <%=$ai%>);
+         if (pyAttrValue != Py_None) {
 <%
+    if (defined $iport) {
+             print 'setAttr = true;';
+    }
 
     my $ce = "__ERROR__";
 	     if ($atype eq 'list') {
@@ -84,6 +95,7 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
 	     
 %>
       otuple.set_<%=$name%>(<%=$ce%>);
+      }
    }
 <%
     if (defined $iport) {
@@ -93,7 +105,7 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
     if (defined $matchInputAttr) {
        if ($matchInputAttr->getSPLType() eq $attribute->getSPLType()) {
 %>
-    else {
+    if (!setAttr) {
       // value from the input attribute
       otuple.set_<%=$name%>(ituple.get_<%=$name%>());
     }

--- a/test/python/spl/testtkpy/opt/python/streams/test_map.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_map.py
@@ -26,3 +26,11 @@ class OffByOne:
             rv = (rv["a"], rv["b"], rv["vl"])
         self.last = tuple
         return rv
+
+@spl.map()
+class SparseTupleMap:
+    def __init__(self):
+       pass
+
+    def __call__(self, *t):
+        return (t[0]+81, 23, None, None, 34) 

--- a/test/python/spl/testtkpy/opt/python/streams/test_source.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_source.py
@@ -41,3 +41,14 @@ class SpecificValues:
            {'abc':35320, 'многоязычных':-236325}
            )
         return itertools.repeat(rv, 1)
+
+@spl.source()
+class SparseTuple:
+    def __init__(self):
+        pass
+
+    def __iter__(self):
+        rv = (
+           37, None, None, -46
+           )
+        return itertools.repeat(rv, 1)


### PR DESCRIPTION
For decorated SPL python operators the returned tuple may contain `None` in an attribute position that results in the SPL attribute being set from the input tuple or set to to its default value.