### PR TITLE
Enable SSL certifcate verification by default

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -9,9 +9,6 @@ import streamsx.st as st
 from .rest_primitives import Domain, Instance, Installation, Resource, _StreamsRestClient, StreamingAnalyticsService,  _exact_resource
 from .rest_errors import ViewNotFoundError
 from pprint import pformat
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 logger = logging.getLogger('streamsx.rest')
 
@@ -31,8 +28,10 @@ class StreamsConnection:
         resource_url: Root URL for IBM Streams REST API.
 
     Example:
+        >>> # If the resource url does not have a valid SSL certificate, you can disable the SSL verification
         >>> _resource_url = "https://streamsqse.localdomain:8443/streams/rest/resources"
         >>> sc = StreamsConnection(username="streamsadmin", password="passw0rd", resource_url=_resource_url)
+        >>> sc.session.verify=False
         >>> instances = sc.get_instances()
         >>> jobs_count = 0
         >>> for instance in instances:
@@ -61,6 +60,7 @@ class StreamsConnection:
         self.resource_url = resource_url
         self.rest_client = _StreamsRestClient(username, password, self.resource_url)
         self.rest_client._sc = self
+        self.session = self.rest_client.session
         self._analytics_service = False
 
     def _get_elements(self, resource_name, eclass, id=None):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -101,11 +101,8 @@ class _StreamsRestClient(object):
         self._username = username
         self._password = password
 
-        session = requests.Session()
-        session.auth = (username, password)
-        session.verify = False
-
-        self.session = session
+        self.session = requests.Session()
+        self.session.auth = (username, password)
 
     def make_request(self, url):
         logger.debug('Beginning a REST request to: ' + url)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -16,14 +16,12 @@ except (ImportError, NameError):
 
 from streamsx import rest
 import logging
-import tempfile
 import os
 import os.path
 import json
 import subprocess
 import threading
 import sys
-import enum
 import codecs
 import tempfile
 
@@ -198,6 +196,9 @@ class _BaseSubmitter(object):
 
     def _create_full_json(self):
         fj = dict()
+
+        # Removing Streams Connection object because it is not JSON serializable, and not applicable for submission
+        self.config.pop(ConfigParams.STREAMS_CONNECTION, None)
         fj["deploy"] = self.config
         fj["graph"] = self.graph.generateSPLGraph()
 
@@ -316,7 +317,7 @@ class _StreamingAnalyticsSubmitter(_BaseSubmitter):
     """
     def __init__(self, ctxtype, config, graph):
         super(_StreamingAnalyticsSubmitter, self).__init__(ctxtype, config, graph)
-        self._streams_connection = None
+        self._streams_connection = self._config().get(ConfigParams.STREAMS_CONNECTION)
         self._vcap_services = self._config().get(ConfigParams.VCAP_SERVICES)
         self._service_name = self._config().get(ConfigParams.SERVICE_NAME)
 
@@ -349,7 +350,7 @@ class _DistributedSubmitter(_BaseSubmitter):
     """
     def __init__(self, ctxtype, config, graph, username, password):
         _BaseSubmitter.__init__(self, ctxtype, config, graph)
-        self._streams_connection = None
+        self._streams_connection = config.get(ConfigParams.STREAMS_CONNECTION)
         self.username = username
         self.password = password
 
@@ -511,6 +512,10 @@ class ConfigParams(object):
     JOB_CONFIG = 'topology.jobConfigOverlays'
     """
     Key for a :py:class:`JobConfig` object representing a job configuration for a submission.
+    """
+    STREAMS_CONNECTION = 'topology.streamsConnection'
+    """
+    Key for a :py:class:`StreamsConnection` object for connecting to a running IBM Streams instance.
     """
 
 class JobConfig(object):

--- a/test/python/rest/README.md
+++ b/test/python/rest/README.md
@@ -14,7 +14,36 @@ To run the test suite, just invoke
 ```
 python test_runner.py
 ```
+or
+```
+python -m unittest rests_*
+```
 
-### Configuring the rest tests
-If you would like to supply a different SWS username and password for the rest tests, modify the sws_credentials.json
-to include the correct values.
+You can add filter to run a particular module, class or test method by:
+```
+# Run all tests within rest_local_tests module
+python -m unittest rest_local_tests
+```
+or
+```
+# Run all test methods within TestRestFeaturesLocal class in rest_local_tests module
+python -m unittest rest_local_tests.TestRestFeaturesLocal
+```
+or
+```
+# Run test_username_and_password class within rest_local_test module
+python -m unittest rest_local_tests.TestRestFeaturesLocal.test_username_and_password
+```
+
+## Configuring the rest tests
+A default set of SWS username and password for the rest_local_tests are supplied:
+* username: streamsadmin
+* password: passw0rd
+
+To change them, specify the environment variables:
+* STREAMS_USERNAME
+* STREAMS_PASSWORD
+
+To run the rest_bluemix_tests, specify the environment variables:
+* VCAP_SERVICES
+* STREAMING_ANALYTICS_SERVICE_NAME

--- a/test/python/rest/common_tests.py
+++ b/test/python/rest/common_tests.py
@@ -1,16 +1,10 @@
-from __future__ import print_function
-import json
 import logging
-import subprocess
-import time
 import unittest
+import time
 from test_operators import DelayedTupleSourceWithLastTuple
 
-from streamsx import rest
+from streamsx.topology.tester import Tester
 from streamsx.topology import topology, schema
-
-credentials_file_name = 'sws_credentials.json'
-vcap_service_config_file_name = 'vcap_service_config.json'
 
 logger = logging.getLogger('streamsx.test.rest_test')
 
@@ -27,34 +21,34 @@ class CommonTests(unittest.TestCase):
     def test_username_and_password(self):
         self.logger.debug("Beginning test: test_username_and_password.")
         # Ensure, at minimum, that the StreamsContext can connect and retrieve valid data from the SWS resources path
-        ctxt = rest.StreamsConnection(self.sws_username, self.sws_password, self.sws_rest_api_url)
-        resources = ctxt.get_resources()
+        resources = self.sc.get_resources()
         self.logger.debug("Number of retrieved resources is: " + str(len(resources)))
         self.assertGreater(len(resources), 0, msg="Returned zero resources from the \"resources\" endpoint.")
+
+    def _verify_basic_view(self):
+        q = self._view.start_data_fetch()
+
+        try:
+            view_tuple_value = q.get(block=True, timeout=25.0)
+        except:
+            logger.exception("Timed out while waiting for tuple.")
+            raise
+
+        self._view.stop_data_fetch()
+        self.logger.debug("Returned view value in basic_view_support is " + view_tuple_value)
+        self.assertTrue(view_tuple_value.startswith('hello'))
 
     def test_basic_view_support(self):
         self.logger.debug("Beginning test: test_basic_view_support.")
         top = topology.Topology('basicViewTest')
         # Send only one tuple
         stream = top.source(DelayedTupleSourceWithLastTuple(['hello'], 20))
-        view = stream.view()
+        self._view = stream.view()
 
         # Temporary workaround for Bluemix TLS issue with views
         stream.publish(schema=schema.CommonSchema.String, topic="__test_topic::test_basic_view_support")
 
-        self.logger.debug("Begging compilation and submission of basic_view_support topology.")
-
-        self._submit(top)
-
-        time.sleep(5)
-        queue = view.start_data_fetch()
-
-        try:
-            view_tuple_value = queue.get(block=True, timeout=20.0)
-        except:
-            logger.exception("Timed out while waiting for tuple.")
-            raise
-        finally:
-            view.stop_data_fetch()
-        self.logger.debug("Returned view value in basic_view_support is " + view_tuple_value)
-        self.assertTrue(view_tuple_value.startswith('hello'))
+        self.logger.debug("Beginning compilation and submission of basic_view_support topology.")
+        tester = Tester(top)
+        tester.local_check = self._verify_basic_view
+        tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/rest/rest_bluemix_tests.py
+++ b/test/python/rest/rest_bluemix_tests.py
@@ -1,37 +1,17 @@
-from common_tests import logger
-from common_tests import vcap_service_config_file_name
-from common_tests import CommonTests
-from streamsx import rest
-from streamsx.topology import context
-import json
+import unittest
+import test_vers
+from common_tests import CommonTests, logger
+from streamsx.topology.tester import Tester
+from streamsx.topology.context import ConfigParams
+from streamsx.rest import StreamingAnalyticsConnection
 
+@unittest.skipIf(not test_vers.tester_supported() , "Tester not supported")
 class TestRestFeaturesBluemix(CommonTests):
     @classmethod
     def setUpClass(cls):
-        """
-        Initialize the logger and get the SWS username, password, and REST URL.
-        :return: None
-        """
         cls.logger = logger
-        cls._submission_context = context.ContextTypes.ANALYTICS_SERVICE
 
-        # Get credentials from creds file.
-        vcap_service_config_file = open(vcap_service_config_file_name, mode='r')
-        try:
-            vcap_service_config = json.loads(vcap_service_config_file.read())
-        except:
-            cls.logger.exception("Error while reading and parsing " + vcap_service_config_file_name)
-            raise
-
-        vs = rest.VcapUtils.get_vcap_services(vcap_service_config)
-        credentials = rest.VcapUtils.get_credentials(vcap_service_config, vs)
-        rest_api_url = rest.VcapUtils.get_rest_api_url_from_creds(credentials)
-
-        cls.vcap_service_config = vcap_service_config
-        cls.sws_username = credentials['userid']
-        cls.sws_password = credentials['password']
-        cls.sws_rest_api_url = rest_api_url
-
-
-    def _submit(self, topology):
-        return context.submit(self._submission_context, topology, config=self.vcap_service_config)
+    def setUp(self):
+        Tester.setup_streaming_analytics(self, force_remote_build=True)
+        self.sc = StreamingAnalyticsConnection()
+        self.test_config[ConfigParams.STREAMS_CONNECTION]=self.sc

--- a/test/python/rest/rest_local_tests.py
+++ b/test/python/rest/rest_local_tests.py
@@ -1,48 +1,18 @@
-from __future__ import print_function
-import json
-import logging
-import subprocess
 import unittest
-from common_tests import CommonTests
+import test_vers
+from common_tests import CommonTests, logger
+from streamsx.topology.tester import Tester
+from streamsx.topology.context import ConfigParams
+from streamsx.rest import StreamsConnection
 
-from common_tests import logger
-from common_tests import vcap_service_config_file_name
-from common_tests import credentials_file_name
-
-from streamsx.topology import context
-
+@unittest.skipIf(not test_vers.tester_supported() , "Tester not supported")
 class TestRestFeaturesLocal(CommonTests):
     @classmethod
     def setUpClass(cls):
-        """
-        Initialize the logger and get the SWS username, password, and REST URL.
-        :return: None
-        """
         cls.logger = logger
-        cls.logger.debug("Performing setUpClass of TestRestFeaturesLocal")
-        cls._submission_context = context.ContextTypes.DISTRIBUTED
 
-        # Get credentials from creds file.
-        creds_file = open(credentials_file_name, mode='r')
-        try:
-            creds_json = json.loads(creds_file.read())
-            cls.sws_username = creds_json['username']
-            cls.sws_password = creds_json['password']
-        except:
-            cls.logger.exception("Error while reading and parsing " + credentials_file_name)
-            raise
-
-        # Get the SWS REST URL
-        try:
-            cls.sws_rest_api_url = creds_json['rest_api_url']
-        except:
-            try:
-                process = subprocess.Popen(['streamtool', 'geturl', '--api'],
-                                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                cls.sws_rest_api_url = process.stdout.readline().strip().decode('utf-8')
-            except:
-                cls.logger.exception("Error getting SWS rest api url via streamtool")
-                raise
-
-    def _submit(self, topology):
-        return context.submit(self._submission_context, topology, username = self.sws_username, password=self.sws_password)
+    def setUp(self):
+        Tester.setup_distributed(self)
+        self.sc = StreamsConnection()
+        self.sc.session.verify = False
+        self.test_config[ConfigParams.STREAMS_CONNECTION] = self.sc

--- a/test/python/rest/sws_credentials.json
+++ b/test/python/rest/sws_credentials.json
@@ -1,1 +1,0 @@
-{"username":"streamsadmin", "password":"passw0rd"}

--- a/test/python/rest/test_vers.py
+++ b/test/python/rest/test_vers.py
@@ -1,0 +1,21 @@
+import csv
+import os
+import sys
+
+def get_version():
+    if 'STREAMS_INSTALL' not in os.environ:
+        return '4.2.x.x'
+
+    pvf = os.environ['STREAMS_INSTALL'] + '/.product'
+    vers={}
+    with open(pvf, "r") as cf:
+        reader = csv.reader(cf, delimiter='=', quoting=csv.QUOTE_NONE)
+        for row in reader:
+            vers[row[0]] = row[1] 
+    return vers['Version']
+
+def tester_supported():
+    if sys.version_info.major == 2:
+        return False
+    v = get_version()
+    return not v.startswith('4.0.') and not v.startswith('4.1.')

--- a/test/python/rest/vcap_service_config.json
+++ b/test/python/rest/vcap_service_config.json
@@ -1,5 +1,0 @@
-{
-  "topology.service.vcap" : "/tmp/vcap_services.json",
-  "topology.service.name" : "Streaming Analytics-be",
-  "topology.forceRemoteBuild" : "True"
-}


### PR DESCRIPTION
Change summary:
* Customize StreamsConnection object with requests session arguments
* topology.context.submit config object accept StreamsConnection object
* Update unittests to disable SSL certificate for local streams connection
* Modify unittests in test/python/rest to use env variables to get credentials

Fixes IBMStreams/streamsx.topology#857