### PR TITLE
[WIP] Https issue encountered with httpcomponents-client-4.3.6

### DIFF
--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -1,0 +1,97 @@
+
+package com.ibm.streamsx.rest ;
+
+import java.io.IOException ;
+
+import org.apache.http.client.ClientProtocolException ;
+import org.apache.http.client.fluent.Executor ;
+import org.apache.http.client.fluent.Form ;
+import org.apache.http.client.fluent.Request ;
+import org.apache.http.client.fluent.Response ;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.Gson;
+
+import com.ibm.streamsx.rest.primitives.Instance;
+import com.ibm.streamsx.rest.primitives.Job;
+import com.ibm.streamsx.rest.primitives.Operator;
+import com.ibm.streamsx.rest.primitives.ActiveVersion;
+import com.ibm.streamsx.rest.primitives.Metrics;
+
+public class StreamsConnection {
+
+   private String userName ;
+   private String authToken ;
+   private String url ;
+
+   private Executor executor ;
+//   private CookieStore cookieStore ;
+
+   private static Gson gson ;
+
+   public StreamsConnection( String userName, String authToken, String url ) 
+   {
+//      this.cookieStore  = new CookieStore() ;
+      this.userName = userName ;
+      this.authToken = authToken ;
+      this.executor = Executor.newInstance()
+//         .use( cookieStore )
+         .auth( userName, authToken ) ;
+      this.url = url ;
+      this.gson = new Gson() ;
+   }
+
+   private String getResponseString( String inputString ) throws ClientProtocolException, IOException
+   {
+      String sReturn = "" ;
+      try {
+        Request request = Request.Get( inputString ) ;
+        Response response = executor.execute( request ) ;
+
+        // need to decode errors
+        sReturn = response.returnContent().asString() ;
+      }
+      catch ( ClientProtocolException e ) {
+        e.printStackTrace() ; 
+      }
+      return sReturn ;
+   }
+
+   public Instance getInstance( String instanceName )
+   {
+      StringBuilder sb = new StringBuilder() ; 
+      sb.append( url ) ;
+      sb.append( "instances/instanceName" ) ;
+
+      String sReturn = "" ;
+      try {
+        sReturn = getResponseString( sb.toString() ) ;
+       } catch ( Exception e ) {
+         e.printStackTrace() ;
+       }
+      // need to check return code
+      System.out.println( sReturn ) ;
+      Instance si = gson.fromJson( sReturn, Instance.class ) ;
+
+      return si ;
+   } 
+
+   public static void main( String[] args)
+   {
+
+     String userName = args[0] ;
+     String authToken = args[1] ;
+     String url = args[2] ;
+     String instanceName = args[3] ;
+
+     System.out.println( userName ) ;
+     System.out.println( authToken ) ;
+     System.out.println( url ) ;
+     System.out.println( instanceName ) ;
+     StreamsConnection rClient = new StreamsConnection( userName, authToken, url ) ;
+
+     rClient.getInstance( instanceName ) ; 
+   }
+}
+

--- a/java/src/com/ibm/streamsx/rest/primitives/ActiveVersion.java
+++ b/java/src/com/ibm/streamsx/rest/primitives/ActiveVersion.java
@@ -1,0 +1,15 @@
+package com.ibm.streamsx.rest.primitives;
+
+public class ActiveVersion
+{
+   public ActiveVersion() { } ; 
+   public String architecture ; 
+   public String buildVersion ; 
+   public String editionName ; 
+   public String fullProductVersion ; 
+   public String minimumOSBaseVersion ; 
+   public String minimumOSPatchVersion ; 
+   public String minimumOSVersion ; 
+   public String productName ; 
+   public String productVersion ; 
+}

--- a/java/src/com/ibm/streamsx/rest/primitives/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/primitives/Instance.java
@@ -1,0 +1,34 @@
+package com.ibm.streamsx.rest.primitives;
+
+import com.ibm.streamsx.rest.primitives.ActiveVersion;
+
+public class Instance
+{
+   public Instance() { } ; 
+   public String activeServices ; 
+   public ActiveVersion activeVersion ; // not a string
+   public String activeViews ; 
+   public String configuredViews ; 
+   public long creationTime ; 
+   public String creationUser ; 
+   public String domain ; 
+   public String exportedStreams ; 
+   public String health ; 
+   public String hosts ; 
+   public String id ; 
+   public String importedStreams ; 
+   public String jobs ; 
+   public String operatorConnections ; 
+   public String operators ; 
+   public String owner ; 
+   public String peConnections ; 
+   public String pes ; 
+   public String resourceAllocations ; 
+   public String resourceType ; 
+   public String restid ; 
+   public String self ; 
+   public long startTime ; 
+   public String startedBy ; 
+   public String status ; 
+   public String views ; 
+}

--- a/java/src/com/ibm/streamsx/rest/primitives/Job.java
+++ b/java/src/com/ibm/streamsx/rest/primitives/Job.java
@@ -1,0 +1,38 @@
+package com.ibm.streamsx.rest.primitives;
+
+public class Job
+{
+
+   public Job() {} ;
+
+   public String activeViews ;
+   public String adlFile ; 
+   public String applicationName ; 
+   public String applicationPath ; 
+   public String applicationScope ; 
+   public String applicationVersion ; 
+   public String checkpointPath ; 
+   public String dataPath ; 
+   public String domain ; 
+   public String health ; 
+   public String hosts ; 
+   public String id ; 
+   public String instance ; 
+   public String jobGroup ; 
+   public String name ; 
+   public String operatorConnections ; 
+   public String operators ; 
+   public String outputPath ; 
+   public String peConnections ; 
+   public String pes ; 
+   public String resourceAllocations ; 
+   public String resourceType ; 
+   public String restid ; 
+   public String self ; 
+   public String startedBy ; 
+   public String status ; 
+   public String submitParameters ; 
+   public long submitTime ; 
+   public String views ; 
+
+}

--- a/java/src/com/ibm/streamsx/rest/primitives/Metrics.java
+++ b/java/src/com/ibm/streamsx/rest/primitives/Metrics.java
@@ -1,0 +1,15 @@
+package com.ibm.streamsx.rest.primitives;
+
+public class Metrics
+{
+   public Metrics() { } ;
+
+   public String description ; 
+   public long lastTimeRetrieved ; 
+   public String metricKind ; 
+   public String metricType ; 
+   public String name ; 
+   public String resourceType ; 
+   public long value ; 
+
+}

--- a/java/src/com/ibm/streamsx/rest/primitives/Operator.java
+++ b/java/src/com/ibm/streamsx/rest/primitives/Operator.java
@@ -1,0 +1,25 @@
+package com.ibm.streamsx.rest.primitives;
+
+public class Operator
+{
+
+   public Operator() {} ;
+
+   public String connections ; 
+   public String domain ; 
+   public String host ; 
+   public long indexWithinJob ; 
+   public String inputPorts ; 
+   public String instance ; 
+   public String job ; 
+   public String metrics ; 
+   public String name ; 
+   public String operatorKind ; 
+   public String outputPorts ; 
+   public String pe ; 
+   public String resourceAllocation ; 
+   public String resourceType ; 
+   public String restid ; 
+   public String self ; 
+
+}


### PR DESCRIPTION
NOTE:  I do not intend to merge this, it's for reference to help resolve an issue I'm encountering.

sample code in java/src/com/ibm/streamsx/rest/StreamsConnection.java to show the problem i'm encountering.

To repro:  run ant to build the file, and you can run it with the following against a bluemix service:

java -cp $STREAMSX_TOPOLOGY_INSTALL/lib/com.ibm.streamsx.topology.jar $DEBUGGING com.ibm.streamsx.rest.StreamsConnection  $USER $PASSWD $STREAMS_REST_URL instances/$INSTANCE

where $USER, $PASSWD and $INSTANCE are self explanatory, and $STREAMS_REST_URL is the url to access the streams rest api in bluemix.  

This should produce the following output with httpcomponents-client-4.3.6:
'''
Request: https://streams-console-c6d1.ng.bluemix.net/streams/rest/instances/49d495e5-563f-4b5c-8d2a-87d184113a69
Apr 20, 2017 6:34:41 PM org.apache.http.impl.auth.HttpAuthenticator handleAuthChallenge
WARNING: Malformed challenge: Authentication challenge is empty
org.apache.http.client.HttpResponseException: Unauthorized
        at org.apache.http.client.fluent.ContentResponseHandler.handleResponse(ContentResponseHandler.java:47)
        at org.apache.http.client.fluent.ContentResponseHandler.handleResponse(ContentResponseHandler.java:40)
        at org.apache.http.client.fluent.Response.handleResponse(Response.java:90)
        at org.apache.http.client.fluent.Response.returnContent(Response.java:97)
        at com.ibm.streamsx.rest.StreamsConnection.getResponseString(StreamsConnection.java:60)
        at com.ibm.streamsx.rest.StreamsConnection.main(StreamsConnection.java:89)
'''

whereas if you set $DEBUGGING to ``` export DEBUGGING="-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog -Dorg.apache.commons.logging.simplelog.showdatetime=true -Dorg.apache.commons.logging.simplelog.log.org.apache.http=DEBUG" ```

you'll get the details output that shows the error 

```
2017/04/20 18:58:37:598 EDT [DEBUG] HttpAuthenticator - streams-console-c6d1.ng.bluemix.net:443 requested authentication
2017/04/20 18:58:37:598 EDT [DEBUG] TargetAuthenticationStrategy - Authentication schemes in the order of preference: [negotiate, Kerberos, NTLM, Digest, Basic]
2017/04/20 18:58:37:598 EDT [DEBUG] TargetAuthenticationStrategy - Challenge for negotiate authentication scheme not available
2017/04/20 18:58:37:598 EDT [DEBUG] TargetAuthenticationStrategy - Challenge for Kerberos authentication scheme not available
2017/04/20 18:58:37:598 EDT [DEBUG] TargetAuthenticationStrategy - Challenge for NTLM authentication scheme not available
2017/04/20 18:58:37:598 EDT [DEBUG] TargetAuthenticationStrategy - Challenge for Digest authentication scheme not available
2017/04/20 18:58:37:599 EDT [WARN] HttpAuthenticator - Malformed challenge: Authentication challenge is empty
2017/04/20 18:58:37:603 EDT [DEBUG] ResponseProcessCookies - Cookie accepted [DPJSESSIONID="PBC5YS:-518333900", version:0, domain:.streams-console-c6d1.ng.bluemix.net, path:/, expiry:null]
```

Replacing this with the latest 4.5.3 of httpcomponents-client, and re-building has solved the problem for me, but that version of httpclient is not in streamsx.topology, so if  someone could help explain why this is failing in my sample, but not in the RestUtils of topology/internal, that would be appreciated.  