### PR TITLE
Initial get_published_streams method

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -468,7 +468,7 @@ class Instance(_ResourceElement):
         and subscribers are independent of each other.
 
         A published stream has a topic and a schema. It is recommended that a
-        topic has only a single schema.
+        topic is only associated with a single schema.
 
         Streams may be published and subscribed by applications regardless of the
         implementation language. For example a Python application can publish

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -21,7 +21,7 @@ class StreamSchema(object) :
     def schema(self):
         return self.__schema
 
-    def str(self):
+    def __str__(self):
         return self.__schema
 
     def spl_json(self):
@@ -112,5 +112,5 @@ class CommonSchema(enum.Enum):
     def extend(self, schema):
         return self.value.extend(schema)
 
-    def str(self):
+    def __str__(self):
         return str(self.schema())

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -705,7 +705,7 @@ class Stream(object):
         """
         self.sink(streamsx.topology.functions.print_flush)
 
-    def publish(self, topic, schema=schema.CommonSchema.Python):
+    def publish(self, topic, schema=None):
         """
         Publish this stream on a topic for other Streams applications to subscribe to.
         A Streams application may publish a stream to allow other
@@ -732,7 +732,7 @@ class Stream(object):
         Returns:
             None
         """
-        if self.oport.schema.schema() != schema.schema():
+        if schema is not None and self.oport.schema.schema() != schema.schema():
             self._map(streamsx.topology.functions.identity,schema=schema).publish(topic, schema=schema)
             return None
 

--- a/test/python/topology/test2_pubsub.py
+++ b/test/python/topology/test2_pubsub.py
@@ -1,0 +1,54 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016
+import unittest
+import sys
+import itertools
+
+import test_vers
+
+from streamsx.topology.topology import *
+from streamsx.topology.tester import Tester
+from streamsx.topology import schema
+import streamsx.topology.context
+import streamsx.spl.op as op
+
+import uuid
+
+
+@unittest.skipIf(not test_vers.tester_supported() , "tester not supported")
+class TestPubSub(unittest.TestCase):
+    """ Test publish/subscribe
+    """
+    def setUp(self):
+        Tester.setup_distributed(self)
+
+    def _check_topics(self):
+        pass
+
+    def test_published_topics(self):
+        """Test a published stream is available through get_published_topics.
+        """
+        self.topic_spl = 'topology/test/python/' + str(uuid.uuid4())
+        self.topic_python = 'topology/test/python/' + str(uuid.uuid4())
+        self.assertNotEqual(self.topic_spl, self.topic_python)
+
+        topo = Topology()
+        s = op.Source(topo, "spl.utility::Beacon",
+            'tuple<uint64 seq>',
+            params = {'period': 0.02})
+        s.seq = s.output('IterationCount()')
+
+        s.stream.publish(topic=self.topic_spl)
+
+        s = s.stream.map(lambda x : x)
+        s.publish(topic=self.topic_python)
+
+        self.tester = Tester(topo)
+        #self.tester.local_check = self._check_topics
+        self.tester.tuple_count(s, 300)
+        self.tester.test(self.test_ctxtype, self.test_config)
+
+@unittest.skipIf(not test_vers.tester_supported() , "tester not supported")
+class TestBluemixPubSub(TestPubSub):
+    def setUp(self):
+        Tester.setup_streaming_analytics(self, force_remote_build=True)

--- a/test/python/topology/test2_pubsub.py
+++ b/test/python/topology/test2_pubsub.py
@@ -10,6 +10,8 @@ from streamsx.topology.topology import *
 from streamsx.topology.tester import Tester
 from streamsx.topology import schema
 import streamsx.topology.context
+from streamsx.topology.schema import StreamSchema as StSc
+from streamsx.topology.schema import CommonSchema as CmnSc
 import streamsx.spl.op as op
 
 import uuid
@@ -32,7 +34,11 @@ class TestPubSub(unittest.TestCase):
         for pt in topics:
             if self.topic_spl == pt.topic:
                 sts += 1
+                if pt.schema is not None:
+                    self.assertEqual(StSc('tuple<uint64 seq>'), pt.schema)
             elif self.topic_python == pt.topic:
+                if pt.schema is not None:
+                    self.assertEqual(CmnSc.Python.value, pt.schema)
                 stp += 1
 
         self.assertEqual(1, sts)


### PR DESCRIPTION
skip ci

Initial get_published_streams  method that gets the published streams and their topics from the exported streams.

WIP: Still to be done:
  - Get the schema of the stream
  - De-duplicate {topic,schema} pairs.