### PR TITLE
Support views of string and SPL schemas

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
@@ -176,3 +176,9 @@ def float64(value):
     Create an SPL ``float64`` value.
     """
     return Expression('FLOAT64', int(value))
+
+def rstring(value):
+    """
+    Create an SPL ``rstring`` value.
+    """
+    return Expression('RSTRING', str(value))

--- a/test/python/topology/test2_views.py
+++ b/test/python/topology/test2_views.py
@@ -9,6 +9,7 @@ from streamsx.topology import context
 from streamsx import rest
 import streamsx.ec as ec
 import streamsx.spl.op as op
+import streamsx.spl.types as spltypes
 import queue
 
 import test_vers
@@ -29,18 +30,15 @@ class TestViews(unittest.TestCase):
         for i in range(100):
              try:
                   v = q.get(timeout=1.0)
-                  print("QUEUE GOT:", v, flush=True)
                   self.assertTrue(isinstance(v, self._expected_type))
                   seen_items = True
              except queue.Empty :
-                  print("QUEUE IS EMPTY", flush=True)
                   pass
         self.assertTrue(seen_items)
         self._ov.stop_data_fetch()
-        print("QUEUE-FINISHED")
 
     def test_object_view(self):
-        """ Test the at least tuple count.
+        """ Test a view of Python objects.
         """
         topo = Topology()
         s = topo.source(rands)
@@ -56,14 +54,14 @@ class TestViews(unittest.TestCase):
         tester.test(self.test_ctxtype, self.test_config)
 
     def test_string_view(self):
-        """ Test the at least tuple count.
+        """ Test a view of strings
         """
-        raise unittest.SkipTest("Not yet ready")
         topo = Topology()
         s = topo.source(rands)
         throttle = op.Map('spl.utility::Throttle', s,
             params = {'rate': 50.0})
         s = throttle.stream
+        s = s.map(lambda t : "ABC" + str(t))
         s = s.as_string()
         self._ov = s.view()
         self._expected_type = str
@@ -73,3 +71,21 @@ class TestViews(unittest.TestCase):
         tester.tuple_count(s, 1000, exact=False)
         tester.test(self.test_ctxtype, self.test_config)
 
+    def test_schema_view(self):
+        """ Test a view of SPL tuples.
+        """
+        topo = Topology()
+        s = op.Source(topo, "spl.utility::Beacon",
+            'tuple<uint64 seq, rstring fixed>',
+            params = {'period': 0.02, 'iterations':1000})
+        s.seq = s.output('IterationCount()')
+        s.fixed = s.output(spltypes.rstring('FixedValue'))
+
+        s = s.stream
+        self._ov = s.view()
+        self._expected_type = dict
+        
+        tester = Tester(topo)
+        tester.local_check = self._object_view
+        tester.tuple_count(s, 1000)
+        tester.test(self.test_ctxtype, self.test_config)


### PR DESCRIPTION
Convert the dictionary (converted from the JSON for a view item) into the original Python representation of a tuple.

Python: Json load string value from the `rstring jsonString`
String: Convert the value into a string (from `rstring string`)
SPL schema: Use the object as-is (dict).