### PR TITLE
SubmissionResult to reflect keepArtifacts setting

### DIFF
--- a/java/src/com/ibm/streamsx/topology/context/StreamsContextFactory.java
+++ b/java/src/com/ibm/streamsx/topology/context/StreamsContextFactory.java
@@ -31,13 +31,13 @@ public class StreamsContextFactory {
         case EMBEDDED:
             return getEmbedded();
         case TOOLKIT:
-            return new ToolkitStreamsContext();
+            return new ToolkitStreamsContext(true);
         case BUILD_ARCHIVE:
             return new ZippedToolkitStreamsContext();
         case STANDALONE_BUNDLE:
-            return new BundleStreamsContext(true, false);
+            return new BundleStreamsContext(true, true);
         case BUNDLE:
-            return new BundleStreamsContext(false, false);
+            return new BundleStreamsContext(false, true);
         case STANDALONE:
             return new StandaloneStreamsContext();
         case DISTRIBUTED:

--- a/java/src/com/ibm/streamsx/topology/context/remote/RemoteContextFactory.java
+++ b/java/src/com/ibm/streamsx/topology/context/remote/RemoteContextFactory.java
@@ -7,13 +7,13 @@ import com.ibm.streamsx.topology.internal.context.remote.ZippedToolkitRemoteCont
 public class RemoteContextFactory {
     
     public static RemoteContext<?> getRemoteContext(String type) {
-        return getRemoteContext(RemoteContext.Type.valueOf(type));
+        return getRemoteContext(RemoteContext.Type.valueOf(type), true);
     }
 
-    public static RemoteContext<?> getRemoteContext(RemoteContext.Type type) {
+    public static RemoteContext<?> getRemoteContext(final RemoteContext.Type type, final boolean keepToolkit) {
         switch (type) {
         case TOOLKIT:
-            return new ToolkitRemoteContext();
+            return new ToolkitRemoteContext(keepToolkit);
         case BUILD_ARCHIVE:
             return new ZippedToolkitRemoteContext();
 	case ANALYTICS_SERVICE:

--- a/java/src/com/ibm/streamsx/topology/internal/context/AnalyticsServiceStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/AnalyticsServiceStreamsContext.java
@@ -12,21 +12,18 @@ import static com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
+import java.util.Map.Entry;
 import java.util.concurrent.Future;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import com.ibm.streamsx.topology.internal.context.remote.DeployKeys;
-import com.ibm.streamsx.topology.internal.context.remote.RemoteContexts;
+import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.internal.process.CompletedFuture;
 import com.ibm.streamsx.topology.internal.streaminganalytics.RestUtils;
 
@@ -107,7 +104,10 @@ public class AnalyticsServiceStreamsContext extends
 
             JsonObject response = RestUtils.postJob(httpClient, service, bundle, jcojson);
             
-            submission.add(RemoteContext.SUBMISSION_RESULTS, response);
+            final JsonObject submissionResult = GsonUtilities.getProperty(submission, RemoteContext.SUBMISSION_RESULTS);
+            for (Entry<String, JsonElement> entry : response.entrySet()) {
+            	submissionResult.add(entry.getKey(), entry.getValue());
+            }
             
             String jobId = jstring(response, "jobId");
             

--- a/java/src/com/ibm/streamsx/topology/internal/context/BundleUserStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/BundleUserStreamsContext.java
@@ -18,7 +18,7 @@ abstract class BundleUserStreamsContext<T> extends JSONStreamsContext<T> {
     private final BundleStreamsContext bundler;
 
     BundleUserStreamsContext(boolean standalone) {
-        bundler = new BundleStreamsContext(standalone, true);
+        bundler = new BundleStreamsContext(standalone, false);
     }
     
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/context/DistributedStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/DistributedStreamsContext.java
@@ -14,6 +14,7 @@ import java.util.concurrent.Future;
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import com.ibm.streamsx.topology.internal.context.remote.SubmissionResultsKeys;
+import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.internal.process.CompletedFuture;
 import com.ibm.streamsx.topology.internal.streams.InvokeSubmit;
 
@@ -42,9 +43,8 @@ public class DistributedStreamsContext extends
 
             BigInteger jobId = submitjob.invoke(deploy(entity.submission));
             
-            JsonObject results = new JsonObject();
-            results.addProperty(SubmissionResultsKeys.JOB_ID, jobId.toString());
-            entity.submission.add(RemoteContext.SUBMISSION_RESULTS, results);
+            final JsonObject submissionResult = GsonUtilities.getProperty(entity.submission, RemoteContext.SUBMISSION_RESULTS);
+            submissionResult.addProperty(SubmissionResultsKeys.JOB_ID, jobId.toString());
             
             return new CompletedFuture<BigInteger>(jobId);
         } finally {

--- a/java/src/com/ibm/streamsx/topology/internal/context/ToolkitStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/ToolkitStreamsContext.java
@@ -28,6 +28,16 @@ public class ToolkitStreamsContext extends JSONStreamsContext<File> {
 
 	static final Logger trace = Topology.TOPOLOGY_LOGGER;
     
+	private final boolean keepToolkit;
+
+	public ToolkitStreamsContext() {
+        this.keepToolkit = false;
+    }
+	
+    public ToolkitStreamsContext(boolean keepToolkit) {
+        this.keepToolkit = keepToolkit;
+    }
+	
     @Override
     public Type getType() {
         return Type.TOOLKIT;
@@ -46,7 +56,7 @@ public class ToolkitStreamsContext extends JSONStreamsContext<File> {
         
         // use the remote context to build the toolkit.
         @SuppressWarnings("unchecked")
-        RemoteContext<File> tkrc = (RemoteContext<File>) getRemoteContext(RemoteContext.Type.TOOLKIT);
+        RemoteContext<File> tkrc = (RemoteContext<File>) getRemoteContext(RemoteContext.Type.TOOLKIT, keepToolkit);
         
         final Future<File> future = tkrc.submit(submission);
         final File toolkitRoot = future.get();

--- a/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/ZippedToolkitStreamsContext.java
@@ -18,7 +18,7 @@ public class ZippedToolkitStreamsContext extends ToolkitStreamsContext {
 	Future<File> action(AppEntity entity) throws Exception {
 	    // Let the remote archive do all the work.
 	    @SuppressWarnings("unchecked")
-        RemoteContext<File> ztrc = (RemoteContext<File>) RemoteContextFactory.getRemoteContext(RemoteContext.Type.BUILD_ARCHIVE);
+        RemoteContext<File> ztrc = (RemoteContext<File>) RemoteContextFactory.getRemoteContext(RemoteContext.Type.BUILD_ARCHIVE, false);
 	    
 	    return ztrc.submit(entity.submission);
 	}

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import java.util.Map.Entry;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.client.ClientProtocolException;
@@ -31,6 +32,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
+import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.internal.streaminganalytics.RestUtils;
 
 class BuildServiceRemoteRESTWrapper {
@@ -103,7 +105,10 @@ class BuildServiceRemoteRESTWrapper {
 			JsonObject response = doSubmitJobFromBuildArtifactPut(httpclient, deploy, apiKey, artifactId);
 			
 			// Pass back to Python
-			submission.add(RemoteContext.SUBMISSION_RESULTS, response);
+			final JsonObject submissionResult = GsonUtilities.getProperty(submission, RemoteContext.SUBMISSION_RESULTS);
+            for (Entry<String, JsonElement> entry : response.entrySet()) {
+            	submissionResult.add(entry.getKey(), entry.getValue());
+            }
 		} finally {
 			httpclient.close();
 

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteContexts.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteContexts.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
+import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 
 public class RemoteContexts {
     /**
@@ -25,10 +26,7 @@ public class RemoteContexts {
             return;
     
         // Write to the file and close the file.
-        JsonObject results_json = object(submission, RemoteContext.SUBMISSION_RESULTS);
-        if(results_json == null)
-            return;
-        
+        JsonObject results_json = GsonUtilities.getProperty(submission, RemoteContext.SUBMISSION_RESULTS);        
         Files.write(Paths.get(resultsFile), results_json.toString().getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/ToolkitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/ToolkitRemoteContext.java
@@ -9,10 +9,9 @@ import static com.ibm.streamsx.topology.context.ContextProperties.VMARGS;
 import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.DEPLOYMENT_CONFIG;
 import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.JOB_CONFIG_OVERLAYS;
 import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.deploy;
+import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.keepArtifacts;
 import static com.ibm.streamsx.topology.internal.core.InternalProperties.TOOLKITS_JSON;
 import static com.ibm.streamsx.topology.internal.graph.GraphKeys.CFG_STREAMS_VERSION;
-import static com.ibm.streamsx.topology.internal.graph.GraphKeys.NAME;
-import static com.ibm.streamsx.topology.internal.graph.GraphKeys.NAMESPACE;
 import static com.ibm.streamsx.topology.internal.graph.GraphKeys.splAppName;
 import static com.ibm.streamsx.topology.internal.graph.GraphKeys.splAppNamespace;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.array;
@@ -69,6 +68,16 @@ import com.ibm.streamsx.topology.internal.toolkit.info.ToolkitInfoModelType;
 
 public class ToolkitRemoteContext extends RemoteContextImpl<File> {
 
+	private final boolean keepToolkit;
+
+	public ToolkitRemoteContext() {
+        this.keepToolkit = false;
+    }
+	
+    public ToolkitRemoteContext(boolean keepToolkit) {
+        this.keepToolkit = keepToolkit;
+    }
+	
     @Override
     public Type getType() {
         return Type.TOOLKIT;
@@ -106,9 +115,10 @@ public class ToolkitRemoteContext extends RemoteContextImpl<File> {
         
         generateSPL(toolkitRoot, jsonGraph);
         
-        JsonObject results = new JsonObject();
-        results.addProperty(SubmissionResultsKeys.TOOLKIT_ROOT, toolkitRoot.getAbsolutePath());
-        submission.add(RemoteContext.SUBMISSION_RESULTS, results);
+        if (keepToolkit || keepArtifacts(submission)) {
+        	final JsonObject submissionResult = GsonUtilities.getProperty(submission, RemoteContext.SUBMISSION_RESULTS);
+        	submissionResult.addProperty(SubmissionResultsKeys.TOOLKIT_ROOT, toolkitRoot.getAbsolutePath());
+        }
         
         setupJobConfigOverlays(deploy, jsonGraph);
 

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/ZippedToolkitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/ZippedToolkitRemoteContext.java
@@ -27,6 +27,7 @@ import java.util.zip.ZipOutputStream;
 
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
+import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.internal.process.CompletedFuture;
 
 public class ZippedToolkitRemoteContext extends ToolkitRemoteContext {
@@ -50,9 +51,8 @@ public class ZippedToolkitRemoteContext extends ToolkitRemoteContext {
         
         Path zipOutPath = pack(toolkitRoot.toPath(), namespace, name, tkName);
         
-        JsonObject results = new JsonObject();
-        results.addProperty(SubmissionResultsKeys.ARCHIVE_PATH, zipOutPath.toString());
-        submission.add(RemoteContext.SUBMISSION_RESULTS, results);
+        final JsonObject submissionResult = GsonUtilities.getProperty(submission, RemoteContext.SUBMISSION_RESULTS);        
+        submissionResult.addProperty(SubmissionResultsKeys.ARCHIVE_PATH, zipOutPath.toString());
         
         JsonObject deployInfo = object(submission, SUBMISSION_DEPLOY);
         deleteToolkit(toolkitRoot, deployInfo);

--- a/java/src/com/ibm/streamsx/topology/internal/gson/GsonUtilities.java
+++ b/java/src/com/ibm/streamsx/topology/internal/gson/GsonUtilities.java
@@ -180,4 +180,24 @@ public class GsonUtilities {
 
         return item; 
     }
+    
+
+    /**
+     * Get a property from a JSON object.  If the property doesn't exist, create it, and assign it an empty JSON object
+     *  
+     * @param obj source JSON object
+     * @param property property to retrieve
+     * @return The associated value of the property
+     */
+    public static JsonObject getProperty (final JsonObject obj, final String property) { 
+    	final JsonObject result;
+    	if (obj.has(property)) {
+    		result = object(obj, property);
+    	} else {
+    		result = new JsonObject();
+    		obj.add(property,  result);
+    	}
+    	return result;
+    }
+    	
 }


### PR DESCRIPTION
When `keepArtifacts=True`, submission result should contain:
* `toolkitRoot` attribute
* `bundlePath` if context is BUNDLE or streams install is available
* `archivePath`, if context is BUILD_ARCHIVE or if streams install is not available.

When `keepArtifacts=False`, submission result should not contain the above attributes, unless the context requires it.

Fixes IBMStreams/streamsx.topology#835, IBMStreams/streamsx.topology#836