### PR TITLE
Use StreamsConnection credentials info config during submit

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -93,19 +93,19 @@ class StreamsConnection:
         """
         return self._get_elements('domains')
 
-    def get_domain(self, domain_id):
+    def get_domain(self, id):
         """Retrieve available domain matching a specific domain ID
 
         Args:
-            domain_id (str): domain ID
+            id (str): domain ID
 
         Returns:
-            :py:class:`~.rest_primitives.Domain`: Domain matching `domain_id`
+            :py:class:`~.rest_primitives.Domain`: Domain matching `id`
 
         Raises:
             ValueError: No matching domain exists or multiple matching domains exist.
         """
-        return self._get_element_by_id('domains', Domain, domain_id)
+        return self._get_element_by_id('domains', Domain, id)
 
     def get_instances(self):
         """Retrieve available instances.
@@ -115,19 +115,19 @@ class StreamsConnection:
         """
         return self._get_elements('instances', Instance, id=id)
 
-    def get_instance(self, instance_id):
+    def get_instance(self, id):
         """Retrieve available instance matching a specific instance ID.
 
         Args:
-            instance_id (str): Instance identifier to retrieve.
+            id (str): Instance identifier to retrieve.
 
         Returns:
-            :py:class:`~.rest_primitives.Instance`: Instance matching `instance_id`.
+            :py:class:`~.rest_primitives.Instance`: Instance matching `id`.
 
         Raises:
             ValueError: No matching instance exists or multiple matching instances exist.
         """
-        return self._get_element_by_id('instances', Instance, instance_id)
+        return self._get_element_by_id('instances', Instance, id)
 
     def get_installations(self):
         """Retrieves a list of all known Streams installations.
@@ -171,7 +171,10 @@ class StreamingAnalyticsConnection(StreamsConnection):
     """
     def __init__(self, vcap_services=None, service_name=None):
         vcap = _get_vcap_services(vcap_services)
-        self.credentials = _get_credentials(vcap, service_name)
+        self.service_name = service_name
+        if service_name is None:
+            self.service_name = os.environ.get('STREAMING_ANALYTICS_SERVICE_NAME')
+        self.credentials = _get_credentials(vcap, self.service_name)
         super(StreamingAnalyticsConnection, self).__init__(self.credentials['userid'], self.credentials['password'])
         self._analytics_service = True
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -322,8 +322,19 @@ class _StreamingAnalyticsSubmitter(_BaseSubmitter):
         self._vcap_services = self._config().get(ConfigParams.VCAP_SERVICES)
         self._service_name = self._config().get(ConfigParams.SERVICE_NAME)
 
-        # TODO: compare status_path (or any REST endpoint in the credential) in the config
-        # and in the StreamsConnection object, and verify if both are same
+        if self._streams_connection is not None:
+            if not isinstance(self._streams_connection, rest.StreamingAnalyticsConnection):
+                raise ValueError("config must contain a StreamingAnalyticsConnection object when submitting to "
+                                 "{} context".format(ctxtype))
+
+            # Use credentials stored within StreamingAnalyticsConnection
+            self._service_name = self._streams_connection.service_name
+            self._vcap_services = {'streaming-analytics': [
+                {'name': self._service_name, 'credentials': self._streams_connection.credentials}
+            ]}
+            self._config()[ConfigParams.SERVICE_NAME] = self._service_name
+
+            # TODO: Compare credentials between the config and StreamsConnection, verify they are the same
 
         # Clear the VCAP_SERVICES key in config, since env var will contain the content
         self._config().pop(ConfigParams.VCAP_SERVICES, None)

--- a/test/python/topology/test2.py
+++ b/test/python/topology/test2.py
@@ -113,14 +113,13 @@ class TestBundleMethodsNew(TestToolkitMethodsNew):
 
 @unittest.skipIf(not test_vers.tester_supported(), "Tester not supported")
 @unittest.skipUnless('STREAMS_INSTALL' in os.environ, "requires STREAMS_INSTALL")
-class TestSubmitArgumentsMethodsNew(unittest.TestCase):
+class TestDistributedSubmitMethodsNew(unittest.TestCase):
 
     def setUp(self):
-        self.topo = Topology('test_SubmitArg')
-        self.topo.source(['Hello', 'SubmitArg'])
+        self.topo = Topology('test_DistributedSubmit')
+        self.topo.source(['Hello', 'DistributedSubmit'])
         self.test_ctxtype = 'DISTRIBUTED'
         self.test_config = {}
-        self.result = {}
 
     def test_DifferentUsername(self):
         sc = rest.StreamsConnection('user1', 'pass1')
@@ -133,6 +132,31 @@ class TestSubmitArgumentsMethodsNew(unittest.TestCase):
         self.test_config[ConfigParams.STREAMS_CONNECTION] = sc
         with self.assertRaises(RuntimeError):
             streamsx.topology.context.submit(self.test_ctxtype, self.topo, self.test_config, username='user1', password='pass2')
+
+@unittest.skipIf(not test_vers.tester_supported(), "Tester not supported")
+@unittest.skipUnless('VCAP_SERVICES' in os.environ, "requires VCAP_SERVICES")
+@unittest.skipUnless('STREAMING_ANALYTICS_SERVICE_NAME' in os.environ, "requires STREAMING_ANALYTICS_SERVICE_NAME")
+class TestBluemixSubmitMethodsNew(unittest.TestCase):
+
+    def setUp(self):
+        self.topo = Topology('test_BluemixSubmit')
+        self.topo.source(['Hello', 'BluemixSubmit'])
+        self.test_ctxtype = 'STREAMING_ANALYTICS_SERVICE'
+        self.test_config = {}
+
+    def test_StreamsConnection(self):
+        sc = rest.StreamsConnection('user1', 'pass1')
+        self.test_config[ConfigParams.STREAMS_CONNECTION] = sc
+        with self.assertRaises(ValueError):
+            streamsx.topology.context.submit(self.test_ctxtype, self.topo, self.test_config)
+
+    def test_StreamingAnalyticsConnection(self):
+        sc = rest.StreamingAnalyticsConnection()
+        self.test_config[ConfigParams.STREAMS_CONNECTION] = sc
+        result = streamsx.topology.context.submit(self.test_ctxtype, self.topo, self.test_config)
+        self.assertEqual(result.return_code, 0)
+        result.job.cancel()
+
 
 @unittest.skipIf(not test_vers.tester_supported() , "Tester not supported")
 class TestTopologyMethodsNew(unittest.TestCase):


### PR DESCRIPTION
Change Summary:
* revert `instance_id` to `id`, `domain_id` to `id` (changes made in PR #917)
* keep service_name in StreamingAnalyticsConnection object, so it can be recalled during job submission

Fixes #921