### PR TITLE
Use templated functions rather than code generation.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionMultiTransform/PyFunctionMultiTransform_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/PyFunctionMultiTransform/PyFunctionMultiTransform_cpp.cgt
@@ -82,7 +82,7 @@ print splpy_inputtuple2value($pystyle);
 
     streamsx::topology::PyGILLock lock;
     // convert spl attribute to python object
-    PyObject * pyArg = streamsx::topology::pyAttributeToPyObject(value);
+    PyObject * pyArg = streamsx::topology::pySplValueToPyObject(value);
 
     PyObject * pyIterator = streamsx::topology::Splpy::pyTupleFunc(function_, pyArg);
 

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -120,22 +120,11 @@ sub cppToPythonMapConversion {
       return "streamsx::topology::pySplMapToPyDict($iv);";
 }
 
+# Returns a string that can be used as an assignment statement
 sub cppToPythonSetConversion {
       my ($iv, $type) = @_;
 
-      my $element_type = SPL::CodeGen::Type::getElementType($type);
-
-      $get = "PySet_New(NULL);\n";
-
-      my $loop = "for(std::tr1::unordered_set<SPL::$element_type>::const_iterator it = $iv.begin();\n";
-      $loop = $loop . "it!=$iv.end(); it++){\n";
-      $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("*it", $element_type) . ";\n";
-      $loop = $loop . "PySet_Add(pyValue, v);\n";
-      $loop = $loop . "Py_DECREF(v);\n";
-      $loop = $loop . "}";
-      $get = $get . $loop;
-
-      return $get;
+      return "streamsx::topology::pySplSetToPySet($iv);";
 }
 
 #

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -105,26 +105,26 @@ sub pythonToCppPrimitiveConversion{
   }
 }
 
-# Returns a string that can be used as an assignment statement
+# Returns a string with the C++ expression
 sub cppToPythonListConversion {
 
     my ($iv, $type) = @_;
 
-    return "streamsx::topology::pySplListToPyList($iv);";
+    return "streamsx::topology::pySplListToPyList($iv)";
 }
 
-# Returns a string that can be used as an assignment statement
+# Returns a string with the C++ expression
 sub cppToPythonMapConversion {
       my ($iv, $type) = @_;
 
-      return "streamsx::topology::pySplMapToPyDict($iv);";
+      return "streamsx::topology::pySplMapToPyDict($iv)";
 }
 
-# Returns a string that can be used as an assignment statement
+# Returns a string with the C++ expression
 sub cppToPythonSetConversion {
       my ($iv, $type) = @_;
 
-      return "streamsx::topology::pySplSetToPySet($iv);";
+      return "streamsx::topology::pySplSetToPySet($iv)";
 }
 
 #
@@ -140,11 +140,13 @@ sub convertToPythonValue {
   # input value
   my $iv = $ituple . ".get_" . $name . "()";
 
-  return convertToPythonValueFromExpr($type, $iv);
+  return convertToPythonValueFromExpr($type, $iv) . ";\n";
 }
 
 ##
 ## Convert to a Python value from an expression
+## Returns a string with a C++ expression
+## representing the Python value
 ##
 sub convertToPythonValueFromExpr {
   my $type = $_[0];

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -16,10 +16,10 @@ sub cppToPythonPrimitiveConversion{
     my $supported = 0;
 
     if(SPL::CodeGen::Type::isSigned($type)) {
-      return "PyLong_FromLong($convert_from_string)";
+      $supported = 1;
     } 
     elsif(SPL::CodeGen::Type::isUnsigned($type)) {
-      return "PyLong_FromUnsignedLong($convert_from_string)";
+      $supported = 1;
     } 
     elsif(SPL::CodeGen::Type::isFloatingpoint($type)) {
       $supported = 1;
@@ -105,43 +105,19 @@ sub pythonToCppPrimitiveConversion{
   }
 }
 
+# Returns a string that can be used as an assignment statement
 sub cppToPythonListConversion {
 
     my ($iv, $type) = @_;
 
-      my $element_type = SPL::CodeGen::Type::getElementType($type);
-
-      my $size = $iv . ".size()";
-      my $get = "PyList_New($size);\n";
-
-      my $loop = "for(int i = 0; i < $size; i++){\n";
-      $loop = $loop . "PyObject *o =" . cppToPythonPrimitiveConversion("($iv)[i]", $element_type) . ";\n";      
-      $loop = $loop . "PyList_SetItem(pyValue, i, o);\n";
-      $loop = $loop . "}\n";
-
-      $get = $get . $loop;
-      return $get;
+    return "streamsx::topology::pySplListToPyList($iv);";
 }
 
+# Returns a string that can be used as an assignment statement
 sub cppToPythonMapConversion {
       my ($iv, $type) = @_;
 
-      my $key_type = SPL::CodeGen::Type::getKeyType($type);
-      my $value_type = SPL::CodeGen::Type::getValueType($type);
-
-      my $get = "PyDict_New();\n";
-
-      my $loop = "for(std::tr1::unordered_map<SPL::$key_type,SPL::$value_type>::const_iterator it = $iv.begin();\n";
-      $loop = $loop . "it!=$iv.end(); it++){\n";
-      $loop = $loop . "PyObject *k = " . cppToPythonPrimitiveConversion("it->first", $key_type) . ";\n";
-      $loop = $loop . "PyObject *v = " . cppToPythonPrimitiveConversion("it->second", $value_type) . ";\n";
-      $loop = $loop . "PyDict_SetItem(pyValue, k, v);\n";
-      $loop =  $loop . "  Py_DECREF(k);\n";
-      $loop =  $loop . "  Py_DECREF(v);\n";
-      $loop = $loop . "}";
-      $get = $get . $loop;
-
-      return $get;
+      return "streamsx::topology::pySplMapToPyDict($iv);";
 }
 
 sub cppToPythonSetConversion {

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -38,7 +38,7 @@ sub cppToPythonPrimitiveConversion{
     }
 
     if ($supported == 1) {
-      return "streamsx::topology::pyAttributeToPyObject($convert_from_string)";
+      return "streamsx::topology::pySplValueToPyObject($convert_from_string)";
     }
     else{
       SPL::CodeGen::errorln("An unknown type was encountered when converting to python types." . $type ); 
@@ -110,21 +110,21 @@ sub cppToPythonListConversion {
 
     my ($iv, $type) = @_;
 
-    return "streamsx::topology::pySplListToPyList($iv)";
+    return "streamsx::topology::pySplValueToPyObject($iv)";
 }
 
 # Returns a string with the C++ expression
 sub cppToPythonMapConversion {
       my ($iv, $type) = @_;
 
-      return "streamsx::topology::pySplMapToPyDict($iv)";
+      return "streamsx::topology::pySplValueToPyObject($iv)";
 }
 
 # Returns a string with the C++ expression
 sub cppToPythonSetConversion {
       my ($iv, $type) = @_;
 
-      return "streamsx::topology::pySplSetToPySet($iv)";
+      return "streamsx::topology::pySplValueToPyObject($iv)";
 }
 
 #

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -4,9 +4,12 @@
 */
 
 /*
- * Compile using the stable abi assuming 3.5.
- * https://docs.python.org/3/c-api/stable.html
+ * Internal header file supporting Python
+ * for com.ibm.streamsx.topology.
  *
+ * This is not part of any public api for
+ * the toolkit or toolkit with decorated
+ * SPL Python operators.
  */
 
 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -102,10 +102,10 @@ namespace streamsx {
     /*
     ** Conversion of Python objects to SPL attributes.
     */
-
     template <class T>
-    inline void pyAttributeFromPyObject(T & attr, PyObject *);
-    
+       inline void pyAttributeFromPyObject(T & attr, PyObject *);
+
+
     /*
     ** Convert to a SPL blob from a Python bytes object.
     */
@@ -195,29 +195,102 @@ namespace streamsx {
     ** Conversion of SPL attributes or value to Python objects
     */
 
+    /**
+     * Integer conversions.
+    */
+
+    inline PyObject * pySplValueToPyObject(const SPL::int32 & value) {
+      return PyLong_FromLong(value);
+    }
+    inline PyObject * pySplValueToPyObject(const SPL::int64 & value) {
+      return PyLong_FromLong(value);
+    }
+    inline PyObject * pySplValueToPyObject(const SPL::uint32 & value) {
+      return PyLong_FromUnsignedLong(value);
+    }
+    inline PyObject * pySplValueToPyObject(const SPL::uint64 & value) {
+      return PyLong_FromUnsignedLong(value);
+    }
+
+    /**
+     * Convert a SPL blob into a Python Memory view object.
+     */
+    inline PyObject * pySplValueToPyObject(const SPL::blob & value) {
+      long int sizeb = value.getSize();
+      const unsigned char * bytes = value.getData();
+
+      return GET_PYTHON_ATTR_FROM_MEMORY(bytes, sizeb);
+    }
+
+    /**
+     * Convert a SPL rstring into a Python Unicode string 
+     */
+    inline PyObject * pySplValueToPyObject(const SPL::rstring & value) {
+      long int sizeb = value.size();
+      const char * pybytes = value.data();
+
+      return PyUnicode_DecodeUTF8(pybytes, sizeb, NULL);
+    }
+    /**
+     * Convert a SPL ustring into a Python Unicode string 
+     */
+    inline PyObject * pySplValueToPyObject(const SPL::ustring & value) {
+      long int sizeb = value.length() * 2; // Need number of bytes
+      const char * pybytes =  (const char*) (value.getBuffer());
+
+      return PyUnicode_DecodeUTF16(pybytes, sizeb, NULL, NULL);
+    }
+
+    inline PyObject * pySplValueToPyObject(const SPL::complex32 & value) {
+       return PyComplex_FromDoubles(value.real(), value.imag());
+    }
+    inline PyObject * pySplValueToPyObject(const SPL::complex64 & value) {
+       return PyComplex_FromDoubles(value.real(), value.imag());
+    }
+
+    inline PyObject * pySplValueToPyObject(const SPL::boolean & value) {
+       PyObject * pyValue = value ? Py_True : Py_False;
+       Py_INCREF(pyValue);
+       return pyValue;
+    }
+    inline PyObject * pySplValueToPyObject(const SPL::float32 & value) {
+       return PyFloat_FromDouble(value);
+    }
+    inline PyObject * pySplValueToPyObject(const SPL::float64 & value) {
+       return PyFloat_FromDouble(value);
+    }
+
+    /**
+     * Convert a PyObject to a PyObject by simply returning the value
+     * nb. that if object has it ref count decremented to 0 the 
+     * "copied" pointer is no longer valid
+     */
+    inline PyObject * pySplValueToPyObject(PyObject * object) {
+      return object;
+    }
 
     /*
-    ** SPL List Conversion to Python objects
+    ** SPL List Conversion to Python list
     */
     template <typename T>
-    inline PyObject * pySplListToPyList(const SPL::list<T> & l) {
+    inline PyObject * pySplValueToPyObject(const SPL::list<T> & l) {
         PyObject * pyList = PyList_New(l.size());
         for (int i = 0; i < l.size(); i++) {
-            PyList_SET_ITEM(pyList, i, pyAttributeToPyObject(l[i]));
+            PyList_SET_ITEM(pyList, i, pySplValueToPyObject(l[i]));
         }
         return pyList;
     }
 
     /*
-    ** SPL Map Conversion to Python objects
+    ** SPL Map Conversion to Python dict.
     */
     template <typename K, typename V>
-    inline PyObject * pySplMapToPyDict(const SPL::map<K,V> & m) {
+    inline PyObject * pySplValueToPyObject(const SPL::map<K,V> & m) {
         PyObject * pyDict = PyDict_New();
         for (typename std::tr1::unordered_map<K,V>::const_iterator it = m.begin();
              it != m.end(); it++) {
-             PyObject *k = pyAttributeToPyObject(it->first);
-             PyObject *v = pyAttributeToPyObject(it->second);
+             PyObject *k = pySplValueToPyObject(it->first);
+             PyObject *v = pySplValueToPyObject(it->second);
              PyDict_SetItem(pyDict, k, v);
              Py_DECREF(k);
              Py_DECREF(v);
@@ -227,106 +300,19 @@ namespace streamsx {
     }
 
     /*
-    ** SPL Set Conversion to Python objects
+    ** SPL Set Conversion to Python set
     */
     template <typename T>
-    inline PyObject * pySplSetToPySet(const SPL::set<T> & s) {
+    inline PyObject * pySplValueToPyObject(const SPL::set<T> & s) {
         PyObject * pySet = PySet_New(NULL);
         for (typename std::tr1::unordered_set<T>::const_iterator it = s.begin();
              it != s.end(); it++) {
-             PyObject * e = pyAttributeToPyObject(*it);
+             PyObject * e = pySplValueToPyObject(*it);
              PySet_Add(pySet, e);
              Py_DECREF(e);
         }
         return pySet;
     }
-
-    /**
-     * Integer conversions.
-    */
-
-    inline PyObject * pyAttributeToPyObject(const SPL::int32 & attr) {
-      return PyLong_FromLong(attr);
-    }
-    inline PyObject * pyAttributeToPyObject(const SPL::int64 & attr) {
-      return PyLong_FromLong(attr);
-    }
-    inline PyObject * pyAttributeToPyObject(const SPL::uint32 & attr) {
-      return PyLong_FromUnsignedLong(attr);
-    }
-    inline PyObject * pyAttributeToPyObject(const SPL::uint64 & attr) {
-      return PyLong_FromUnsignedLong(attr);
-    }
-
-    /**
-     * Convert a SPL blob into a Python Memory view object.
-     */
-    inline PyObject * pyAttributeToPyObject(const SPL::blob & attr) {
-      long int sizeb = attr.getSize();
-      const unsigned char * bytes = attr.getData();
-
-      return GET_PYTHON_ATTR_FROM_MEMORY(bytes, sizeb);
-    }
-
-    /**
-     * Convert a SPL rstring into a Python Unicode string 
-     */
-    inline PyObject * pyAttributeToPyObject(const SPL::rstring & attr) {
-      long int sizeb = attr.size();
-      const char * pybytes = attr.data();
-
-      return PyUnicode_DecodeUTF8(pybytes, sizeb, NULL);
-    }
-    /**
-     * Convert a SPL ustring into a Python Unicode string 
-     */
-    inline PyObject * pyAttributeToPyObject(const SPL::ustring & attr) {
-      long int sizeb = attr.length() * 2; // Need number of bytes
-      const char * pybytes =  (const char*) (attr.getBuffer());
-
-      return PyUnicode_DecodeUTF16(pybytes, sizeb, NULL, NULL);
-    }
-
-    inline PyObject * pyAttributeToPyObject(const SPL::complex32 & attr) {
-       return PyComplex_FromDoubles(attr.real(), attr.imag());
-    }
-    inline PyObject * pyAttributeToPyObject(const SPL::complex64 & attr) {
-       return PyComplex_FromDoubles(attr.real(), attr.imag());
-    }
-
-    inline PyObject * pyAttributeToPyObject(const SPL::boolean & attr) {
-       PyObject * value = attr ? Py_True : Py_False;
-       Py_INCREF(value);
-       return value;
-    }
-    inline PyObject * pyAttributeToPyObject(const SPL::float32 & attr) {
-       return PyFloat_FromDouble(attr);
-    }
-    inline PyObject * pyAttributeToPyObject(const SPL::float64 & attr) {
-       return PyFloat_FromDouble(attr);
-    }
-
-    /**
-     * Convert a PyObject to a PyObject by simply returning the value
-     * nb. that if object has it ref count decremented to 0 the 
-     * "copied" pointer is no longer valid
-     */
-    inline PyObject * pyAttributeToPyObject(PyObject * object) {
-      return object;
-    }
-
-/*
-
-    template <class T>
-    inline PyObject * pyAttributeToPyObjectT(T & attr);
-
-    inline PyObject * pyAttributeToPyObjectT(SPL::blob & attr) {
-        return pyAttributeToPyObject(attr);
-    }
-    inline PyObject * pyAttributeToPyObjectT(SPL::rstring & attr) {
-        return pyAttributeToPyObject(attr);
-    }
-*/
 
     class Splpy {
 
@@ -455,7 +441,7 @@ namespace streamsx {
     static void pyTupleSink(PyObject * function, T & splVal) {
       PyGILLock lock;
 
-      PyObject * arg = pyAttributeToPyObject(splVal);
+      PyObject * arg = pySplValueToPyObject(splVal);
 
       PyObject * pyReturnVar = pyTupleFunc(function, arg);
 
@@ -486,7 +472,7 @@ namespace streamsx {
 
       PyGILLock lock;
 
-      PyObject * arg = pyAttributeToPyObject(splVal);
+      PyObject * arg = pySplValueToPyObject(splVal);
 
       PyObject * pyReturnVar = pyTupleFunc(function, arg);
 
@@ -509,7 +495,7 @@ namespace streamsx {
     static int pyTupleTransform(PyObject * function, T & splVal, R & retSplVal) {
       PyGILLock lock;
 
-      PyObject * arg = pyAttributeToPyObject(splVal);
+      PyObject * arg = pySplValueToPyObject(splVal);
 
       // invoke python nested function that calls the application function
       PyObject * pyReturnVar = pyTupleFunc(function, arg);
@@ -534,7 +520,7 @@ namespace streamsx {
 
       PyGILLock lock;
 
-      PyObject * arg = pyAttributeToPyObject(splVal);
+      PyObject * arg = pySplValueToPyObject(splVal);
 
       // invoke python nested function that generates the int32 hash
       // clear any indication of an error and then check later for an 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -223,6 +223,21 @@ namespace streamsx {
         return pyDict;
     }
 
+    /*
+    ** SPL Set Conversion to Python objects
+    */
+    template <typename T>
+    inline PyObject * pySplSetToPySet(const SPL::set<T> & s) {
+        PyObject * pySet = PySet_New(NULL);
+        for (typename std::tr1::unordered_set<T>::const_iterator it = s.begin();
+             it != s.end(); it++) {
+             PyObject * e = pyAttributeToPyObject(*it);
+             PySet_Add(pySet, e);
+             Py_DECREF(e);
+        }
+        return pySet;
+    }
+
     /**
      * Integer conversions.
     */

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -189,9 +189,56 @@ namespace streamsx {
     /**************************************************************/
 
     /*
-    ** Conversion of SPL attributes to Python objects
+    ** Conversion of SPL attributes or value to Python objects
     */
 
+
+    /*
+    ** SPL List Conversion to Python objects
+    */
+    template <typename T>
+    inline PyObject * pySplListToPyList(const SPL::list<T> & l) {
+        PyObject * pyList = PyList_New(l.size());
+        for (int i = 0; i < l.size(); i++) {
+            PyList_SET_ITEM(pyList, i, pyAttributeToPyObject(l[i]));
+        }
+        return pyList;
+    }
+
+    /*
+    ** SPL Map Conversion to Python objects
+    */
+    template <typename K, typename V>
+    inline PyObject * pySplMapToPyDict(const SPL::map<K,V> & m) {
+        PyObject * pyDict = PyDict_New();
+        for (typename std::tr1::unordered_map<K,V>::const_iterator it = m.begin();
+             it != m.end(); it++) {
+             PyObject *k = pyAttributeToPyObject(it->first);
+             PyObject *v = pyAttributeToPyObject(it->second);
+             PyDict_SetItem(pyDict, k, v);
+             Py_DECREF(k);
+             Py_DECREF(v);
+        }
+      
+        return pyDict;
+    }
+
+    /**
+     * Integer conversions.
+    */
+
+    inline PyObject * pyAttributeToPyObject(const SPL::int32 & attr) {
+      return PyLong_FromLong(attr);
+    }
+    inline PyObject * pyAttributeToPyObject(const SPL::int64 & attr) {
+      return PyLong_FromLong(attr);
+    }
+    inline PyObject * pyAttributeToPyObject(const SPL::uint32 & attr) {
+      return PyLong_FromUnsignedLong(attr);
+    }
+    inline PyObject * pyAttributeToPyObject(const SPL::uint64 & attr) {
+      return PyLong_FromUnsignedLong(attr);
+    }
 
     /**
      * Convert a SPL blob into a Python Memory view object.

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
@@ -28,17 +28,17 @@
          my $tp = $model->getParameterAt($i);
 
          print '{';
-         print 'PyObject * pk = PyUnicode_DecodeUTF8((const char*)  "' . $tp->getName() . '", ((int)(sizeof("' . $tp->getName() . '")))-1 , NULL);';
+         print 'PyObject * param_key = PyUnicode_DecodeUTF8((const char*)  "' . $tp->getName() . '", ((int)(sizeof("' . $tp->getName() . '")))-1 , NULL);';
 
          # cardinality == 1
-         print 'PyObject * pv = ';
-         print convertToPythonValueFromExpr(
+         print 'PyObject * param_value = ' .
+              convertToPythonValueFromExpr(
                  $tp->getValueAt(0)->getSPLType(),
-                 $tp->getValueAt(0)->getCppExpression());
+                 $tp->getValueAt(0)->getCppExpression()) . ";\n";
 
-         print " PyDict_SetItem(param_dict, pk, pv);\n";
-         print " Py_DECREF(pk);\n";
-         print " Py_DECREF(pv);\n";
+         print " PyDict_SetItem(param_dict, param_key, param_value);\n";
+         print " Py_DECREF(param_key);\n";
+         print " Py_DECREF(param_value);\n";
          print "}\n";
      }
 %>

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonFunctionalOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonFunctionalOperatorsTest.java
@@ -138,9 +138,9 @@ public class PythonFunctionalOperatorsTest extends TestTopology {
         Condition<List<Tuple>> viaSPLResult = tester.tupleContents(viaSPL);
         Condition<List<Tuple>> viaPythonResult = tester.tupleContents(viaPython);
         
-        complete(tester, expectedCount, 10, TimeUnit.SECONDS);
+        complete(tester, expectedCount, 20, TimeUnit.SECONDS);
 
-        assertTrue(expectedCount.valid());
+        assertTrue(expectedCount.getResult().toString(), expectedCount.valid());
         assertEquals(viaSPLResult.getResult(), viaPythonResult.getResult());
     }
     


### PR DESCRIPTION
For conversion of SPL list, map and set to a Python object.

Easier to understand, debug etc.

Also results in being able to support any combination of list, map set and supported primitive types, .e.g. `list<list<float64>>`.