### PR TITLE
Pass keys to parallel partition by in the JSON graph.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -161,10 +161,10 @@ class _SPLInvocation(object):
         self.inputPorts = []
         self.outputPorts = []
 
-    def addOutputPort(self, oWidth=None, name=None, inputPort=None, schema= CommonSchema.Python,partitioned=None):
+    def addOutputPort(self, oWidth=None, name=None, inputPort=None, schema= CommonSchema.Python,partitioned_keys=None):
         if name is None:
             name = self.name + "_OUT"+str(len(self.outputPorts))
-        oport = OPort(name, self, len(self.outputPorts), schema, oWidth, partitioned)
+        oport = OPort(name, self, len(self.outputPorts), schema, oWidth, partitioned_keys)
         self.outputPorts.append(oport)
         if schema == CommonSchema.Python:
             self.viewable = False
@@ -308,13 +308,14 @@ class IPort(object):
         return _iport
 
 class OPort(object):
-    def __init__(self, name, operator, index, schema, width=None, partitioned=None):
+    def __init__(self, name, operator, index, schema, width=None, partitioned_keys=None):
         self.name = name
         self.operator = operator
         self.schema = _stream_schema(schema)
         self.index = index
         self.width = width
-        self.partitioned =  partitioned
+        self.partitioned = partitioned_keys is not None
+        self.partitioned_keys = partitioned_keys
 
         self.inputPorts = []
 
@@ -334,6 +335,8 @@ class OPort(object):
             _oport["width"] = int(self.width)
         if not self.partitioned is None:
             _oport["partitioned"] = self.partitioned
+        if self.partitioned_keys is not None:
+            _oport["partitionedKeys"] = self.partitioned_keys
         return _oport
 
 class Marker(_SPLInvocation):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -41,6 +41,17 @@ class StreamSchema(object) :
         new_schema = base[:-1] + ',' + extends[6:]
         return StreamSchema(new_schema)
 
+    def __hash__(self):
+        return hash(self.schema())
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.schema() == other.schema()
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 # XML = StreamSchema("tuple<xml document>")
 
 @enum.unique

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -558,23 +558,31 @@ class Stream(object):
             oport = op2.addOutputPort(width)
             return Stream(self.topology, oport)
         elif(routing == Routing.HASH_PARTITIONED ) :
-            if (func is None) :
-                func = hash   
-            hash_adder = self.topology.graph.addOperator(self.topology.opnamespace+"::PyFunctionHashAdder", func)
-            hash_schema = self.oport.schema.extend(schema.StreamSchema("tuple<int64 __spl_hash>"))
-            hash_adder.addInputPort(outputPort=self.oport)
-            hash_adder_oport = hash_adder.addOutputPort(schema=hash_schema)
 
+            if (func is None):
+                if self.oport.schema == schema.CommonSchema.String:
+                    #TODO - use SPL partitioning on string
+                    func = hash
+                else:
+                    func = hash
+
+            if func is not None:
+                hash_adder = self.topology.graph.addOperator(self.topology.opnamespace+"::PyFunctionHashAdder", func)
+                hash_schema = self.oport.schema.extend(schema.StreamSchema("tuple<int64 __spl_hash>"))
+                hash_adder.addInputPort(outputPort=self.oport)
+                parallel_input = hash_adder.addOutputPort(schema=hash_schema)
 
             parallel_op = self.topology.graph.addOperator("$Parallel$")
-            parallel_op.addInputPort(outputPort=hash_adder_oport)
-            parallel_op_port = parallel_op.addOutputPort(oWidth=width, schema=hash_schema, partitioned=True)
+            parallel_op.addInputPort(outputPort=parallel_input)
+            parallel_op_port = parallel_op.addOutputPort(oWidth=width, schema=parallel_input.schema, partitioned=True)
 
-            # use the Functor passthru operator to effectively remove the hash attribute by removing it from output port schema 
-            hrop = self.topology.graph.addPassThruOperator()
-            hrop.addInputPort(outputPort=parallel_op_port)
-            hrOport = hrop.addOutputPort(schema=self.oport.schema)
-            return Stream(self.topology, hrOport)
+            if func is not None:
+                # use the Functor passthru operator to remove the hash attribute by removing it from output port schema
+                hrop = self.topology.graph.addPassThruOperator()
+                hrop.addInputPort(outputPort=parallel_op_port)
+                parallel_op_port = hrop.addOutputPort(schema=self.oport.schema)
+
+            return Stream(self.topology, parallel_op_port)
         else :
             raise TypeError("Invalid routing type supplied to the parallel operator")    
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -561,12 +561,13 @@ class Stream(object):
 
             if (func is None):
                 if self.oport.schema == schema.CommonSchema.String:
-                    #TODO - use SPL partitioning on string
-                    func = hash
+                    keys = ['string']
+                    parallel_input = self.oport
                 else:
                     func = hash
 
             if func is not None:
+                keys = ['__spl_hash']
                 hash_adder = self.topology.graph.addOperator(self.topology.opnamespace+"::PyFunctionHashAdder", func)
                 hash_schema = self.oport.schema.extend(schema.StreamSchema("tuple<int64 __spl_hash>"))
                 hash_adder.addInputPort(outputPort=self.oport)
@@ -574,7 +575,7 @@ class Stream(object):
 
             parallel_op = self.topology.graph.addOperator("$Parallel$")
             parallel_op.addInputPort(outputPort=parallel_input)
-            parallel_op_port = parallel_op.addOutputPort(oWidth=width, schema=parallel_input.schema, partitioned=True)
+            parallel_op_port = parallel_op.addOutputPort(oWidth=width, schema=parallel_input.schema, partitioned_keys=keys)
 
             if func is not None:
                 # use the Functor passthru operator to remove the hash attribute by removing it from output port schema

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -149,10 +149,19 @@ class OperatorGenerator {
             }
             boolean partitioned = jboolean(op, "partitioned");
             if (partitioned) {
-                String parallelInputPortName = op.get("parallelInputPortName").getAsString();
+                String parallelInputPortName = jstring(op, "parallelInputPortName");
+                JsonArray partitionKeys = op.get("partitionedKeys").getAsJsonArray();
+                
                 parallelInputPortName = splBasename(parallelInputPortName);
-                sb.append(", partitionBy=[{port=" + parallelInputPortName
-                        + ", attributes=[__spl_hash]}]");
+                sb.append(", partitionBy=[{port=");
+                sb.append(parallelInputPortName);
+                sb.append(", attributes=[");
+                for (int i = 0; i < partitionKeys.size(); i++) {
+                    if (i != 0)
+                        sb.append(", ");
+                    sb.append(partitionKeys.get(i).getAsString());
+                }
+                sb.append("]}]");
             }
             sb.append(")\n");
         }

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streamsx.topology.TSink;
@@ -472,7 +473,7 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
                     "The parallel width must be greater than or equal to 1.");
 
         BOutput toBeParallelized = output();
-        boolean needHashRemover = false;
+        boolean isPartitioned = false;
         if (keyer != null) {
 
             final ToIntFunction<T> hasher = new KeyFunctionHasher<>(keyer);
@@ -486,12 +487,15 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
             StreamSchema hashSchema = ip.port().getStreamSchema()
                     .extend("int32", "__spl_hash");
             toBeParallelized = hashAdder.addOutput(hashSchema);
-            needHashRemover = true;
+            isPartitioned = true;
         }
                 
         BOutput parallelOutput = builder().parallel(toBeParallelized, width);
-        if (needHashRemover) {
+        if (isPartitioned) {
             parallelOutput.json().put("partitioned", true);
+            JSONArray partitionKeys = new JSONArray();
+            partitionKeys.add("__spl_hash");
+            parallelOutput.json().put("partitionedKeys", partitionKeys);
             // Add hash remover
             StreamImpl<T> parallelStream = new StreamImpl<T>(this,
                     parallelOutput, getTupleType());

--- a/test/python/topology/test2_udp.py
+++ b/test/python/topology/test2_udp.py
@@ -167,7 +167,6 @@ class TestUDP(unittest.TestCase):
 
               tester = Tester(topo)
               tester.contents(s, expected, ordered=width==1)
-              self.test_config['topology.keepArtifacts'] = True
               tester.test(self.test_ctxtype, self.test_config)
               print(tester.result)
 


### PR DESCRIPTION
Will allow support for partition by key and supports avoiding a HashAdder/HashRemover pair when using a schema like `tuple<rstring string>`.