### PR TITLE
Support list,map& set of arbitrary types.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.python/namespace-info.spl
@@ -879,8 +879,9 @@ A limited set of SPL types are supported.
   * `complex32`, `complex64` - maps to Python `complex`
   * `rstring`, `ustring` - maps to Python `String` - `rstring` values assume UTF-8 encoding
  * **Collection types**
-  * `list<P>` where `P` is one of the supported primitive types. Passed into Python as a list.
-  * `map<K,V>` where `K` and `V` are supported primitive types. Passed into Python as a dictionary.
+  * `list<T>` where `T` is any supported type. Passed into Python as a list.
+  * `set<T>` where `T` is any supported primitive type. Passed into Python as a set. `T` must be primitive to match Python's requirement that an element of a set is hashable.
+  * `map<K,V>` where `K` is any supported primitive type and `V` is any supported type. Passed into Python as a dictionary.  `K` must be primitive to match Python's requirement that a key of a map is hashable.
 
 ++ \@spl decorator options
 \@spl decorators support an number of options.

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -6,17 +6,33 @@ sub splToPythonConversionCheck{
 
     my ($type) = @_;
 
-    if (SPL::CodeGen::Type::isList($type) || SPL::CodeGen::Type::isSet($type)) {
+    if (SPL::CodeGen::Type::isList($type)) {
         my $element_type = SPL::CodeGen::Type::getElementType($type);
         splToPythonConversionCheck($element_type);
         return;
     }
+    elsif (SPL::CodeGen::Type::isSet($type)) {
+        my $element_type = SPL::CodeGen::Type::getElementType($type);
+        # Python sets must have hashable keys
+        # (which excludes Python collection type such as list,map,set)
+        # so for now restrict to primitive types)
+        if (SPL::CodeGen::Type::isPrimitive($element_type)) {
+            splToPythonConversionCheck($element_type);
+            return;
+        }
+    }
     elsif (SPL::CodeGen::Type::isMap($type)) {
         my $key_type = SPL::CodeGen::Type::getKeyType($type);
-        my $value_type = SPL::CodeGen::Type::getValueType($type);
-        splToPythonConversionCheck($key_type);
-        splToPythonConversionCheck($value_type);
-        return;
+        # Python maps must have hashable keys
+        # (which excludes Python collection type such as list,map,set)
+        # so for now restrict to primitive types)
+        if (SPL::CodeGen::Type::isPrimitive($key_type)) {
+            splToPythonConversionCheck($key_type);
+
+           my $value_type = SPL::CodeGen::Type::getValueType($type);
+           splToPythonConversionCheck($value_type);
+           return;
+        }
     }
     elsif(SPL::CodeGen::Type::isSigned($type)) {
       return;
@@ -40,7 +56,7 @@ sub splToPythonConversionCheck{
       return;
     }
 
-    SPL::CodeGen::errorln("An unsupported SPL type was encountered when converting to python types. " . $type ); 
+    SPL::CodeGen::errorln("SPL type: " . $type . " is not supported for conversion to or from Python."); 
 }
 
 # Convert a Python type back to a

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -1,6 +1,6 @@
 
 # Check if a SPL type is supported for conversion
-# to a Python value.
+# to/from a Python value.
 #
 sub splToPythonConversionCheck{
 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -279,9 +279,8 @@ namespace streamsx {
         const Py_ssize_t size = PyList_Size(value);
 
         for (Py_ssize_t i = 0; i < size; i++) {
-            SPL::ValueHandle vhe = l.createElement();
-            l.add(vhe); // Add takes a copy of the value
-            vhe.deleteValue();
+            T se;
+            l.add(se); // Add takes a copy of the value
 
             PyObject * e = PyList_GET_ITEM(value, i);
             pySplValueFromPyObject(l.at(i), e);
@@ -294,15 +293,13 @@ namespace streamsx {
         PyObject *k,*v;
         Py_ssize_t pos = 0;
         while (PyDict_Next(value, &pos, &k, &v)) {
-           SPL::ValueHandle vhk = m.createKey();
-           K & sk = vhk;
+           K sk;
 
            // Set the SPL key
            pySplValueFromPyObject(sk, k);
 
            // map[] creates the value if it does not exist
            V & sv = m[sk];
-           vhk.deleteValue();
  
            // Set the SPL value 
            pySplValueFromPyObject(sv, v);

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -286,6 +286,26 @@ namespace streamsx {
             pySplValueFromPyObject(l.at(i), e);
         }
     }
+ 
+    // SPL set from Python set
+    template <typename T>
+    inline void pySplValueFromPyObject(SPL::set<T> & s, PyObject *value) {
+        // validates that value is a Python set
+        const Py_ssize_t size = PySet_Size(value);
+
+        PyObject * iterator = PyObject_GetIter(value);
+        if (iterator == 0) {
+            throw streamsx::topology::pythonException("iter(set)");
+        }
+        PyObject *item;
+        while (item = PyIter_Next(iterator)) {
+            T se;
+            pySplValueFromPyObject(se, item);
+            Py_DECREF(item);
+            s.add(se);
+        }
+        Py_DECREF(iterator);
+    }
 
     // SPL map from Python dictionary
     template <typename K, typename V>

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -175,49 +175,118 @@ namespace streamsx {
     }
 
     /*
-    ** Conversion of Python objects to SPL attributes.
+    ** Conversion of Python objects to SPL values.
     */
-    template <class T>
-       inline void pyAttributeFromPyObject(T & attr, PyObject *);
+    //inline PyObject * pySplValueToPyObject(const SPL::int32 & value) {
 
     /*
     ** Convert to a SPL blob from a Python bytes object.
     */
-    inline void pyAttributeFromPyObject(SPL::blob & attr, PyObject * value) {
+    inline void pySplValueFromPyObject(SPL::blob & splv, PyObject * value) {
       long int size = PyBytes_Size(value);
       char * bytes = PyBytes_AsString(value);          
-      attr.setData((const unsigned char *)bytes, size);
+      splv.setData((const unsigned char *)bytes, size);
     }
 
     /*
     ** Convert to a SPL rstring from a Python string object.
     */
-    inline void pyAttributeFromPyObject(SPL::rstring & attr, PyObject * value) {
-      if (pyRStringFromPyObject(attr, value) != 0) {
+    inline void pySplValueFromPyObject(SPL::rstring & splv, PyObject * value) {
+      if (pyRStringFromPyObject(splv, value) != 0) {
          SPLAPPTRC(L_ERROR, "Python can't convert to UTF-8!", "python");
          throw streamsx::topology::pythonException("rstring");
       }
     }
 
-    inline void pyAttributeFromPyObject(SPL::ustring & attr, PyObject * value) {
+    inline void pySplValueFromPyObject(SPL::ustring & splv, PyObject * value) {
          SPL::rstring rs;
-         pyAttributeFromPyObject(rs, value);
+         pySplValueFromPyObject(rs, value);
 
-         attr = SPL::ustring::fromUTF8(rs);
+         splv = SPL::ustring::fromUTF8(rs);
     }
 
     inline SPL::rstring pyRstringFromPyObject(PyObject * value)
     {
         SPL::rstring rs;
-        pyAttributeFromPyObject(rs, value);
+        pySplValueFromPyObject(rs, value);
         return rs ;
     }
     inline SPL::ustring pyUstringFromPyObject(PyObject * value)
     {
         SPL::ustring us;
-        pyAttributeFromPyObject(us, value);
+        pySplValueFromPyObject(us, value);
         return us ;
     }
+
+    // signed integers
+    inline void pySplValueFromPyObject(SPL::int8 & splv, PyObject * value) {
+       splv = (SPL::int8) PyLong_AsLong(value);
+    }
+    inline void pySplValueFromPyObject(SPL::int16 & splv, PyObject * value) {
+       splv = (SPL::int16) PyLong_AsLong(value);
+    }
+    inline void pySplValueFromPyObject(SPL::int32 & splv, PyObject * value) {
+       splv = (SPL::int32) PyLong_AsLong(value);
+    }
+    inline void pySplValueFromPyObject(SPL::int64 & splv, PyObject * value) {
+       splv = (SPL::int64) PyLong_AsLong(value);
+    }
+
+    // unsigned integers
+    inline void pySplValueFromPyObject(SPL::uint8 & splv, PyObject * value) {
+       splv = (SPL::uint8) PyLong_AsUnsignedLong(value);
+    }
+    inline void pySplValueFromPyObject(SPL::uint16 & splv, PyObject * value) {
+       splv = (SPL::uint16) PyLong_AsUnsignedLong(value);
+    }
+    inline void pySplValueFromPyObject(SPL::uint32 & splv, PyObject * value) {
+       splv = (SPL::uint32) PyLong_AsUnsignedLong(value);
+    }
+    inline void pySplValueFromPyObject(SPL::uint64 & splv, PyObject * value) {
+       splv = (SPL::uint64) PyLong_AsUnsignedLong(value);
+    }
+
+    // boolean
+    inline void pySplValueFromPyObject(SPL::boolean & splv, PyObject * value) {
+       splv = PyObject_IsTrue(value);
+    }
+ 
+    // floats
+    inline void pySplValueFromPyObject(SPL::float32 & splv, PyObject * value) {
+       splv = (SPL::float32) PyFloat_AsDouble(value);
+    }
+    inline void pySplValueFromPyObject(SPL::float64 & splv, PyObject * value) {
+       splv = PyFloat_AsDouble(value);
+    }
+
+    // complex
+    inline void pySplValueFromPyObject(SPL::complex32 & splv, PyObject * value) {
+        splv = SPL::complex32(
+          (SPL::float32) PyComplex_RealAsDouble(value),
+          (SPL::float32) PyComplex_ImagAsDouble(value)
+        );
+    }
+    inline void pySplValueFromPyObject(SPL::complex64 & splv, PyObject * value) {
+        splv = SPL::complex64(
+          (SPL::float64) PyComplex_RealAsDouble(value),
+          (SPL::float64) PyComplex_ImagAsDouble(value)
+        );
+    }
+
+    // list
+    /*
+    template <typename T>
+    inline void pySplValueFromPyObject(SPL::list<T> & l, PyObject *value) {
+        Py_ssize_t size = PyList_Size(value);
+
+        for (int i = 0; i < size; i++) {
+            PyObject e = PyList_GET_ITEM(value, i);
+            T se;
+            pySplValueFromPyObject(se, e);
+            l.add(se);
+        }
+    }
+    */
 
     /**************************************************************/
 
@@ -533,7 +602,7 @@ namespace streamsx {
          throw streamsx::topology::pythonException("transform");
       } 
 
-      pyAttributeFromPyObject(retSplVal, pyReturnVar);
+      pySplValueFromPyObject(retSplVal, pyReturnVar);
       Py_DECREF(pyReturnVar);
 
       return 1;

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
@@ -67,26 +67,32 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
 	     if ($atype eq 'list') {
 		 my $assign_string = pythonToCppPrimitiveConversion("PyList_GET_ITEM(pyAttrValue, i)", $element_type);
 		 %>
-		     SPL::list< <%=$element_type%> > li = SPL::list< <%=$element_type%> >(PyList_Size(pyAttrValue));
-		 for(int i = 0; i < li.size(); i++){
-		     li[i] = <%=$assign_string%>;
-		 }
+		  //   SPL::list< <%=$element_type%> > li = SPL::list< <%=$element_type%> >(PyList_Size(pyAttrValue));
+		 //for(int i = 0; i < li.size(); i++){
+		 //    li[i] = <%=$assign_string%>;
+		 //}
+                  streamsx::topology::pySplValueFromPyObject(
+                               otuple.get_<%=$name%>(), pyAttrValue);
 		 <%
 		     $ce = "li";
+                  $ce = "otuple.get_$name()";
 	     }
 	     
        elsif ($atype eq 'map') {
 		 my $key_assign_string = pythonToCppPrimitiveConversion("k", $key_type);
 		 my $value_assign_string = pythonToCppPrimitiveConversion("v", $value_type);
 		 %>
-		 SPL::map< <%=$key_type%>, <%=$value_type%> > ma = SPL::map< <%=$key_type%>, <%=$value_type%> >();
-		 PyObject *k,*v;
-		 Py_ssize_t pos = 0;
-		 while(PyDict_Next(pyAttrValue, &pos, &k, &v)){
-		     ma[ <%=$key_assign_string%> ] = <%=$value_assign_string%>;
-		 }
+                  streamsx::topology::pySplValueFromPyObject(
+                               otuple.get_<%=$name%>(), pyAttrValue);
+		 //SPL::map< <%=$key_type%>, <%=$value_type%> > ma = SPL::map< <%=$key_type%>, <%=$value_type%> >();
+		 //PyObject *k,*v;
+		 //Py_ssize_t pos = 0;
+		 //while(PyDict_Next(pyAttrValue, &pos, &k, &v)){
+		 //    ma[ <%=$key_assign_string%> ] = <%=$value_assign_string%>;
+		 //}
 		 <%
-		     $ce = "ma";
+		  #   $ce = "ma";
+                  $ce = "otuple.get_$name()";
 	     }
 	     else {
                   %>

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
@@ -26,6 +26,7 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
     my $attribute = $oport->getAttributeAt($ai);
     my $name = $attribute->getName();
     my $atype = $attribute->getSPLType();
+    splToPythonConversionCheck($atype);
     
     if (defined $iport) {
              print 'setAttr = false;';

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
@@ -27,29 +27,6 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
     my $name = $attribute->getName();
     my $atype = $attribute->getSPLType();
     
-    my $key_type = "";
-    my $value_type = "";
-    my $element_type = "";
-
-
-# For some reason, in the code generation API, getSPLType() does not
-# return a type, but string. As such, we need to use regex to extract
-# the list or map types.
-  
-    if($atype =~ m/^map.*/){
-      $atype =~ /.*<(.*),.*/;
-      $key_type = $1;
-      $atype =~ /.*,(.*)>/;
-      $value_type = $1;
-      $atype = "map";
-    }
-
-    if($atype =~ m/^list.*/){
-      $atype =~ /.*<(.*)>.*/;
-      $element_type = $1;
-      $atype = "list";
-    }
-
     if (defined $iport) {
              print 'setAttr = false;';
     }
@@ -58,57 +35,13 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
          // Value from the Python function
          PyObject *pyAttrValue = PyTuple_GET_ITEM(pyTuple, <%=$ai%>);
          if (pyAttrValue != Py_None) {
+                  streamsx::topology::pySplValueFromPyObject(
+                               otuple.get_<%=$name%>(), pyAttrValue);
 <%
     if (defined $iport) {
              print 'setAttr = true;';
     }
-
-    my $ce = "__ERROR__";
-	     if ($atype eq 'list') {
-		 my $assign_string = pythonToCppPrimitiveConversion("PyList_GET_ITEM(pyAttrValue, i)", $element_type);
-		 %>
-		  //   SPL::list< <%=$element_type%> > li = SPL::list< <%=$element_type%> >(PyList_Size(pyAttrValue));
-		 //for(int i = 0; i < li.size(); i++){
-		 //    li[i] = <%=$assign_string%>;
-		 //}
-                  streamsx::topology::pySplValueFromPyObject(
-                               otuple.get_<%=$name%>(), pyAttrValue);
-		 <%
-		     $ce = "li";
-                  $ce = "otuple.get_$name()";
-	     }
-	     
-       elsif ($atype eq 'map') {
-		 my $key_assign_string = pythonToCppPrimitiveConversion("k", $key_type);
-		 my $value_assign_string = pythonToCppPrimitiveConversion("v", $value_type);
-		 %>
-                  streamsx::topology::pySplValueFromPyObject(
-                               otuple.get_<%=$name%>(), pyAttrValue);
-		 //SPL::map< <%=$key_type%>, <%=$value_type%> > ma = SPL::map< <%=$key_type%>, <%=$value_type%> >();
-		 //PyObject *k,*v;
-		 //Py_ssize_t pos = 0;
-		 //while(PyDict_Next(pyAttrValue, &pos, &k, &v)){
-		 //    ma[ <%=$key_assign_string%> ] = <%=$value_assign_string%>;
-		 //}
-		 <%
-		  #   $ce = "ma";
-                  $ce = "otuple.get_$name()";
-	     }
-	     else {
-                  %>
-                  streamsx::topology::pySplValueFromPyObject(
-                               otuple.get_<%=$name%>(), pyAttrValue);
-                  <%
-
-                 
-		  # $ce = pythonToCppPrimitiveConversion("pyAttrValue", $atype);		     
-                  # temp - the function call above sets the attr
-                  $ce = "otuple.get_$name()";
-	     }
-	     
-	     
 %>
-      otuple.set_<%=$name%>(<%=$ce%>);
       }
    }
 <%

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_pyTupleTosplTuple.cgt
@@ -89,7 +89,15 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
 		     $ce = "ma";
 	     }
 	     else {
-		  $ce = pythonToCppPrimitiveConversion("pyAttrValue", $atype);		     
+                  %>
+                  streamsx::topology::pySplValueFromPyObject(
+                               otuple.get_<%=$name%>(), pyAttrValue);
+                  <%
+
+                 
+		  # $ce = pythonToCppPrimitiveConversion("pyAttrValue", $atype);		     
+                  # temp - the function call above sets the attr
+                  $ce = "otuple.get_$name()";
 	     }
 	     
 	     

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonFunctionalOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonFunctionalOperatorsTest.java
@@ -584,15 +584,26 @@ public class PythonFunctionalOperatorsTest extends TestTopology {
     }
     
     @Test(expected=Exception.class)
-    public void testNonHashableSet() throws Exception {
+    public void testNonHashableSetInput() throws Exception {
         StreamSchema bad = Type.Factory.getStreamSchema("tuple<set<list<int32>> a>");
         _testSchemaBuild(bad, INT32_SCHEMA);
     }
     
     @Test(expected=Exception.class)
-    public void testNonHashableMap() throws Exception {
+    public void testNonHashableMapInput() throws Exception {
         StreamSchema bad = Type.Factory.getStreamSchema("tuple<map<set<int32>,rstring> a>");
         _testSchemaBuild(bad, INT32_SCHEMA);
+    }
+    @Test(expected=Exception.class)
+    public void testNonHashableSetOutput() throws Exception {
+        StreamSchema bad = Type.Factory.getStreamSchema("tuple<set<list<int32>> a>");
+        _testSchemaBuild(INT32_SCHEMA, bad);
+    }
+    
+    @Test(expected=Exception.class)
+    public void testNonHashableMapOutput() throws Exception {
+        StreamSchema bad = Type.Factory.getStreamSchema("tuple<map<set<int32>,rstring> a>");
+        _testSchemaBuild(INT32_SCHEMA, bad);
     }
     
     /**

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonFunctionalOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonFunctionalOperatorsTest.java
@@ -73,11 +73,11 @@ public class PythonFunctionalOperatorsTest extends TestTopology {
     		  "map<rstring,float64> mrf64," +
     		  "list<list<float64>> llf64," +
     		  "map<rstring,list<int32>> mrli32," +
-    		  "map<rstring,map<rstring,float64>> mrmrf64" +
-    		  // "map<list<int8>,int8> mli8i8" +
+    		  "map<rstring,map<rstring,float64>> mrmrf64," +
+    		  "set<int32> si32" +
     		  ">");
 
-    public static final StreamSchema ALL_PYTHON_TYPES_WITH_SETS_SCHEMA = ALL_PYTHON_TYPES_SCHEMA.extend("set<int32>", "si32"); 
+    public static final StreamSchema ALL_PYTHON_TYPES_WITH_SETS_SCHEMA = ALL_PYTHON_TYPES_SCHEMA; 
     
     public static final int TUPLE_COUNT = 1000;
     

--- a/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonFunctionalOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/splpy/PythonFunctionalOperatorsTest.java
@@ -10,16 +10,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.math.complex.Complex;
 import org.junit.Before;
@@ -45,6 +40,8 @@ import com.ibm.streamsx.topology.tester.Condition;
 import com.ibm.streamsx.topology.tester.Tester;
 
 public class PythonFunctionalOperatorsTest extends TestTopology {
+    
+  // Need to match schema in test/python/pubsub/pytest_schema.py
   public static final StreamSchema ALL_PYTHON_TYPES_SCHEMA=
           Type.Factory.getStreamSchema("tuple<boolean b," +
     		  "int8 i8, int16 i16, int32 i32, int64 i64," +
@@ -72,7 +69,12 @@ public class PythonFunctionalOperatorsTest extends TestTopology {
     		  "map<float64,int32> mf64i32," +
     		  "map<float64,uint32> mf64u32," +
     		  "map<float64,rstring> mf64r," +
-    		  "map<rstring,float64> mrf64>");
+    		  "map<rstring,float64> mrf64," +
+    		  "list<list<float64>> llf64," +
+    		  "map<rstring,list<int32>> mrli32," +
+    		  "map<rstring,map<rstring,float64>> mrmrf64" +
+    		  // "map<list<int8>,int8> mli8i8" +
+    		  ">");
 
     public static final StreamSchema ALL_PYTHON_TYPES_WITH_SETS_SCHEMA = ALL_PYTHON_TYPES_SCHEMA.extend("set<int32>", "si32"); 
     

--- a/test/python/build.xml
+++ b/test/python/build.xml
@@ -58,6 +58,16 @@
 	   </target>	   
 
 
+     <target name="test.python3" description="Run all Python tests with python executable (assumed to be Python 3)" depends="test.python2">
+        <!-- SPL Python operators are only supported in Python 3 -->
+         <ant inheritAll="no" dir="../java">
+            <property name="topology.test.python" value="python"/>
+            <property name="topology.test.base.pattern" value="**/splpy/*Test.java"/>
+            <target name="unittest.standalone"/>
+            <target name="unittest.distributed"/>
+         </ant>
+     </target>
+
      <target name="test.python2" description="Run all Python tests with python executable (assumed to be Python 2)">
          <exec executable="python">
             <arg value="-V"/>
@@ -66,15 +76,6 @@
             <param name="topology.test.python" value="python"/>
             <target name="test.application.api"/>
          </antcall>
-         <!--
-              Disable until issue #574 is fixed
-         <ant inheritAll="no" dir="../java">
-            <property name="topology.test.python" value="python"/>
-            <property name="topology.test.base.pattern" value="**/splpy/*Test.java"/>
-            <target name="unittest.standalone"/>
-            <target name="unittest.distributed"/>
-         </ant>
-         -->
          <ant inheritAll="no" dir="../java">
             <property name="topology.test.python" value="python"/>
             <property name="topology.test.base.pattern" value="**/python/*Test.java"/>

--- a/test/python/pubsub/pytest_schema.py
+++ b/test/python/pubsub/pytest_schema.py
@@ -29,6 +29,9 @@ all_spl_types = StreamSchema("tuple<boolean b,"
     		  "map<float64,uint32> mf64u32,"
     		  "map<float64,rstring> mf64r,"
     		  "map<rstring,float64> mrf64,"
+                  "list<list<float64>> llf64,"
+                  "map<rstring,list<int32>> mrli32,"
+                  "map<rstring,map<rstring,float64>> mrmrf64,"
     		  "set<int32> si32>"
                   )
 


### PR DESCRIPTION
SPL Python operators, support list,map & set of arbitrary types, e.g. `list<list<float64>>`, `map<rstring,list<int32>>` etc.

- Also add checking for valid SPL schemas.
- Disallow set elements and map keys that are not hashable, so only support sets of primitive types and map keys of primitive types. This is because Python requires such items to be hashable.