### PR TITLE
Remove get_views() and get_view()

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -135,33 +135,6 @@ class StreamsConnection:
         """
         return self._get_elements('installations', Installation)
 
-    def get_views(self):
-        """Gets a list of all View resources across all known streams installations.
-
-        :return: Returns a list of all View resources.
-        :type return: list.
-        """
-        views = []
-        for domain in self.get_domains():
-            for instance in domain.get_instances():
-                for view in instance.get_views():
-                    views.append(view)
-        return views
-
-    def get_view(self, name):
-        """Gets a view with the specified `name`. If there are multiple views with the same name, it will return
-        the first one encountered.
-
-        :param name: The name of the View resource.
-        :return: The view resource with the specified `name`.
-        """
-        for domain in self.get_domains():
-            for instance in domain.get_instances():
-                for view in instance.get_views():
-                    if view.name == name:
-                        return view
-        raise ViewNotFoundError("Could not locate view: " + name)
-
     def get_resources(self):
         resources = []
         json_resources = self.rest_client.make_request(self.resource_url)['resources']


### PR DESCRIPTION
At this point removing these methods as:

- `get_views()` breaks if an instance visible in the domain is not running.
- `get_view()` does not work for views that are within composites.

Rather than try to fix these at this point (close to a release) remove them and they can be added back later, especially once we have a strategy for how to accurately match view "logical" names to the name reported in the REST call. (or do we match by id?).

One can still obtain a list of views for an instance or a job. 

Fixes #856 (at least for this release).