### PR TITLE
Remove conversion of deploy JSON to Map

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -3,7 +3,6 @@ package com.ibm.streamsx.topology.internal.context.remote;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import java.util.Random;
 
 import javax.xml.bind.DatatypeConverter;
@@ -20,21 +19,21 @@ import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
-import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
-import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.ibm.streamsx.topology.context.remote.RemoteContext;
+import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 
-public class BuildServiceRemoteRESTWrapper {
+class BuildServiceRemoteRESTWrapper {
 	
-	JsonObject credentials;
+	private JsonObject credentials;
 	
-	public BuildServiceRemoteRESTWrapper(JsonObject credentials){
+	BuildServiceRemoteRESTWrapper(JsonObject credentials){
 		this.credentials = credentials;
 	}
 	
-	public void remoteBuildAndSubmit(File archive) throws ClientProtocolException, IOException{
+	void remoteBuildAndSubmit(File archive) throws ClientProtocolException, IOException{
 		CloseableHttpClient httpclient = HttpClients.createDefault();
         String apiKey = getAPIKey(GsonUtilities.jstring(credentials,  "userid"), GsonUtilities.jstring(credentials, "password"));
         

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteBuildAndSubmitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteBuildAndSubmitRemoteContext.java
@@ -1,12 +1,12 @@
 package com.ibm.streamsx.topology.internal.context.remote;
 
+import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.object;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.Future;
 
 import com.google.gson.JsonObject;
-import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 
 public class RemoteBuildAndSubmitRemoteContext extends ZippedToolkitRemoteContext {
@@ -18,15 +18,14 @@ public class RemoteBuildAndSubmitRemoteContext extends ZippedToolkitRemoteContex
 	@Override
 	public Future<File> submit(JsonObject submission) throws Exception {
 		Future<File> archive = super.submit(submission);
-		Map<String, Object> config = RemoteContexts.gsonDeployToMap(
-				GsonUtilities.object(submission, "deploy"));
-		doSubmit(config, archive.get());
+		JsonObject deploy = GsonUtilities.object(submission, "deploy");
+		doSubmit(deploy, archive.get());
        return archive;
 	}
 	
-	private void doSubmit(Map<String, Object> config, File archive) throws IOException{
-		JsonObject service = RemoteContexts.getVCAPService(config);        
-        JsonObject credentials = GsonUtilities.object(service,  "credentials");
+	private void doSubmit(JsonObject deploy, File archive) throws IOException{
+		JsonObject service = RemoteContexts.getVCAPService(deploy);        
+        JsonObject credentials = object(service,  "credentials");
      
         BuildServiceRemoteRESTWrapper wrapper = new BuildServiceRemoteRESTWrapper(credentials);
         wrapper.remoteBuildAndSubmit(archive);


### PR DESCRIPTION
@wmarshall484 

Seems that there's no reason to take the JSON and put top-level vcap keys into a `Map<String,Object>`  just to fetch them out as JSON.