### PR TITLE
Clear VCAP from config after content is loaded into env var

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -273,6 +273,9 @@ class _RemoteBuildSubmitter(_BaseSubmitter):
         self._set_vcap()
         self._set_credentials()
 
+        # Clear the VCAP_SERVICES key in config, since env var will contain the content
+        self._config().pop(ConfigParams.VCAP_SERVICES, None)
+
         username = self.credentials['userid']
         password = self.credentials['password']
 


### PR DESCRIPTION
Remove key ConfigParams.VCAP_SERVICES from config object after the vcap content has been loaded.  When the config object is passed into the Java submitter logic, not having this key, will trigger the load from the env var VCAP_SERVICES.

Fixes IBMStreams/streamsx.topology#772