### PR TITLE
Fix test2_views unittest

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -269,16 +269,17 @@ class Tester(object):
         return sr['return_code'] == 0
 
     def _distributed_test(self, config, username, password):
-        sjr = stc.submit(stc.ContextTypes.DISTRIBUTED, self.topology, config, username=username, password=password)
-        self.submission_result = sjr
-        if sjr['return_code'] != 0:
-            print("DO AS LOGGER", "Failed to submit job to distributed instance.")
-            return False
         self.sc = config.get(ConfigParams.STREAMS_CONNECTION)
         if self.sc is None:
             # Disable SSL verification
             self.sc = StreamsConnection(username, password)
             self.sc.session.verify = False
+            config[ConfigParams.STREAMS_CONNECTION] = self.sc
+        sjr = stc.submit(stc.ContextTypes.DISTRIBUTED, self.topology, config, username=username, password=password)
+        self.submission_result = sjr
+        if sjr['return_code'] != 0:
+            print("DO AS LOGGER", "Failed to submit job to distributed instance.")
+            return False
         return self._distributed_wait_for_result()
 
     def _streaming_analytics_test(self, ctxtype, config):

--- a/test/python/topology/test2_unicode.py
+++ b/test/python/topology/test2_unicode.py
@@ -6,8 +6,10 @@ import unittest
 from streamsx.topology.topology import *
 from streamsx.topology.tester import Tester
 from streamsx.topology import context
+from streamsx.topology.context import ConfigParams
 from streamsx import rest
 import streamsx.ec as ec
+
 
 import test_vers
 
@@ -86,6 +88,10 @@ class TestDistributedUnicode(TestUnicode):
         password = self.password
 
         self.sc = rest.StreamsConnection(username=username, password=password)
+
+        # Disable SSL verification
+        self.sc.session.verify = False
+        self.test_config[ConfigParams.STREAMS_CONNECTION] = self.sc
 
 @unittest.skipIf(not test_vers.tester_supported() , "Tester not supported")
 class TestBluemixUnicode(TestUnicode):


### PR DESCRIPTION
* Tester to add SSL disabled StreamsConnection object into test_config
* modify test2_unicode.py to disable SSL verification

Fixes IBMStreams/streamsx.topology#886