### PR TITLE
Minor cleanup.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -57,7 +57,7 @@ print splpy_inputtuple2value($pystyle);
 <%if ($pystyle eq 'dict') {%>
 @include "../pyspltuple2dict.cgt"
 <%}%>
-  streamsx::topology::Splpy::pyTupleSink(funcop_->callable(), value);
+  streamsx::topology::Splpy::pyTupleForEach(funcop_->callable(), value);
 }
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -60,7 +60,7 @@ print splpy_inputtuple2value($pystyle);
 @include "../pyspltuple2dict.cgt"
 <%}%>
   OPort0Type otuple;
-  if (streamsx::topology::Splpy::pyTupleTransform(funcop_->callable(), value,
+  if (streamsx::topology::Splpy::pyTupleMap(funcop_->callable(), value,
        otuple.get_<%=$model->getOutputPortAt(0)->getAttributeAt(0)->getName()%>()))
      submit(otuple, 0);
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -53,7 +53,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
   IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
 
 <%
-print splpy_inputtuple2value($pystyle, $pyoutstyle);
+print splpy_inputtuple2value($pystyle);
 %>
 
 <%if ($pystyle eq 'dict') {%>

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -181,6 +181,8 @@ sub splpy_inputtuple2value{
 
  if ($pystyle eq 'dict') {
   # nothing done here for dict style 
+  # instead cgt is used to generate code specific
+  # the input schema
  }
 }
 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -48,10 +48,13 @@ namespace streamsx {
 
       public:
 
-    // Call the function passing an SPL attribute
-    // converted to a Python object and discard the return 
+    /*
+     * Call the function passing an SPL attribute
+     * converted to a Python object and discard the return 
+     * Implementation for function ForEach operator.
+     */
     template <class T>
-    static void pyTupleSink(PyObject * function, T & splVal) {
+    static void pyTupleForEach(PyObject * function, T & splVal) {
       SplpyGIL lock;
 
       PyObject * arg = pySplValueToPyObject(splVal);
@@ -68,6 +71,7 @@ namespace streamsx {
     /*
     * Call a function passing the SPL attribute value of type T
     * and return the function return as a boolean
+    * Implementation for function Filter operator.
     */
     template <class T>
     static int pyTupleFilter(PyObject * function, T & splVal) {
@@ -91,9 +95,10 @@ namespace streamsx {
     /*
     * Call a function passing the SPL attribute value of type T
     * and fill in the SPL attribute of type R with its result.
+    * Implementation for function Map operator.
     */
     template <class T, class R>
-    static int pyTupleTransform(PyObject * function, T & splVal, R & retSplVal) {
+    static int pyTupleMap(PyObject * function, T & splVal, R & retSplVal) {
       SplpyGIL lock;
 
       PyObject * arg = pySplValueToPyObject(splVal);


### PR DESCRIPTION
Change implementation functions to match operator kinds.

Remove incorrect argument passed to tuple procesing perl function (`splpy_inputtuple2value`)