### PR TITLE
Added correct status messages during remote submit.

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -33,6 +33,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import com.ibm.streamsx.topology.internal.streaminganalytics.RestUtils;
+import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 
 class BuildServiceRemoteRESTWrapper {
 	
@@ -43,57 +44,62 @@ class BuildServiceRemoteRESTWrapper {
     }
 	
 
-    void remoteBuildAndSubmit(JsonObject deploy, File archive) throws ClientProtocolException, IOException{
-	CloseableHttpClient httpclient = HttpClients.createDefault();
+	void remoteBuildAndSubmit(JsonObject deploy, File archive) throws ClientProtocolException, IOException {
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		try {
+			JsonObject serviceg = VcapServices.getVCAPService(key -> deploy.get(key));
 
-	RestUtils.checkInstanceStatus(httpclient, this.credentials);
-        String apiKey = getAPIKey(jstring(credentials,  "userid"), jstring(credentials, "password"));
-        
-        // Perform initial post of the archive
-        RemoteContext.REMOTE_LOGGER.info("Submitting application to remote build.");
-        JsonObject jso = doUploadBuildArchivePost(httpclient, apiKey, archive);
-        
-        JsonObject build = object(jso, "build");
-        String buildId = jstring(build, "id");
-        String outputId = jstring(build,  "output_id");
-        
-        // Loop until built
-        String status = "";
-        while(!status.equals("built")){
-        	status = buildStatusGet(buildId, httpclient, apiKey);
-        	if(status.equals("building")){
-        		try {
-			    Thread.sleep(1000);
-			} catch (InterruptedException e) {
-			    Thread.currentThread().interrupt();
+			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service: Checking status :" + serviceg.get("name"));
+			RestUtils.checkInstanceStatus(httpclient, this.credentials);
+
+			String apiKey = getAPIKey(jstring(credentials, "userid"), jstring(credentials, "password"));
+
+			// Perform initial post of the archive
+			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service: Submitting archive : " + archive.getName() + " to " + serviceg.get("name"));
+			JsonObject jso = doUploadBuildArchivePost(httpclient, apiKey, archive);
+
+			JsonObject build = object(jso, "build");
+			String buildId = jstring(build, "id");
+			String outputId = jstring(build, "output_id");
+
+			// Loop until built
+			String status = "";
+			while (!status.equals("built")) {
+				status = buildStatusGet(buildId, httpclient, apiKey);
+				if (status.equals("building")) {
+					try {
+						Thread.sleep(1000);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+					continue;
+				} else if (status.equals("failed")) {
+					RemoteContext.REMOTE_LOGGER.severe("Streaming Analytics Service: The submitted archive " + archive.getName() + " failed to build.");
+					JsonObject output = getBuildOutput(buildId, outputId, httpclient, apiKey);
+					String strOutput = "";
+					if (output != null)
+						strOutput = prettyPrintOutput(output);
+					throw new IllegalStateException("Error submitting archive for compilation: \n" + strOutput);
+				}
 			}
-        		continue;
-        	}
-        	else if(status.equals("failed")){
-        		RemoteContext.REMOTE_LOGGER.severe("The application failed to build.");
-        		JsonObject output = getBuildOutput(buildId, outputId, httpclient, apiKey);
-        		String strOutput = "";
-        		if(output!=null)
-        			strOutput = prettyPrintOutput(output);
-        		throw new IllegalStateException("Error submitting archive for compilation: \n"
-        				+ strOutput);
-        	}
-        }
-        RemoteContext.REMOTE_LOGGER.info("The application built successfully.");
-        
-        // Now perform archive put
-        build = getBuild(buildId, httpclient, apiKey);
-        
-        JsonArray artifacts = array(build, "artifacts");
-        if (artifacts == null || artifacts.size() == 0){
-        	throw new IllegalStateException("No artifacts associated with build " + buildId);
-        }
-        
-        // TODO: support multiple artifacts associated with a single build.
-        String artifactId = jstring(artifacts.get(0).getAsJsonObject(), "id");
-        RemoteContext.REMOTE_LOGGER.info("Submitting job to remote instance.");
-        doSubmitJobFromBuildArtifactPut(httpclient, deploy, apiKey, artifactId);
-    }
+
+			// Now perform archive put
+			build = getBuild(buildId, httpclient, apiKey);
+
+			JsonArray artifacts = array(build, "artifacts");
+			if (artifacts == null || artifacts.size() == 0) {
+				throw new IllegalStateException("No artifacts associated with build " + buildId);
+			}
+
+			// TODO: support multiple artifacts associated with a single build.
+			String artifactId = jstring(artifacts.get(0).getAsJsonObject(), "id");
+			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service: submiting job request.");
+			doSubmitJobFromBuildArtifactPut(httpclient, deploy, apiKey, artifactId);
+		} finally {
+			httpclient.close();
+
+		}
+	}
 	
 	/**
 	 * Submit the job from the built artifact.
@@ -118,6 +124,7 @@ class BuildServiceRemoteRESTWrapper {
         httpput.setEntity(params);
        
         JsonObject jso = RestUtils.getGsonResponse(httpclient, httpput);
+        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service: submit job response: " + jso.toString());
 		return jso;
 	}
 	

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -55,8 +55,9 @@ class BuildServiceRemoteRESTWrapper {
 			String apiKey = getAPIKey(jstring(credentials, "userid"), jstring(credentials, "password"));
 
 			// Perform initial post of the archive
-			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service: Submitting archive : " + archive.getName() + " to " + serviceg.get("name"));
-			JsonObject jso = doUploadBuildArchivePost(httpclient, apiKey, archive);
+			String buildName = newBuildName(16);
+			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service: Submitting build : \"" + buildName + "\" to " + serviceg.get("name"));
+			JsonObject jso = doUploadBuildArchivePost(httpclient, apiKey, archive, buildName);
 
 			JsonObject build = object(jso, "build");
 			String buildId = jstring(build, "id");
@@ -138,8 +139,8 @@ class BuildServiceRemoteRESTWrapper {
 	}
 
 	private JsonObject doUploadBuildArchivePost(CloseableHttpClient httpclient,
-			String apiKey, File archive) throws ClientProtocolException, IOException{
-		String newBuildURL = getBuildsURL(credentials) + "?build_name=" + newBuildName(16);
+						    String apiKey, File archive, String buildName) throws ClientProtocolException, IOException{
+	    String newBuildURL = getBuildsURL(credentials) + "?build_name=" + buildName;
 		HttpPost httppost = new HttpPost(newBuildURL);
         httppost.addHeader("accept", ContentType.APPLICATION_JSON.getMimeType());
         httppost.addHeader("Authorization", apiKey);

--- a/java/src/com/ibm/streamsx/topology/internal/streaminganalytics/RestUtils.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streaminganalytics/RestUtils.java
@@ -26,9 +26,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.bind.DatatypeConverter;
-import java.nio.charset.StandardCharsets;
 
 public class RestUtils {
 


### PR DESCRIPTION
Example remote submit:
```
2017-01-19 02:54:50,133 - streamsx.topology.py_submit - INFO - Generating SPL and submitting application.
Jan 19, 2017 2:54:51 AM com.ibm.streamsx.topology.internal.context.remote.BuildServiceRemoteRESTWrapper remoteBuildAndSubmit
INFO: Streaming Analytics Service: Checking status :"Streaming Analytics-p1"
Jan 19, 2017 2:54:54 AM com.ibm.streamsx.topology.internal.streaminganalytics.RestUtils checkInstanceStatus
INFO: Streaming Analytics Service instance status response:{"state":"STARTED","plan":"Standard","enabled":true,"status":"running"}
Jan 19, 2017 2:54:54 AM com.ibm.streamsx.topology.internal.context.remote.BuildServiceRemoteRESTWrapper remoteBuildAndSubmit
INFO: Streaming Analytics Service: Submitting archive : tk4994625408662797149.zip to "Streaming Analytics-p1"
Jan 19, 2017 2:55:25 AM com.ibm.streamsx.topology.internal.context.remote.BuildServiceRemoteRESTWrapper remoteBuildAndSubmit
INFO: Streaming Analytics Service: submiting job request.
Jan 19, 2017 2:55:31 AM com.ibm.streamsx.topology.internal.context.remote.BuildServiceRemoteRESTWrapper doSubmitJobFromBuildArtifactPut
INFO: Streaming Analytics Service: submit job response: {"artifact":"249","jobId":"8","application":"myTop::myTop","name":"myTop::myTop_8","state":"STARTED","plan":"Standard","enabled":true,"status":"running"}
```