### PR TITLE
Submission results should be interactable.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -693,3 +693,5 @@ class SubmissionResult(object):
             return
         self.__delattr__(key)
 
+    def __contains__(self, item):
+        return item in self.results

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -77,7 +77,7 @@ def submit(ctxtype, graph, config=None, username=None, password=None):
         raise ValueError("Topology {0} does not contain any streams.".format(graph.topology.name))
 
     context_submitter = _SubmitContextFactory(graph, config, username, password).get_submit_context(ctxtype)
-    return _SubmissionResult(context_submitter.submit())
+    return SubmissionResult(context_submitter.submit())
 
 
 
@@ -647,7 +647,7 @@ class JobConfig(object):
         if jc:
             jco["jobConfig"] = jc
 
-class _SubmissionResult(object):
+class SubmissionResult(object):
     """Passed back to the user after a call to submit.
     Allows the user to use dot notation to access dictionary elements."""
     def __init__(self, results):
@@ -679,7 +679,7 @@ class _SubmissionResult(object):
             results = self.results
             results[key] = value
         else:
-            super(_SubmissionResult, self).__setattr__(key, value)
+            super(SubmissionResult, self).__setattr__(key, value)
 
     def __getitem__(self, item):
         return self.__getattr__(item)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -239,7 +239,6 @@ class Tester(object):
 
         if config is None:
             config = {}
-
         _logger.debug("Starting test topology %s context %s.", self.topology.name, ctxtype)
 
         if stc.ContextTypes.STANDALONE == ctxtype:

--- a/test/python/topology/test2_submission_result.py
+++ b/test/python/topology/test2_submission_result.py
@@ -1,0 +1,47 @@
+import unittest
+from streamsx.topology.tester import Tester
+from streamsx.topology.topology import Topology
+from streamsx.topology.context import ConfigParams
+from streamsx import rest
+
+import test_vers
+
+@unittest.skipIf(not test_vers.tester_supported() , "Tester not supported")
+class TestSubmissionResult(unittest.TestCase):
+    def setUp(self):
+        Tester.setup_distributed(self)
+
+    def _correct_job_ids(self):
+        # Test that result.job exists and you can pull values from it.
+        json_job_id = self.tester.submission_result.jobId
+        job_job_id = self.tester.submission_result.job.id
+        self.assertEqual(json_job_id, job_job_id)
+
+    def test_get_job(self):
+        topo = Topology("job_in_result_test")
+        topo.source(["foo"])
+
+        sc = rest.StreamsConnection(username=self.username, password=self.password)
+        sc.session.verify = False
+        config = {ConfigParams.STREAMS_CONNECTION : sc}
+
+        tester = Tester(topo)
+        self.tester = tester
+
+        tester.local_check = self._correct_job_ids
+        tester.test(self.test_ctxtype, config)
+
+
+class TestSubmissionResultStreamingAnalytics(TestSubmissionResult):
+    def setUp(self):
+        Tester.setup_streaming_analytics(self, force_remote_build=True)
+
+    def test_get_job(self):
+        topo = Topology("job_in_result_test")
+        topo.source(["foo"])
+
+        tester = Tester(topo)
+        self.tester = tester
+
+        tester.local_check = self._correct_job_ids
+        tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/topology/test2_test.py
+++ b/test/python/topology/test2_test.py
@@ -56,7 +56,7 @@ class TestTester(unittest.TestCase):
 
     def my_local(self):
         self.assertTrue(hasattr(self.tester, 'submission_result'))
-        self.assertTrue(hasattr(self.tester, 'sc'))
+        self.assertTrue(hasattr(self.tester, 'streams_connection'))
         self.my_local_called = True
    
 


### PR DESCRIPTION
Only WIP because I'm running the python tests locally before indicating that this is ready to be merged.

**Changes.**
* The result of `submit` now returns an instance of the `SubmissionResult` class.
  * The `SubmissionResult` class allows access of fields through `[]` notation or dot notation.
* The `StreamsConnection`, when possible, is returned in the submission result
