### PR TITLE
Add parens to indicate this is an assignment

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -172,7 +172,7 @@ namespace streamsx {
             throw SplpyGeneral::pythonException("iter(set)");
         }
         PyObject *item;
-        while (item = PyIter_Next(iterator)) {
+        while ((item = PyIter_Next(iterator))) {
             T se;
             pySplValueFromPyObject(se, item);
             Py_DECREF(item);


### PR DESCRIPTION
See:

http://stackoverflow.com/questions/5476759/compiler-warning-suggest-parentheses-around-assignment-used-as-truth-value