### PR TITLE
Sample does not run because of missing parameter

### DIFF
--- a/samples/python/topology/simple/temperature_sensor.py
+++ b/samples/python/topology/simple/temperature_sensor.py
@@ -40,7 +40,7 @@ def main():
     source.print()
     
     # Now execute the topology by submitting to a standalone context.
-    streamsx.topology.context.submit("STANDALONE")
+    streamsx.topology.context.submit("STANDALONE",topo)
      
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
If you compare the [sample on Github and](https://github.com/IBMStreams/streamsx.topology/blob/master/samples/python/topology/simple/temperature_sensor.py#L43) the s[ample in the developer guide](http://ibmstreams.github.io/streamsx.documentation/docs/python/1.6/python-appapi-devguide-3/#37-the-complete-application), you'll notice that the former is missing the topo parameter.  Running it as-is leads to an error and the[ documentation for context.submit ](http://ibmstreams.github.io/streamsx.topology/doc/releases/1.6/pythondoc/streamsx.topology.context.html#streamsx.topology.context.submit)shows that the context type and graph are required parameters.