### PR TITLE
Get resource URL only when there is a REST API request

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -49,8 +49,8 @@ class StreamsConnection:
             username = 'streamsadmin'
             password = 'passw0rd'
         else:
-            raise ValueError("Must supply either a BlueMix VCAP Services or a username, password"
-                             " to the StreamsContext constructor.")
+            raise ValueError("Must supply either a Bluemix VCAP Services or a username, password"
+                             " to the StreamsConnection constructor.")
 
         self._resource_url = resource_url
         self.rest_client = _StreamsRestClient(username, password)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -30,9 +30,6 @@ def _matching_resource(json_rep, name=None):
         return re.match(name, json_rep['name'])
     return True
 
-  
-
-
 class _ResourceElement(object):
     """A class whose fields are populated by the JSON returned from a REST call.
     """
@@ -107,18 +104,14 @@ class _ResourceElement(object):
         raise ValueError("Multiple resources matching: {0}".format(id))
 
 class _StreamsRestClient(object):
-    """Handles the session connection with the Streams REST API.
-
-    :param username: The username of an authorized Streams user.
-    :type username: str.
-    :param password: The password associated with the username.
-    :type password: str.
-    :param resource_url: The resource endpoint of the instance. Can be found with `st geturl --api` for local Streams
-    installs.
-    :type resource_url: str.
+    """Handles the session connection with the Streams REST API
     """
-    def __init__(self, username, password, resource_url):
-        self.resource_url = resource_url
+    def __init__(self, username, password):
+        """
+        Args:
+            username(str): The username of an authorized Streams user.
+            password(str): The password associated with the username.
+        """
         # Create session to reuse TCP connection
         # https authentication
         self._username = username

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -8,11 +8,8 @@ import time
 import json
 import re
 
-from pprint import pprint, pformat
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from pprint import pformat
 import streamsx.topology.schema
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 logger = logging.getLogger('streamsx.rest')
 
@@ -29,6 +26,7 @@ def _matching_resource(json_rep, name=None):
             return False
         return re.match(name, json_rep['name'])
     return True
+
 
 class _ResourceElement(object):
     """A class whose fields are populated by the JSON returned from a REST call.
@@ -102,6 +100,7 @@ class _ResourceElement(object):
         if len(elements) == 1:
             return elements[0]
         raise ValueError("Multiple resources matching: {0}".format(id))
+
 
 class _StreamsRestClient(object):
     """Handles the session connection with the Streams REST API
@@ -210,6 +209,7 @@ def _get_view_dict_tuple(item):
     """
     return item.data
 
+
 class View(_ResourceElement):
     """The view element resource provides access to information about a view that is associated with an active job, and
     exposes methods to retrieve data from the View's Stream.
@@ -256,11 +256,13 @@ class View(_ResourceElement):
         logger.debug("Retrieved " + str(len(view_items)) + " items from view " + self.name)
         return view_items
 
+
 class ViewItem(_ResourceElement):
     """
     Represents the data of a tuple, it's type, and the time when it was collected from the stream.
     """
     pass
+
 
 class Host(_ResourceElement):
     """The host element resource provides access to information about a host that is allocated to a domain as a
@@ -322,6 +324,7 @@ class Job(_ResourceElement):
             return True
         raise NotImplementedError('Job.cancel()')
 
+
 class Operator(_ResourceElement):
     """The operator element resource provides access to information about a specific operator in a job.
     """
@@ -339,11 +342,13 @@ class Operator(_ResourceElement):
         """
         return self._get_elements(self.metrics, 'metrics', Metric, name=name)
 
+
 class OperatorConnection(_ResourceElement):
     """The operator connection element resource provides access to information about a connection between two operator
     ports.
     """
     pass
+
 
 class OperatorOutputPort(_ResourceElement):
     """Operator output port resource provides access to information about an output port
@@ -352,11 +357,13 @@ class OperatorOutputPort(_ResourceElement):
     """
     pass
 
+
 class Metric(_ResourceElement):
     """
     Metric resource provides access to information about a Streams metric.
     """
     pass
+
 
 class PE(_ResourceElement):
     """The processing element (PE) resource provides access to information about a PE.
@@ -427,6 +434,7 @@ class ExportedStream(_ResourceElement):
                 schema = streamsx.topology.schema.StreamSchema(ta_resp['splType'])
             return PublishedTopic(topic[1:-1], schema)
         return
+
 
 class Instance(_ResourceElement):
     """The instance element resource provides access to information about a Streams instance."""

--- a/test/python/topology/test2.py
+++ b/test/python/topology/test2.py
@@ -116,22 +116,11 @@ class TestBundleMethodsNew(TestToolkitMethodsNew):
 class TestSubmitArgumentsMethodsNew(unittest.TestCase):
 
     def setUp(self):
-        if not 'STREAMS_DOMAIN_ID' in os.environ:
-            self.skipTest('STREAMS_DOMAIN_ID not set')
-        if not 'STREAMS_INSTANCE_ID' in os.environ:
-            self.skipTest('STREAMS_INSTANCE_ID not set')
-
         self.topo = Topology('test_SubmitArg')
         self.topo.source(['Hello', 'SubmitArg'])
         self.test_ctxtype = 'DISTRIBUTED'
         self.test_config = {}
         self.result = {}
-
-    def test_SameCredential(self):
-        sc = rest.StreamsConnection('user1', 'pass1')
-        self.test_config[ConfigParams.STREAMS_CONNECTION] = sc
-        self.result = streamsx.topology.context.submit(self.test_ctxtype, self.topo, self.test_config, username='user1', password='pass1')
-        self.assertEqual(self.result['return_code'], 0)
 
     def test_DifferentUsername(self):
         sc = rest.StreamsConnection('user1', 'pass1')


### PR DESCRIPTION
Fixes IBMStreams/streamsx.topology#908

* removing `test2.TestSubmitArgumentsMethodsNew.test_SameCredential` because most distributed tests that are going through Tester, are already supplying the same credential into both the submit() and StreamsConnection object.  This test is not providing additional test coverage.