### PR TITLE
add a userName to the invokeCancel()

### DIFF
--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -36,6 +36,7 @@ public class StreamsConnection {
 
     static final Logger traceLog = Logger.getLogger("com.ibm.streamsx.topology.rest.StreamsConnection");
 
+    private final String userName;
     private String url;
     private String instanceId;
     protected String apiKey;
@@ -68,6 +69,7 @@ public class StreamsConnection {
      *            String representing the root url to the REST API
      */
     protected StreamsConnection(String userName, String authToken, String url) {
+        this.userName = userName ;
         String apiCredentials = userName + ":" + authToken;
         apiKey = "Basic " + DatatypeConverter.printBase64Binary(apiCredentials.getBytes(StandardCharsets.UTF_8));
 
@@ -211,7 +213,7 @@ public class StreamsConnection {
      */
     public boolean cancelJob(String jobId) throws Exception {
         boolean rc = true;
-        InvokeCancel cancelJob = new InvokeCancel(new BigInteger(jobId));
+        InvokeCancel cancelJob = new InvokeCancel(new BigInteger(jobId), userName );
         cancelJob.invoke();
         return rc;
     }

--- a/java/src/com/ibm/streamsx/topology/internal/streams/InvokeCancel.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/InvokeCancel.java
@@ -18,10 +18,17 @@ public class InvokeCancel {
     static final Logger trace = Topology.STREAMS_LOGGER;
 
     private final BigInteger jobId;
+    private final String userName;
 
+    public InvokeCancel(BigInteger jobId, String userName) {
+        super();
+        this.jobId = jobId;
+        this.userName = userName;
+    }
     public InvokeCancel(BigInteger jobId) {
         super();
         this.jobId = jobId;
+        this.userName = null;
     }
 
     public void invoke() throws Exception, InterruptedException {
@@ -34,6 +41,11 @@ public class InvokeCancel {
 
         commands.add(sj.getAbsolutePath());
         commands.add("canceljob");
+        if ( null != userName )
+        {
+          commands.add("-U");
+          commands.add(userName);
+        }
         commands.add(jobId.toString());
 
         trace.info("Invoking streamtool canceljob " + jobId);


### PR DESCRIPTION
the current InvokeCancel call in topology/internal/streams does not take a userName, but uses the name of the current user to attempt to cancel the job.  This change will push the name that was used to create the streamsConnection object down so that we use that userid instead of the user that's running the application.

this doesn't allow for the password to be passed down, so if the password is needed, the InvokeCancel will throw an exception and fail.  