### PR TITLE
outputConnections changes code gen based upon value

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter.xml
@@ -76,7 +76,7 @@
         <name>outputConnections</name>
         <description>Number of output connections.</description>
         <optional>true</optional>
-        <rewriteAllowed>true</rewriteAllowed>
+        <rewriteAllowed>false</rewriteAllowed>
         <expressionMode>Constant</expressionMode>
         <type>int32</type>
         <cardinality>1</cardinality>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap.xml
@@ -76,7 +76,7 @@
         <name>outputConnections</name>
         <description>Number of output connections.</description>
         <optional>true</optional>
-        <rewriteAllowed>true</rewriteAllowed>
+        <rewriteAllowed>false</rewriteAllowed>
         <expressionMode>Constant</expressionMode>
         <type>int32</type>
         <cardinality>1</cardinality>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map.xml
@@ -76,7 +76,7 @@
         <name>outputConnections</name>
         <description>Number of output connections.</description>
         <optional>true</optional>
-        <rewriteAllowed>true</rewriteAllowed>
+        <rewriteAllowed>false</rewriteAllowed>
         <expressionMode>Constant</expressionMode>
         <type>int32</type>
         <cardinality>1</cardinality>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source.xml
@@ -73,7 +73,7 @@
         <name>outputConnections</name>
         <description>Number of output connections.</description>
         <optional>true</optional>
-        <rewriteAllowed>true</rewriteAllowed>
+        <rewriteAllowed>false</rewriteAllowed>
         <expressionMode>Constant</expressionMode>
         <type>int32</type>
         <cardinality>1</cardinality>


### PR DESCRIPTION
Since the code generated depends on the value of the `outputConnections` value, then it needs to not allow rewrites.