### PR TITLE
Add error checking, and improve streamsx.utility REST copy.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,8 +19,9 @@
       <arg value="clone"/>
       <arg value="https://github.com/IBMStreams/streamsx.utility.git"/>
    </exec>
-    <copy file="streamsx.utility/python/packages/streamsx/rest.py"
-      todir="${streamsx.py}"/>
+    <copy todir="${streamsx.py}">
+      <fileset dir="streamsx.utility/python/packages/streamsx" excludes="**/__init__.py"/>
+    </copy>
    <delete dir="streamsx.utility"/>
   </target>
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -294,8 +294,11 @@ class _DistributedSubmitter(_BaseSubmitter):
     def __init__(self, ctxtype, config, app_topology, username, password):
         _BaseSubmitter.__init__(self, ctxtype, config, app_topology)
 
-        # If a username or password isn't supplied, don't attempt to retrieve view data.
-        if username is None or password is None:
+        # If a username or password isn't supplied, don't attempt to retrieve view data, but throw an error if views
+        # were created
+        if (username is None or password is None) and len(app_topology.get_views()) > 0:
+            raise ValueError("To access views data, both a username and a password must be supplied when submitting.")
+        elif username is None or password is None:
             return
         try:
             process = subprocess.Popen(['streamtool', 'geturl', '--api'],
@@ -394,8 +397,7 @@ class UnsupportedContextException(Exception):
     def __init__(self, msg):
         Exception.__init__(self, msg)
 
-@enum.unique
-class ContextTypes(enum.Enum):
+class ContextTypes:
     """
         Types of submission contexts:
 
@@ -428,8 +430,7 @@ class ContextTypes(enum.Enum):
     JUPYTER = 'JUPYTER'
 
 
-@enum.unique
-class ConfigParams(enum.Enum):
+class ConfigParams:
     """
     Configuration options which may be used as keys in the submit's config parameter.
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -500,9 +500,10 @@ class View(threading.Thread):
     def initialize_rest(self):
         if not self.is_rest_initialized:
             if self.streams_context_config['username'] is None or \
-               self.streams_context_config['password'] is None:
+               self.streams_context_config['password'] is None or \
+               self.streams_context_config['rest_api_url'] is None:
                 raise ValueError(
-                    "WARNING: Both a username and password must be supplied when submitting a job in order to access view data")
+                    "WARNING: A username, a password, and a rest url must be present in order to access view data")
             from streamsx import rest
             rc = rest.StreamsContext(self.streams_context_config['username'],
                                      self.streams_context_config['password'],


### PR DESCRIPTION
When streamsx.utility is cloned to obtain rest.py, it currently only copies rest.py. It has now been updated to copy everything from the directory except __init__.py, as this allows for also copying support modules which could be added later.

Additionally, additional error checking has been added regarding supplying a username/password for retrieving view data via REST.