### PR TITLE
Reasonable name handling for Python.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -57,7 +57,7 @@ class SPLGraph(object):
         self.resolver = streamsx.topology.dependency._DependencyResolver(self.topology)
         self._views = []
         self._spl_toolkits = []
-        self._used_names = set()
+        self._used_names = {'list', 'tuple'}
 
     def get_views(self):
         return self._views
@@ -99,7 +99,7 @@ class SPLGraph(object):
             else:
                 name = self.name
 
-        # Recurse once to et unique version of name
+        # Recurse once to get unique version of name
         return self._requested_name(name)
 
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -57,6 +57,7 @@ class SPLGraph(object):
         self.resolver = streamsx.topology.dependency._DependencyResolver(self.topology)
         self._views = []
         self._spl_toolkits = []
+        self._used_names = set()
 
     def get_views(self):
         return self._views
@@ -64,24 +65,51 @@ class SPLGraph(object):
     def add_views(self, view):
         self._views.append(view)
 
+    def _requested_name(self, name, action=None, func=None):
+        """Create a unique name for an operator or a stream.
+        """
+        if name is not None:
+            if name in self._used_names:
+                # start at 2 for the "second" one of this name
+                n = 2
+                while True:
+                    pn = name + '_' + str(n)
+                    if pn not in self._used_names:
+                        self._used_names.add(pn)
+                        return pn
+                    n += 1
+            else:
+                self._used_names.add(name)
+                return name
+
+        if func is not None:
+            if hasattr(func, '__name__'):
+                name = func.__name__
+                if name == '<lambda>':
+                    # Avoid use of <> characters in name
+                    # as they are converted to unicode
+                    # escapes in SPL identifier
+                    name = action + '_lambda'
+            elif hasattr(func, '__class__'):
+                name = func.__class__.__name__
+
+        if name is None:
+            if action is not None:
+                name = action
+            else:
+                name = self.name
+
+        # Recurse once to et unique version of name
+        return self._requested_name(name)
+
+
     def addOperator(self, kind, function=None, name=None, params=None, sl=None):
         if(params is None):
             params = {}
+
         if name is None:
-            if function is not None:
-               if hasattr(function, '__name__'):
-                   n = function.__name__
-                   if n == '<lambda>':
-                       # Avoid use of <> characters in name
-                       # as they are converted to unicode
-                       # escapes in SPL identifier
-                       n = 'lambda'
-                   name = n + "_"
-               elif hasattr(function, '__class__'):
-                   name = function.__class__.__name__ + "_"
-            else:
-               name = self.name + "_OP"
-        name = name + str(len(self.operators))
+            name = self._requested_name(None,action="Op", func = function)
+
         if(kind.startswith("$")):    
             op = Marker(len(self.operators), kind, name, {}, self)                           
         else:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -57,7 +57,7 @@ class SPLGraph(object):
         self.resolver = streamsx.topology.dependency._DependencyResolver(self.topology)
         self._views = []
         self._spl_toolkits = []
-        self._used_names = {'list', 'tuple'}
+        self._used_names = {'list', 'tuple', 'int'}
 
     def get_views(self):
         return self._views

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -419,7 +419,7 @@ class Stream(object):
         sl = _SourceLocation(_source_info(), "for_each")
         name = self.topology.graph._requested_name(name, action="for_each", func=func)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::ForEach", func, name=name, sl=sl)
-        op.addInputPort(outputPort=self.oport)
+        op.addInputPort(outputPort=self.oport, name=self.name)
 
     def sink(self, func, name=None):
         """
@@ -442,14 +442,14 @@ class Stream(object):
         sl = _SourceLocation(_source_info(), "filter")
         name = self.topology.graph._requested_name(name, action="filter", func=func)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::Filter", func, name=name, sl=sl)
-        op.addInputPort(outputPort=self.oport)
+        op.addInputPort(outputPort=self.oport, name=self.name)
         oport = op.addOutputPort(schema=self.oport.schema, name=name)
         return Stream(self.topology, oport)
 
     def _map(self, func, schema, name=None):
         name = self.topology.graph._requested_name(name, action="map", func=func)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::Map", func, name=name)
-        op.addInputPort(outputPort=self.oport)
+        op.addInputPort(outputPort=self.oport, name=self.name)
         oport = op.addOutputPort(schema=schema, name=name)
         return Stream(self.topology, oport)
 
@@ -551,7 +551,7 @@ class Stream(object):
         sl = _SourceLocation(_source_info(), "flat_map")
         name = self.topology.graph._requested_name(name, action='flat_map', func=func)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::FlatMap", func, name=name, sl=sl)
-        op.addInputPort(outputPort=self.oport)
+        op.addInputPort(outputPort=self.oport, name=self.name)
         oport = op.addOutputPort(name=name)
         return Stream(self.topology, oport)
     
@@ -656,7 +656,7 @@ class Stream(object):
                 keys = ['__spl_hash']
                 hash_adder = self.topology.graph.addOperator(self.topology.opnamespace+"::HashAdder", func)
                 hash_schema = self.oport.schema.extend(schema.StreamSchema("tuple<int64 __spl_hash>"))
-                hash_adder.addInputPort(outputPort=self.oport)
+                hash_adder.addInputPort(outputPort=self.oport, name=self.name)
                 parallel_input = hash_adder.addOutputPort(schema=hash_schema)
 
             parallel_op = self.topology.graph.addOperator("$Parallel$")
@@ -757,7 +757,7 @@ class Stream(object):
 
         sl = _SourceLocation(_source_info(), "publish")
         op = self.topology.graph.addOperator("com.ibm.streamsx.topology.topic::Publish", params={'topic': topic}, sl=sl)
-        op.addInputPort(outputPort=self.oport)
+        op.addInputPort(outputPort=self.oport, name=self.name)
         self.oport.operator.colocate(op, 'publish')
 
     def autonomous(self):

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -262,16 +262,14 @@ class OperatorGenerator {
             if (!firstPort.getAndSet(false))
                 sb.append("; ");
 
-            // 
-            
-            String portName = jstring(input, "name");
+            final String portName = jstring(input, "name");
 
             // If a single input stream and its name 
             // is the same as the port name
             // then don't use an 'as'. Allows better logical names
             // where the user provided stream name is used consistently.
             boolean singleName = false;
-            JsonArray connections = array(op, "connections");
+            JsonArray connections = array(input, "connections");
             if (connections.size() == 1) {
                 String connName = connections.get(0).getAsString();
 

--- a/test/python/topology/test_names.py
+++ b/test/python/topology/test_names.py
@@ -1,0 +1,72 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+import unittest
+import itertools
+from streamsx.topology.topology import *
+
+def f42():
+    pass
+
+class cool_class(object):
+    def __init__(self):
+        pass
+    def __call__(self, t):
+        pass
+
+class TestNames(unittest.TestCase):
+
+  def test_names(self):
+     topo = Topology("Abc")
+
+     s1 = topo.source([], name="CoolSource")
+     self.assertEqual(s1.name, "CoolSource")
+
+     s1a = topo.source([], name="CoolSource")
+     self.assertEqual(s1a.name, "CoolSource_2")
+
+     s1b = topo.source([], name="CoolSource")
+     self.assertEqual(s1b.name, "CoolSource_3")
+
+     s2 = topo.source(f42)
+     self.assertEqual(s2.name, "f42")
+     s2a = topo.source(f42)
+     self.assertEqual(s2a.name, "f42_2")
+
+     s3 = topo.source(lambda : [])
+     self.assertEqual(s3.name, "source_lambda")
+     s3a = topo.source(lambda : [])
+     self.assertEqual(s3a.name, "source_lambda_2")
+
+     s4 = topo.source(cool_class())
+     self.assertEqual(s4.name, "cool_class")
+
+     s4a = topo.source(cool_class())
+     self.assertEqual(s4a.name, "cool_class_2")
+
+     s5 = topo.source([])
+     self.assertEqual(s5.name, "list")
+     s5a = topo.source([])
+     self.assertEqual(s5a.name, "list_2")
+
+     s6 = topo.source(itertools.repeat('Fred'))
+     self.assertEqual(s6.name, "repeat")
+     s6a = topo.source(itertools.repeat('Fred'))
+     self.assertEqual(s6a.name, "repeat_2")
+
+     s6.for_each(name="End", func=cool_class)
+
+     s7 = s6.filter(cool_class, name="mYF")
+     self.assertEqual(s7.name, "mYF")
+     s8 = s6.filter(cool_class)
+     self.assertEqual(s8.name, "cool_class_3")
+
+     s9 = s6.map(cool_class, name="mYM")
+     self.assertEqual(s9.name, "mYM")
+     s10 = s6.map(cool_class)
+     self.assertEqual(s10.name, "cool_class_4")
+
+     s11 = s6.flat_map(cool_class, name="mYFM")
+     self.assertEqual(s11.name, "mYFM")
+     s12 = s6.flat_map(cool_class)
+     self.assertEqual(s12.name, "cool_class_5")
+     

--- a/test/python/topology/test_names.py
+++ b/test/python/topology/test_names.py
@@ -44,9 +44,9 @@ class TestNames(unittest.TestCase):
      self.assertEqual(s4a.name, "cool_class_2")
 
      s5 = topo.source([])
-     self.assertEqual(s5.name, "list")
+     self.assertEqual(s5.name, "list_2")
      s5a = topo.source([])
-     self.assertEqual(s5a.name, "list_2")
+     self.assertEqual(s5a.name, "list_3")
 
      s6 = topo.source(itertools.repeat('Fred'))
      self.assertEqual(s6.name, "repeat")


### PR DESCRIPTION
With this app:
```
topo = stt.Topology()
s = topo.source(['a'], name="VehicleLocations")
s = s.filter(lambda _:True, name="IdleVehicles")
s = s.map(lambda _:_, name="BrokenDown")
s = s.for_each(lambda _:None, name="Alerts")
```

Before and after console view (upper is new)

![image](https://cloud.githubusercontent.com/assets/3769612/24310384/fd8ccf7a-108c-11e7-8ef8-7cbd7055b759.png)

and the output ports have the simpler name:

![image](https://cloud.githubusercontent.com/assets/3769612/24310504/67cccf7a-108d-11e7-8a95-852941e2907b.png)
