### PR TITLE
Add simple log4j.properties

### DIFF
--- a/java/build.xml
+++ b/java/build.xml
@@ -46,6 +46,9 @@
                  ${cisxt}/internal/context/remote/*.java
                  "
     />
+    <copy toDir="${classes}">
+      <fileset dir="${src}" includes="**/*.properties"/>
+    </copy>
   </target>
 
   <target name="compile" depends="init,compile.pure">

--- a/java/src/log4j.properties
+++ b/java/src/log4j.properties
@@ -1,0 +1,7 @@
+# Root logger option
+log4j.rootLogger=INFO, stderr
+
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.Target=System.err
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Sends log4j messages to stderr.

Fixes #669. 