### PR TITLE
Use python2 new-style classes in context.py

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -78,7 +78,7 @@ def submit(ctxtype, graph, config=None, username=None, password=None, log_level=
         logger.exception("Error while submitting application.")
 
 
-class _BaseSubmitter:
+class _BaseSubmitter(object):
     """
     A submitter which handles submit operations common across all submitter types..
     """
@@ -370,7 +370,7 @@ class _DistributedSubmitter(_BaseSubmitter):
                 {'username': username, 'password': password, 'rest_api_url': rest_api_url})
 
 
-class _SubmitContextFactory:
+class _SubmitContextFactory(object):
     """
     ContextSubmitter:
         Responsible for performing the correct submission depending on a number of factors, including: the
@@ -457,7 +457,7 @@ class UnsupportedContextException(Exception):
     def __init__(self, msg):
         Exception.__init__(self, msg)
 
-class ContextTypes:
+class ContextTypes(object):
     """
         Types of submission contexts:
 
@@ -492,7 +492,7 @@ class ContextTypes:
     ANALYTICS_SERVICE = 'ANALYTICS_SERVICE'
 
 
-class ConfigParams:
+class ConfigParams(object):
     """
     Configuration options which may be used as keys in the submit's config parameter.
 
@@ -504,7 +504,7 @@ class ConfigParams:
     FORCE_REMOTE_BUILD = 'topology.forceRemoteBuild'
     JOB_CONFIG = 'topology.jobConfigOverlays'
 
-class JobConfig:
+class JobConfig(object):
     """
     Job configuration
     """


### PR DESCRIPTION
Use the python2 new-style class syntax so we can
avoid issues with calls to super() and other inheritance issues.
This has no effect on python3, as it both class declarations
are equivalent.

For verification run the following snippet on py2 and py3:

```
  from __future__ import print_function

  class MyThing(object):
      pass

  class MyThing2:
      pass

  print(issubclass(MyThing, object))
  # True on py2 and py3

  print(issubclass(MyThing2, object))
  # False on py2, True on py3
```