### PR TITLE
Cleanup regarding to remote submit status messages.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -214,7 +214,6 @@ class Stream(object):
         _view = View(name, port, buffer_time, sample_size)
         self.topology.graph.get_views().append(_view)
         return _view
-        
 
     def map(self, func, name=None):
         """

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -41,8 +41,8 @@ class BuildServiceRemoteRESTWrapper {
 	
 	BuildServiceRemoteRESTWrapper(JsonObject service){
 	    JsonObject credentials = object(service,  "credentials");
-		this.credentials = credentials;
-		this.service = service;
+	    this.credentials = credentials;
+	    this.service = service;
     }
 	
 

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -37,9 +37,12 @@ import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 class BuildServiceRemoteRESTWrapper {
 	
     private JsonObject credentials;
+    private JsonObject service;
 	
-	BuildServiceRemoteRESTWrapper(JsonObject credentials){
+	BuildServiceRemoteRESTWrapper(JsonObject service){
+	    JsonObject credentials = object(service,  "credentials");
 		this.credentials = credentials;
+		this.service = service;
     }
 	
 
@@ -50,11 +53,10 @@ class BuildServiceRemoteRESTWrapper {
 	    
 		CloseableHttpClient httpclient = HttpClients.createDefault();
 		try {
-			JsonObject serviceg = VcapServices.getVCAPService(deploy);
-			String serviceName = serviceg.get("name").toString();
+			String serviceName = this.service.get("name").toString();
 
 			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service (" + serviceName + "): Checking status");
-			RestUtils.checkInstanceStatus(httpclient, serviceg);
+			RestUtils.checkInstanceStatus(httpclient, this.service);
 
 			String apiKey = RestUtils.getAPIKey(credentials);
 
@@ -127,8 +129,7 @@ class BuildServiceRemoteRESTWrapper {
        
         JsonObject jso = RestUtils.getGsonResponse(httpclient, httpput);
         
-        JsonObject serviceg = VcapServices.getVCAPService(deploy);
-        String serviceName = serviceg.get("name").toString();
+        String serviceName = this.service.get("name").toString();
         RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service(" + serviceName + "): submit job response: " + jso.toString());
 		return jso;
 	}

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -53,7 +53,7 @@ class BuildServiceRemoteRESTWrapper {
 			JsonObject serviceg = VcapServices.getVCAPService(deploy);
 			String serviceName = serviceg.get("name").toString();
 
-			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service (" + serviceName + "): Checking status :" + serviceName);
+			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service (" + serviceName + "): Checking status");
 			RestUtils.checkInstanceStatus(httpclient, serviceg);
 
 			String apiKey = RestUtils.getAPIKey(credentials);
@@ -61,7 +61,7 @@ class BuildServiceRemoteRESTWrapper {
 			// Perform initial post of the archive
 			String buildName = graphBuildName + randomHex(16);
 			buildName = URLEncoder.encode(buildName, StandardCharsets.UTF_8.name());
-			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service (" + serviceName + "): submitting build \"" + buildName + "\" to " + serviceg.get("name"));
+			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service (" + serviceName + "): submitting build \"" + buildName);
 			JsonObject jso = doUploadBuildArchivePost(httpclient, apiKey, archive, buildName);
 
 			JsonObject build = object(jso, "build");

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -61,7 +61,7 @@ class BuildServiceRemoteRESTWrapper {
 			String apiKey = RestUtils.getAPIKey(credentials);
 
 			// Perform initial post of the archive
-			String buildName = graphBuildName + randomHex(16);
+			String buildName = graphBuildName + "_" + randomHex(16);
 			buildName = URLEncoder.encode(buildName, StandardCharsets.UTF_8.name());
 			RemoteContext.REMOTE_LOGGER.info("Streaming Analytics Service (" + serviceName + "): submitting build \"" + buildName);
 			JsonObject jso = doUploadBuildArchivePost(httpclient, apiKey, archive, buildName);

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteBuildAndSubmitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteBuildAndSubmitRemoteContext.java
@@ -34,10 +34,7 @@ public class RemoteBuildAndSubmitRemoteContext extends ZippedToolkitRemoteContex
 	}
 	
 	private void doSubmit(JsonObject submission, JsonObject service, File archive) throws IOException{
-		        
-        JsonObject credentials = object(service,  "credentials");
-     
-        BuildServiceRemoteRESTWrapper wrapper = new BuildServiceRemoteRESTWrapper(credentials);
+        BuildServiceRemoteRESTWrapper wrapper = new BuildServiceRemoteRESTWrapper(service);
         wrapper.remoteBuildAndSubmit(submission, archive);
 	}
 }


### PR DESCRIPTION
* Certain error messages listed the instance redundantly.
* The getVCAPService method was being called multiple times. This can be inefficient.
* For clarity, and underscore was added in the build name between the topology name and the unique identifier.