### PR TITLE
[WIP] Initial Window class

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/exop.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/exop.py
@@ -1,7 +1,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
 
-from streamsx.topology.topology import Stream
+from streamsx.topology.topology import Stream, Window
 import streamsx.topology.schema as sch
 
 
@@ -23,16 +23,23 @@ class ExtensionOperator(object):
         """
         return self._op.params
 
+    def _add_input(self, _input):
+        win_cfg = None
+        if isinstance(_input, Window):
+            win_cfg = _input._config
+            _input = _input.stream
+        self._op.addInputPort(outputPort=_input.oport, name=_input.name, window_config = win_cfg)
+        self._inputs.append(_input)
+
     def __inputs(self, inputs):
         if inputs is not None:
+            self._inputs = []
             try:
-                for input in inputs:
-                    self._op.addInputPort(outputPort=input.oport, name=input.name)
-                self.inputs = list(inputs)
+                for _input in inputs:
+                    self._add_input(_input)
             except TypeError:
                 # not iterable, single input
-                self._op.addInputPort(outputPort=inputs.oport, name=inputs.name)
-                self.inputs = [inputs]
+                self._add_input(inputs)
 
     def __outputs(self, schemas):
         self.outputs = []

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -224,13 +224,13 @@ class _SPLInvocation(object):
     def addViewConfig(self, view_configs):
         self.view_configs.append(view_configs)
 
-    def addInputPort(self, name=None, outputPort=None):
+    def addInputPort(self, name=None, outputPort=None, window_config=None):
         if name is None:
             name = self.name + "_IN"+ str(len(self.inputPorts))
         iPortSchema = CommonSchema.Python    
         if not outputPort is None :
             iPortSchema = outputPort.schema        
-        iport = IPort(name, self, len(self.inputPorts),iPortSchema)
+        iport = IPort(name, self, len(self.inputPorts),iPortSchema, window_config)
         self.inputPorts.append(iport)
 
         if not outputPort is None:
@@ -337,11 +337,12 @@ class _SPLInvocation(object):
             print(port.name)
 
 class IPort(object):
-    def __init__(self, name, operator, index, schema):
+    def __init__(self, name, operator, index, schema, window_config):
         self.name = name
         self.operator = operator
         self.index = index
         self.schema = schema
+        self.window_config = window_config
         self.outputPorts = []
 
     def connect(self, oport):
@@ -356,6 +357,8 @@ class IPort(object):
         _iport["name"] = self.name
         _iport["connections"] = [port.name for port in self.outputPorts]
         _iport["type"] = self.schema.schema()
+        if self.window_config is not None:
+            _iport['window'] = self.window_config
         return _iport
 
 class OPort(object):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -181,6 +181,7 @@ import os
 import time
 import inspect
 import logging
+import datetime
 from enum import Enum
 
 logger = logging.getLogger('streamsx.topology')
@@ -720,6 +721,37 @@ class Stream(object):
         endP = Stream(self.topology, oport)
         return endP
 
+    def last(self, size=1):
+        """ Declares a window containing most recent tuples on this stream.
+
+        The number of tuples maintained in the window is defined by `size`.
+
+        If `size` is an `int` then it is the count of tuples in the window.
+        For example, with ``size=10`` the window always contains the
+        last (most recent) ten tuples.
+
+        If `size` is an `datetime.timedelta` then it is the duration
+        of the window. With a `timedelta` representing five minutes
+        then the window contains any tuples that arrived in the last
+        five minutes.
+ 
+        Args:
+            size: The size of the window, either an `int` to define the
+                number of tuples or `datetime.timedelta` to define the
+                duration of the window.
+
+        Returns:
+            Window: Window of the last (most recent) tuples on this stream.
+        """
+        win = Window(self, 'SLIDING')
+        if isinstance(size, datetime.timedelta):
+            win._evict_time(size)
+        elif isinstance(size, int):
+            win._evict_count(size)
+        else:
+            raise ValueError(size)
+        return win
+
     def union(self, streamSet):
         """
         Creates a stream that is a union of this stream and other streams
@@ -954,3 +986,74 @@ class PendingStream(object):
             """Has this connection been completed.
             """
             return self._marker.inputPorts
+
+
+class Window(object):
+    """Declaration of a window of tuples on a `Stream`.
+
+    A `Window` can be passed as the input of an SPL
+    operator invocation to indicate the operator's
+    input port is windowed.
+
+    Example invoking the SPL `Aggregate` operator with a sliding window of
+    the last two minutes, triggering every five tuples::
+   
+        win = s.last(datetime.timedelta(minutes=2)).trigger(5)
+
+        agg = op.Map('spl.relational::Aggregate', win,
+                    schema = 'tuple<uint64 sum, uint64 max>')
+        agg.sum = agg.output('Sum(val)')
+        agg.max = agg.output('Max(val)')
+    """
+    def __init__(self, stream, window_type):
+        self.topology = stream.topology
+        self.stream = stream
+        self._config = {'type': window_type}
+
+    def _evict_count(self, size):
+        self._config['evictPolicy'] = 'COUNT'
+        self._config['evictConfig'] = size
+
+    def _evict_time(self, duration):
+        self._config['evictPolicy'] = 'TIME'
+        self._config['evictConfig'] = int(duration.total_seconds() * 1000.0)
+        self._config['evictTimeUnit'] = 'MILLISECONDS'
+
+    def trigger(self, when=1):
+        """Declare a window with this window's size and a trigger policy.
+
+        When the window is triggered is defined by `when`.
+
+        If `when` is an `int` then the window is triggered every
+        `when` tuples.  For example, with ``when=5`` the window
+        will be triggered every five tuples.
+
+        If `when` is an `datetime.timedelta` then it is the period
+        of the trigger. With a `timedelta` representing one minute
+        then the window is triggered every minute.
+
+        By default, when `trigger` has not been called on a `Window`
+        it triggers for every tuple inserted into the window
+        (equivalent to ``when=1``).
+
+        Args:
+            when: The size of the window, either an `int` to define the
+                number of tuples or `datetime.timedelta` to define the
+                duration of the window.
+
+        Returns:
+            Window: Window that will be triggered.
+    """
+        tw = Window(self.stream, self._config['type'])
+        tw._config['evictPolicy'] = self._config['evictPolicy']
+        tw._config['evictConfig'] = self._config['evictConfig']
+        if isinstance(when, datetime.timedelta):
+            tw._config['triggerPolicy'] = 'TIME'
+            tw._config['triggerConfig'] = int(when.total_seconds() * 1000.0)
+            tw._config['triggerTimeUnit'] = 'MILLISECONDS'
+        elif isinstance(when, int):
+            tw._config['triggerPolicy'] = 'COUNT'
+            tw._config['triggerConfig'] = when
+        else:
+            raise ValueError(when)
+        return tw

--- a/test/python/topology/test2_spl_window.py
+++ b/test/python/topology/test2_spl_window.py
@@ -1,0 +1,44 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016
+import unittest
+import sys
+import itertools
+
+import test_vers
+
+from streamsx.topology.topology import *
+from streamsx.topology.tester import Tester
+from streamsx.topology import schema
+import streamsx.topology.context
+import streamsx.spl.op as op
+
+
+@unittest.skipIf(not test_vers.tester_supported() , "tester not supported")
+class TestSPLWindow(unittest.TestCase):
+    """ Test invocations of SPL operators from Python topology.
+    """
+    def setUp(self):
+        Tester.setup_standalone(self)
+
+    def test_sliding_count(self):
+        for step in [1, 3]:
+            with self.subTest(step=step):
+                topo = Topology()
+                b = op.Source(topo, "spl.utility::Beacon",
+                    'tuple<uint64 seq>',
+                    params = {'iterations':12})
+                b.seq = b.output('IterationCount()')
+                s = b.stream
+ 
+                agg = op.Map('spl.relational::Aggregate', s.last(4).trigger(step),
+                    schema = 'tuple<uint64 sum, uint64 max>')
+                agg.sum = agg.output('Sum(seq)')
+                agg.max = agg.output('Max(seq)')
+ 
+                expected = []
+                for i in range(4 + step - 2, 12, step):
+                    expected.append({'sum': sum(range(i-3, i+1)), 'max': i})
+
+                tester = Tester(topo)
+                tester.contents(agg.stream, expected)
+                tester.test(self.test_ctxtype, self.test_config)


### PR DESCRIPTION
Initial api for windowing in Python, currently limited to the invocation of SPL operators (e..g Aggregate).

Supports SPL sliding windows using the `last` method against a stream:

```
#  window of the last tuple on the stream
w = s.last()

# window of the last 20 tuples on the stream
w = s.last(20)

# window of the last five minutes
w = s.last(datetime.timedelta(minutes=5))
```

Example with trigger and SPL invocation:
```
agg = op.Map('spl.relational::Aggregate', s.last(4).trigger(2),
                    schema = 'tuple<uint64 sum, uint64 max>')
agg.sum = agg.output('Sum(seq)')
agg.max = agg.output('Max(seq)')
```