### PR TITLE
allow a job to be canceled from the Job object in the rest api.

### DIFF
--- a/java/src/com/ibm/streamsx/rest/ActiveVersion.java
+++ b/java/src/com/ibm/streamsx/rest/ActiveVersion.java
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 /**
  * Basic class to hold the ActiveVersion JSON structure

--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -2,17 +2,12 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 import java.io.IOException;
 import java.util.List;
 
 import com.google.gson.Gson;
-
-import com.ibm.streamsx.rest.StreamsConnection;
-import com.ibm.streamsx.rest.primitives.Job;
-import com.ibm.streamsx.rest.primitives.InstanceGson;
-import com.ibm.streamsx.rest.primitives.ActiveVersion;
 
 /**
  * {@Instance}

--- a/java/src/com/ibm/streamsx/rest/InstanceGson.java
+++ b/java/src/com/ibm/streamsx/rest/InstanceGson.java
@@ -2,38 +2,37 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
-import java.util.ArrayList;
+/**
+ * Class used to hold the Instance JSON structur
+ */
+class InstanceGson {
 
-class JobGson {
+    public String activeServices;
+    public ActiveVersion activeVersion;
     public String activeViews;
-    public String adlFile;
-    public String applicationName;
-    public String applicationPath;
-    public String applicationScope;
-    public String applicationVersion;
-    public String checkpointPath;
-    public String dataPath;
+    public String configuredViews;
+    public long creationTime;
+    public String creationUser;
     public String domain;
+    public String exportedStreams;
     public String health;
     public String hosts;
     public String id;
-    public String instance;
-    public String jobGroup;
-    public String name;
+    public String importedStreams;
+    public String jobs;
     public String operatorConnections;
     public String operators;
-    public String outputPath;
+    public String owner;
     public String peConnections;
     public String pes;
     public String resourceAllocations;
     public String resourceType;
     public String restid;
     public String self;
+    public long startTime;
     public String startedBy;
     public String status;
-    public ArrayList<String> submitParameters;
-    public long submitTime;
     public String views;
 }

--- a/java/src/com/ibm/streamsx/rest/InstancesArray.java
+++ b/java/src/com/ibm/streamsx/rest/InstancesArray.java
@@ -2,23 +2,21 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gson.Gson;
-import com.ibm.streamsx.rest.StreamsConnection;
-import com.ibm.streamsx.rest.primitives.Instance;
-import com.ibm.streamsx.rest.primitives.InstanceGson;
 
-public class InstancesArray {
-    private final StreamsConnection connection;
+/**
+ * class to hold information about instances from GET instances URL
+ */
+class InstancesArray {
     private List<Instance> instances;
     private InstancesArrayGson instanceArray;
 
     public InstancesArray(StreamsConnection sc, String gsonInstances) {
-        connection = sc;
         instanceArray = new Gson().fromJson(gsonInstances, InstancesArrayGson.class);
 
         instances = new ArrayList<Instance>(instanceArray.instances.size());

--- a/java/src/com/ibm/streamsx/rest/Job.java
+++ b/java/src/com/ibm/streamsx/rest/Job.java
@@ -2,15 +2,13 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gson.Gson;
-import com.ibm.streamsx.rest.StreamsConnection;
-import com.ibm.streamsx.rest.primitives.Operator;
 
 public class Job {
     private final StreamsConnection connection;
@@ -33,7 +31,6 @@ public class Job {
     public List<Operator> getOperators() throws IOException {
         String sGetOperatorsURI = job.operators;
 
-        System.out.println(sGetOperatorsURI);
         String sReturn = connection.getResponseString(sGetOperatorsURI);
 
         List<Operator> operators = new OperatorsArray(connection, sReturn).getOperators();

--- a/java/src/com/ibm/streamsx/rest/Job.java
+++ b/java/src/com/ibm/streamsx/rest/Job.java
@@ -37,6 +37,13 @@ public class Job {
         return operators;
     }
 
+    /**
+     * @return true if this job is cancelled, false otherwise
+     */
+    public boolean cancel() throws Exception, IOException {
+        return connection.cancelJob(job.id);
+    }
+
     public String getActiveViews() {
         return job.activeViews;
     }

--- a/java/src/com/ibm/streamsx/rest/JobGson.java
+++ b/java/src/com/ibm/streamsx/rest/JobGson.java
@@ -2,39 +2,38 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
-import com.ibm.streamsx.rest.primitives.ActiveVersion;
+import java.util.ArrayList;
 
-/**
- * Class used to hold the Instance JSON structur
- */
-class InstanceGson {
-
-    public String activeServices;
-    public ActiveVersion activeVersion;
+class JobGson {
     public String activeViews;
-    public String configuredViews;
-    public long creationTime;
-    public String creationUser;
+    public String adlFile;
+    public String applicationName;
+    public String applicationPath;
+    public String applicationScope;
+    public String applicationVersion;
+    public String checkpointPath;
+    public String dataPath;
     public String domain;
-    public String exportedStreams;
     public String health;
     public String hosts;
     public String id;
-    public String importedStreams;
-    public String jobs;
+    public String instance;
+    public String jobGroup;
+    public String name;
     public String operatorConnections;
     public String operators;
-    public String owner;
+    public String outputPath;
     public String peConnections;
     public String pes;
     public String resourceAllocations;
     public String resourceType;
     public String restid;
     public String self;
-    public long startTime;
     public String startedBy;
     public String status;
+    public ArrayList<String> submitParameters;
+    public long submitTime;
     public String views;
 }

--- a/java/src/com/ibm/streamsx/rest/JobsArray.java
+++ b/java/src/com/ibm/streamsx/rest/JobsArray.java
@@ -2,23 +2,21 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gson.Gson;
-import com.ibm.streamsx.rest.StreamsConnection;
-import com.ibm.streamsx.rest.primitives.Job;
-import com.ibm.streamsx.rest.primitives.JobGson;
 
-public class JobsArray {
-    private final StreamsConnection connection;
+/**
+ * Package class to hold information about the Jobs list from GET jobs URL
+ */
+class JobsArray {
     private List<Job> jobs;
     private JobsArrayGson jobArray;
 
     public JobsArray(StreamsConnection sc, String gsonJobs) {
-        connection = sc;
         jobArray = new Gson().fromJson(gsonJobs, JobsArrayGson.class);
 
         jobs = new ArrayList<Job>(jobArray.jobs.size());

--- a/java/src/com/ibm/streamsx/rest/Metric.java
+++ b/java/src/com/ibm/streamsx/rest/Metric.java
@@ -2,15 +2,11 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
-
-import com.google.gson.Gson;
-import com.ibm.streamsx.rest.StreamsConnection;
-import com.ibm.streamsx.rest.primitives.MetricGson;
+package com.ibm.streamsx.rest;
 
 public class Metric {
+    @SuppressWarnings("unused")
     private final StreamsConnection connection;
-    private final Gson gson = new Gson();
     private MetricGson metric;
 
     public Metric(StreamsConnection sc, MetricGson gsonMetric) {

--- a/java/src/com/ibm/streamsx/rest/MetricGson.java
+++ b/java/src/com/ibm/streamsx/rest/MetricGson.java
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 class MetricGson {
     public String description;

--- a/java/src/com/ibm/streamsx/rest/MetricsArray.java
+++ b/java/src/com/ibm/streamsx/rest/MetricsArray.java
@@ -2,23 +2,21 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gson.Gson;
-import com.ibm.streamsx.rest.StreamsConnection;
-import com.ibm.streamsx.rest.primitives.Metric;
-import com.ibm.streamsx.rest.primitives.MetricGson;
 
-public class MetricsArray {
-    private final StreamsConnection connection;
+/**
+ * Package class to hold information all metrics information from the GET metrics URL
+ */
+class MetricsArray {
     private List<Metric> metrics;
     private MetricsArrayGson metricsArray;
 
     public MetricsArray(StreamsConnection sc, String gsonMetrics) {
-        connection = sc;
         metricsArray = new Gson().fromJson(gsonMetrics, MetricsArrayGson.class);
 
         metrics = new ArrayList<Metric>(metricsArray.metrics.size());

--- a/java/src/com/ibm/streamsx/rest/Operator.java
+++ b/java/src/com/ibm/streamsx/rest/Operator.java
@@ -2,14 +2,10 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 import java.io.IOException;
 import java.util.List;
-
-import com.google.gson.Gson;
-import com.ibm.streamsx.rest.StreamsConnection;
-import com.ibm.streamsx.rest.primitives.Metric;
 
 public class Operator {
     private final StreamsConnection connection;

--- a/java/src/com/ibm/streamsx/rest/OperatorGson.java
+++ b/java/src/com/ibm/streamsx/rest/OperatorGson.java
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 class OperatorGson {
     public String connections;

--- a/java/src/com/ibm/streamsx/rest/OperatorsArray.java
+++ b/java/src/com/ibm/streamsx/rest/OperatorsArray.java
@@ -2,23 +2,21 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
  */
-package com.ibm.streamsx.rest.primitives;
+package com.ibm.streamsx.rest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gson.Gson;
-import com.ibm.streamsx.rest.StreamsConnection;
-import com.ibm.streamsx.rest.primitives.Operator;
-import com.ibm.streamsx.rest.primitives.OperatorGson;
 
-public class OperatorsArray {
-    private final StreamsConnection connection;
+/**
+ * Package class to hold all information about operators from the GET operators URL
+ */
+class OperatorsArray {
     private List<Operator> operators;
     private OperatorsArrayGson operatorsArray;
 
     public OperatorsArray(StreamsConnection sc, String gsonOperators) {
-        connection = sc;
         operatorsArray = new Gson().fromJson(gsonOperators, OperatorsArrayGson.class);
 
         operators = new ArrayList<Operator>(operatorsArray.operators.size());

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
@@ -4,20 +4,22 @@
  */
 package com.ibm.streamsx.rest;
 
-import java.io.IOException;
-import java.util.List;
-
 import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.SERVICE_NAME;
 import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.VCAP_SERVICES;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Logger;
+
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.ibm.streamsx.rest.primitives.Instance;
-import com.ibm.streamsx.rest.primitives.Job;
-import com.ibm.streamsx.rest.primitives.Metric;
-import com.ibm.streamsx.rest.primitives.Operator;
 import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 
-public class StreamingAnalyticsConnection extends StreamsConnection{
+public class StreamingAnalyticsConnection extends StreamsConnection {
+
+    static final Logger traceLog = Logger.getLogger("com.ibm.streamsx.topology.rest.StreamingAnalyticsConnection");
+
+    private String jobsPath;
 
     /**
      * Basic connection to the Streaming Analytics Instance
@@ -29,31 +31,32 @@ public class StreamingAnalyticsConnection extends StreamsConnection{
      * @throws IOException
      */
     private StreamingAnalyticsConnection(String userName, String authToken, String url) {
-      super( userName, authToken, url );
+        super(userName, authToken, url);
     }
 
-    public static StreamingAnalyticsConnection createInstance( String credentialsFile, String serviceName )
+    public static StreamingAnalyticsConnection createInstance(String credentialsFile, String serviceName)
             throws IOException {
 
-        JsonObject SAcredentials = new JsonObject();
+        JsonObject streamingAnalyticsCredentials = new JsonObject();
 
-        SAcredentials.addProperty(SERVICE_NAME, serviceName);
-        SAcredentials.addProperty(VCAP_SERVICES, credentialsFile);
+        streamingAnalyticsCredentials.addProperty(SERVICE_NAME, serviceName);
+        streamingAnalyticsCredentials.addProperty(VCAP_SERVICES, credentialsFile);
 
-        JsonObject service = VcapServices.getVCAPService(SAcredentials);
+        JsonObject service = VcapServices.getVCAPService(streamingAnalyticsCredentials);
 
         JsonObject credential = new JsonObject();
         credential = service.get("credentials").getAsJsonObject();
 
         String userId = credential.get("userid").getAsString();
         String authToken = credential.get("password").getAsString();
+
         String resourcesPath = credential.get("resources_path").getAsString();
         String sURL = credential.get("rest_url").getAsString() + resourcesPath;
 
-        String restURL = "" ;
-        StreamingAnalyticsConnection SAConn = new StreamingAnalyticsConnection( userId, authToken, restURL ) ;
+        String restURL = "";
+        StreamingAnalyticsConnection streamingConnection = new StreamingAnalyticsConnection(userId, authToken, restURL);
 
-        String sResources = SAConn.getResponseString(sURL);
+        String sResources = streamingConnection.getResponseString(sURL);
         if (!sResources.equals("")) {
             JsonParser jParse = new JsonParser();
             JsonObject resources = jParse.parse(sResources).getAsJsonObject();
@@ -61,19 +64,20 @@ public class StreamingAnalyticsConnection extends StreamsConnection{
             restURL = resources.get("streams_rest_url").getAsString();
         }
 
-        if ( restURL.equals("") ) {
+        if (restURL.equals("")) {
             throw new IllegalStateException("Missing restURL for service");
         }
 
-        SAConn.setURL( restURL ) ;
+        streamingConnection.setURL(restURL);
         String[] rTokens = resourcesPath.split("/");
         if (rTokens[3].equals("service_instances")) {
-            SAConn.setInstanceId(rTokens[4]) ;
+            streamingConnection.setInstanceId(rTokens[4]);
         } else {
             throw new IllegalStateException("Resource Path decoding error.");
         }
-        return SAConn ;
+        return streamingConnection;
     }
+
 
     /**
      * main currently exists to test this object
@@ -107,9 +111,10 @@ public class StreamingAnalyticsConnection extends StreamsConnection{
                 }
             }
 
-            System.out.println(" Getting job 0 specifically");
-            Job job = instance.getJob("0");
-
+            if (!jobs.isEmpty()) {
+                System.out.println("Getting first job");
+                Job job = jobs.get(0);
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -30,6 +30,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 
+import com.ibm.streamsx.topology.internal.streams.InvokeCancel;
+
 public class StreamsConnection {
 
     static final Logger traceLog = Logger.getLogger("com.ibm.streamsx.topology.rest.StreamsConnection");
@@ -203,6 +205,18 @@ public class StreamsConnection {
     }
 
     /**
+     * @param jobId string identifying the job to be cancelled
+     * @return true if job is cancelled
+     * @throws Exception
+     */
+    public boolean cancelJob(String jobId) throws Exception {
+        boolean rc = true;
+        InvokeCancel cancelJob = new InvokeCancel(new BigInteger(jobId));
+        cancelJob.invoke();
+        return rc;
+    }
+
+    /**
      * Main function to test this class for now will be removed eventually
      */
     public static void main(String[] args) {
@@ -240,8 +254,11 @@ public class StreamsConnection {
                 }
 
                 if (!jobs.isEmpty()) {
-                    System.out.println("Looking at first job specifically");
+                    System.out.println("Removing first job specifically");
                     Job job = jobs.get(0);
+                    if (job.cancel()) {
+                        System.out.println("Job canceled");
+                    }
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
*Array* classes have been cleaned up to remove an unused StreamsConnection object, and most have been made package level classes.  The InstanceArray is needed by the higher level package, so it's been left public.

The Job.cancel() functionality has been added to the api, and can cancel either a StreamingAnalyticsConnection job (via the REST api), or a StreamsConnection job (via the InvokeCancel api)