### PR TITLE
Use provided name for functional operator submission param keys

### DIFF
--- a/java/src/com/ibm/streamsx/topology/generator/spl/SubmissionTimeValue.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SubmissionTimeValue.java
@@ -108,13 +108,14 @@ public class SubmissionTimeValue {
         for (String opParamName : allSubmissionParams.keySet()) {
             JsonObject spParam = allSubmissionParams.get(opParamName);
             JsonObject spval = jobject(spParam, "value");
+            String name = jstring(spval, "name");
             if (first)
                 first = false;
             else {
                 namesSb.append(", ");
                 valuesSb.append(", ");
             }
-            namesSb.append(SPLGenerator.stringLiteral(opParamName));
+            namesSb.append(SPLGenerator.stringLiteral(name));
             valuesSb.append("(rstring) ").append(generateCompParamName(spval));
         }
 

--- a/java/src/com/ibm/streamsx/topology/internal/functional/ops/SubmissionParameterManager.java
+++ b/java/src/com/ibm/streamsx/topology/internal/functional/ops/SubmissionParameterManager.java
@@ -172,7 +172,7 @@ public class SubmissionParameterManager {
         // good to go. initialize params
         params = new HashMap<>();
         for (Map.Entry<String, String> e : allsp.entrySet()) {
-            params.put(SubmissionTimeValue.mkOpParamName(e.getKey()), e.getValue());
+            params.put(e.getKey(), e.getValue());
         }
         // System.out.println("SPM.initializeEmbedded() " + params);
     }
@@ -188,7 +188,7 @@ public class SubmissionParameterManager {
      *          may be null.
      */
     public static Object getValue(String spName, MetaType metaType) {
-        String value = params.get(SubmissionTimeValue.mkOpParamName(spName));
+        String value = params.get(spName);
         if (value == null) {
             // System.out.println("SPM.getValue "+spName+" "+metaType+ " params " + params);
             throw new IllegalArgumentException("Unexpected submission parameter name " + spName);


### PR DESCRIPTION
Partial changes for #649 to address:

In addition when passing the values to a functional operator, the mangled name is used rather than the user provided name, there seems no reason for this, as the operator has the user provided name. E.g. this is currently set as the parameters for a functional operator:
```
submissionParamNames: "__jaa_stv_width";
submissionParamValues: __jaa_stv_width;
```

It can simply be:
```
submissionParamNames: "width";
submissionParamValues: __jaa_stv_width;
```
leading to consistent use of the user-provided name everywhere, except when it needs to be used as the composite parameter definition and value.

