### PR TITLE
added javadoc items for the java rest api wrappers

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -86,6 +86,7 @@
                <exclude name="com/ibm/streamsx/topology/internal/**"/>
                <exclude name="com/ibm/streamsx/topology/builder/**"/>
                <exclude name="com/ibm/streamsx/topology/generator/**"/>
+               <include name="com/ibm/streamsx/rest/**"/>
             </fileset>
        </javadoc>
        <ant dir="toolkit" target="spldoc"/>

--- a/java/src/com/ibm/streamsx/rest/InputPort.java
+++ b/java/src/com/ibm/streamsx/rest/InputPort.java
@@ -50,7 +50,7 @@ public class InputPort {
     /**
      * Gets the index of this input port within the {@link Operator}
      * 
-     * @return long
+     * @return the index number as a long
      */
     public long getIndexWithinOperator() {
         return indexWithinOperator;
@@ -59,7 +59,7 @@ public class InputPort {
     /**
      * Gets the {@link Metric metrics} for this input port
      * 
-     * @return {@link List} of {@link Metric}
+     * @return List of {@link Metric IBM Streams Metrics}
      */
     public List<Metric> getMetrics() throws IOException {
         String sReturn = connection.getResponseString(metrics);
@@ -70,16 +70,16 @@ public class InputPort {
     /**
      * Gets the name for this input port
      * 
-     * @return {@link String}
+     * @return the name
      */
     public String getName() {
         return name;
     }
 
     /**
-     * Identifies the REST resource type, which is "inputport"
+     * Identifies the REST resource type
      * 
-     * @return {@link String}
+     * @return "inputport"
      */
     public String getResourceType() {
         return resourceType;

--- a/java/src/com/ibm/streamsx/rest/InputPort.java
+++ b/java/src/com/ibm/streamsx/rest/InputPort.java
@@ -48,28 +48,18 @@ public class InputPort {
     }
 
     /**
-     * @return the connections
-     */
-    public String getConnections() {
-        return connections;
-    }
-
-    /**
-     * @return the indexWithinOperator
+     * Gets the index of this input port within the {@link Operator}
+     * 
+     * @return long
      */
     public long getIndexWithinOperator() {
         return indexWithinOperator;
     }
 
     /**
-     * @return the job
-     */
-    public String getJob() {
-        return job;
-    }
-
-    /**
-     * @return the metrics
+     * Gets the {@link Metric metrics} for this input port
+     * 
+     * @return {@link List} of {@link Metric}
      */
     public List<Metric> getMetrics() throws IOException {
         String sReturn = connection.getResponseString(metrics);
@@ -78,52 +68,21 @@ public class InputPort {
     }
 
     /**
-     * @return the name
+     * Gets the name for this input port
+     * 
+     * @return {@link String}
      */
     public String getName() {
         return name;
     }
 
     /**
-     * @return the operator
-     */
-    public String getOperator() {
-        return operator;
-    }
-
-    /**
-     * @return the pe
-     */
-    public String getPe() {
-        return pe;
-    }
-
-    /**
-     * @return the peInputPorts
-     */
-    public String getPeInputPorts() {
-        return peInputPorts;
-    }
-
-    /**
-     * @return the resourceType
+     * Identifies the REST resource type, which is "inputport"
+     * 
+     * @return {@link String}
      */
     public String getResourceType() {
         return resourceType;
-    }
-
-    /**
-     * @return the restid
-     */
-    public String getRestid() {
-        return restid;
-    }
-
-    /**
-     * @return the self
-     */
-    public String getSelf() {
-        return self;
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -94,7 +94,7 @@ public class Instance {
     }
 
     /**
-     * Returns a list of Jobs that this Instance knows about
+     * Gets a list of {@link Job jobs} that this instance knows about
      * 
      * @return List of {@link Job}
      * @throws IOException
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     /**
-     * Returns the {@link Job} for a given jobId in this instance
+     * Gets the {@link Job} for a given jobId in this instance
      * 
      * @param jobId
      *            String identifying the job
@@ -123,7 +123,7 @@ public class Instance {
     }
 
     /**
-     * Provides information about the IBM Streams Installation that was used to
+     * Gets information about the IBM Streams Installation that was used to
      * start this instance
      * 
      * @return {@link ActiveVersion}
@@ -133,16 +133,16 @@ public class Instance {
     }
 
     /**
-     * Provides the time in milliseconds when this instance was created
+     * Gets the time in milliseconds when this instance was created
      * 
-     * @return {@link long} representing milliseconds since epoch
+     * @return long representing milliseconds since epoch
      */
     public long getCreationTime() {
         return creationTime;
     }
 
     /**
-     * Provides the user ID that created this instance
+     * Gets the user ID that created this instance
      * 
      * @return {@link String}
      */
@@ -151,7 +151,9 @@ public class Instance {
     }
 
     /**
-     * Provides the summarized status of jobs in this instance
+     * Gets the summarized status of jobs in this instance
+     *
+     * @return {@link String} that contains one of the following values:
      * <ul>
      * <li>healthy
      * <li>partiallyHealthy
@@ -160,14 +162,13 @@ public class Instance {
      * <li>unknown
      * </ul>
      * 
-     * @return {@link String}
      */
     public String getHealth() {
         return health;
     }
 
     /**
-     * Provides the IBM Streams unique identifier for this instance
+     * Gets the IBM Streams unique identifier for this instance
      * 
      * @return {@link String}
      */
@@ -176,17 +177,17 @@ public class Instance {
     }
 
     /**
-     * Provides the user ID that represents the Owner of this instance
+     * Gets the user ID that represents the owner of this instance
      * 
-     * @return
+     * @return {@link String}
      */
     public String getOwner() {
         return owner;
     }
 
     /**
-     * Provides the resource type (instance) associated with this object
-     * 
+     * Identifies the REST resource type as 'instance'
+     *
      * @return {@link String}
      */
     public String getResourceType() {
@@ -194,16 +195,18 @@ public class Instance {
     }
 
     /**
-     * Provides the time in milliseconds since the instance was started.
+     * Gets the time in milliseconds since the instance was started.
      * 
-     * @return {@long} representing milliseconds since epoch
+     * @return long representing milliseconds since epoch
      */
     public long getStartTime() {
         return startTime;
     }
 
     /**
-     * Provides the status of the instance
+     * Gets the status of the instance
+     *
+     * @return {@link String} that contains one of the following values:
      * <ul>
      * <li>running
      * <li>failed
@@ -215,17 +218,11 @@ public class Instance {
      * <li>unknown
      * </ul>
      * 
-     * @return {@link String}
      */
     public String getStatus() {
         return status;
     }
 
-    /**
-     * Provides a user friendly printing function for this object
-     * 
-     * @return {@link String}
-     */
     @Override
     public String toString() {
         return (new GsonBuilder().excludeFieldsWithoutExposeAnnotation().setPrettyPrinting().create().toJson(this));

--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -96,7 +96,7 @@ public class Instance {
     /**
      * Gets a list of {@link Job jobs} that this instance knows about
      * 
-     * @return List of {@link Job}
+     * @return List of {@link Job IBM Streams Jobs}
      * @throws IOException
      */
     public List<Job> getJobs() throws IOException {
@@ -111,7 +111,7 @@ public class Instance {
      * 
      * @param jobId
      *            String identifying the job
-     * @return {@link Job}
+     * @return a single {@link Job}
      * @throws IOException
      */
     public Job getJob(String jobId) throws IOException {
@@ -135,7 +135,7 @@ public class Instance {
     /**
      * Gets the time in milliseconds when this instance was created
      * 
-     * @return long representing milliseconds since epoch
+     * @return the epoch time in milliseconds when the instance was created as a long
      */
     public long getCreationTime() {
         return creationTime;
@@ -144,7 +144,7 @@ public class Instance {
     /**
      * Gets the user ID that created this instance
      * 
-     * @return {@link String}
+     * @return the creation user ID
      */
     public String getCreationUser() {
         return creationUser;
@@ -153,7 +153,7 @@ public class Instance {
     /**
      * Gets the summarized status of jobs in this instance
      *
-     * @return {@link String} that contains one of the following values:
+     * @return the summarized status that contains one of the following values:
      * <ul>
      * <li>healthy
      * <li>partiallyHealthy
@@ -170,7 +170,7 @@ public class Instance {
     /**
      * Gets the IBM Streams unique identifier for this instance
      * 
-     * @return {@link String}
+     * @return the IBM Streams unique idenitifer
      */
     public String getId() {
         return id;
@@ -179,25 +179,25 @@ public class Instance {
     /**
      * Gets the user ID that represents the owner of this instance
      * 
-     * @return {@link String}
+     * @return the owner user ID
      */
     public String getOwner() {
         return owner;
     }
 
     /**
-     * Identifies the REST resource type as 'instance'
+     * Identifies the REST resource type
      *
-     * @return {@link String}
+     * @return "instance"
      */
     public String getResourceType() {
         return resourceType;
     }
 
     /**
-     * Gets the time in milliseconds since the instance was started.
+     * Gets the time in milliseconds when the instance was started.
      * 
-     * @return long representing milliseconds since epoch
+     * @return the epoch time in milliseconds when the instance was started as a long
      */
     public long getStartTime() {
         return startTime;
@@ -206,7 +206,7 @@ public class Instance {
     /**
      * Gets the status of the instance
      *
-     * @return {@link String} that contains one of the following values:
+     * @return the instance status that contains one of the following values:
      * <ul>
      * <li>running
      * <li>failed

--- a/java/src/com/ibm/streamsx/rest/Job.java
+++ b/java/src/com/ibm/streamsx/rest/Job.java
@@ -98,7 +98,7 @@ public class Job {
     /**
      * Gets a list of {@link Operator operators} for this job
      * 
-     * @return List of {@link Operator}
+     * @return List of {@link Operator IBM Streams Operators}
      * @throws IOException
      */
     public List<Operator> getOperators() throws IOException {
@@ -111,7 +111,7 @@ public class Job {
     /**
      * Cancels this job
      * 
-     * @return boolean
+     * @return the result of the cancel method
      *         <ul>
      *         <li>true if this job is cancelled
      *         <li>false if this job still exists
@@ -127,7 +127,7 @@ public class Job {
      * Gets the name of the streams processing application that this job is
      * running
      * 
-     * @return {@link String}
+     * @return the application name
      */
     public String getApplicationName() {
         return applicationName;
@@ -136,7 +136,7 @@ public class Job {
     /**
      * Gets the health indicator for this job
      * 
-     * @return {@link String} containing one of these possible values
+     * @return the health indicator containing one of the following values:
      *         <ul>
      *         <li>healthy
      *         <li>partiallyHealthy
@@ -153,7 +153,7 @@ public class Job {
     /**
      * Gets the id of this job
      * 
-     * @return {@link String}
+     * @return the job identifier
      */
     public String getId() {
         return id;
@@ -162,7 +162,7 @@ public class Job {
     /**
      * Gets the group this job belongs to
      * 
-     * @return {@link String}
+     * @return the job group
      */
     public String getJobGroup() {
         return jobGroup;
@@ -171,7 +171,7 @@ public class Job {
     /**
      * Gets the name of this job
      * 
-     * @return {@link String}
+     * @return the job name
      */
     public String getName() {
         return name;
@@ -180,7 +180,7 @@ public class Job {
     /**
      * Gets a list of {@link ProcessingElement processing elements} for this job
      * 
-     * @return List of {@link ProcessingElement}
+     * @return List of {@link ProcessingElement Processing Elements}
      * @throws IOException
      */
     public List<ProcessingElement> getPes() throws IOException {
@@ -190,9 +190,9 @@ public class Job {
     }
 
     /**
-     * Identifies the REST resource type as 'job'
+     * Identifies the REST resource type
      * 
-     * @return {@link String}
+     * @return "job"
      */
     public String getResourceType() {
         return resourceType;
@@ -201,7 +201,7 @@ public class Job {
     /**
      * Identifies the user ID that started this job
      * 
-     * @return {@link String}
+     * @return the user ID that started this job
      */
     public String getStartedBy() {
         return startedBy;
@@ -210,7 +210,7 @@ public class Job {
     /**
      * Describes the status of this job
      * 
-     * @return {@link String} that contains one of the following values:
+     * @return the job status that contains one of the following values:
      *         <ul>
      *         <li>canceling
      *         <li>running
@@ -225,7 +225,7 @@ public class Job {
     /**
      * Gets the list of parameters that were submitted to this job
      * 
-     * @return {@link List} of {@link String}
+     * @return List of parameters 
      */
     public List<String> getSubmitParameters() {
         return submitParameters;
@@ -234,7 +234,7 @@ public class Job {
     /**
      * Gets the Epoch time when this job was submitted
      * 
-     * @return long
+     * @return the epoch time when the job was submitted as a long
      */
     public long getSubmitTime() {
         return submitTime;

--- a/java/src/com/ibm/streamsx/rest/Job.java
+++ b/java/src/com/ibm/streamsx/rest/Job.java
@@ -14,6 +14,9 @@ import java.util.List;
 
 import com.google.gson.Gson;
 
+/**
+ * An object describing an IBM Streams Job submitted within a specified instance
+ */
 public class Job {
     private StreamsConnection connection;
 
@@ -77,24 +80,25 @@ public class Job {
     private String views;
 
     /**
-      * this function is not intended for external consumption
-      */
+     * this function is not intended for external consumption
+     */
     static final Job create(StreamsConnection sc, String gsonJobString) {
-        Job job = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create()
-                                   .fromJson(gsonJobString, Job.class);
+        Job job = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create().fromJson(gsonJobString, Job.class);
         job.setConnection(sc);
-        return job ;
+        return job;
     }
 
     /**
-      * this function is not intended for external consumption
-      */
-    void setConnection( final StreamsConnection sc) {
+     * this function is not intended for external consumption
+     */
+    void setConnection(final StreamsConnection sc) {
         connection = sc;
     }
 
     /**
-     * @return {@Operator}
+     * Gets a list of {@link Operator operators} for this job
+     * 
+     * @return List of {@link Operator}
      * @throws IOException
      */
     public List<Operator> getOperators() throws IOException {
@@ -105,7 +109,13 @@ public class Job {
     }
 
     /**
-     * @return true if this job is cancelled, false otherwise
+     * Cancels this job
+     * 
+     * @return boolean
+     *         <ul>
+     *         <li>true if this job is cancelled
+     *         <li>false if this job still exists
+     *         </ul>
      * @throws IOException
      * @throws Exception
      */
@@ -113,118 +123,121 @@ public class Job {
         return connection.cancelJob(id);
     }
 
-    public String getActiveViews() {
-        return activeViews;
-    }
-
-    public String getAdlFile() {
-        return adlFile;
-    }
-
+    /**
+     * Gets the name of the streams processing application that this job is
+     * running
+     * 
+     * @return {@link String}
+     */
     public String getApplicationName() {
         return applicationName;
     }
 
-    public String getApplicationPath() {
-        return applicationPath;
-    }
-
-    public String getApplicationScope() {
-        return applicationScope;
-    }
-
-    public String getApplicationVersion() {
-        return applicationVersion;
-    }
-
-    public String getCheckpointPath() {
-        return checkpointPath;
-    }
-
-    public String getDataPath() {
-        return dataPath;
-    }
-
-    public String getDomain() {
-        return domain;
-    }
-
+    /**
+     * Gets the health indicator for this job
+     * 
+     * @return {@link String} containing one of these possible values
+     *         <ul>
+     *         <li>healthy
+     *         <li>partiallyHealthy
+     *         <li>partiallyUnhealthy
+     *         <li>unhealthy
+     *         <li>unknown
+     *         </ul>
+     *
+     */
     public String getHealth() {
         return health;
     }
 
-    public String getHosts() {
-        return hosts;
-    }
-
+    /**
+     * Gets the id of this job
+     * 
+     * @return {@link String}
+     */
     public String getId() {
         return id;
     }
 
-    public String getInstance() {
-        return instance;
-    }
-
+    /**
+     * Gets the group this job belongs to
+     * 
+     * @return {@link String}
+     */
     public String getJobGroup() {
         return jobGroup;
     }
 
+    /**
+     * Gets the name of this job
+     * 
+     * @return {@link String}
+     */
     public String getName() {
         return name;
     }
 
-    public String getOperatorConnections() {
-        return operatorConnections;
-    }
-
-    public String getOutputPath() {
-        return outputPath;
-    }
-
-    public String getPeConnections() {
-        return peConnections;
-    }
-
+    /**
+     * Gets a list of {@link ProcessingElement processing elements} for this job
+     * 
+     * @return List of {@link ProcessingElement}
+     * @throws IOException
+     */
     public List<ProcessingElement> getPes() throws IOException {
         String sReturn = connection.getResponseString(pes);
         List<ProcessingElement> peList = ProcessingElement.getPEList(connection, sReturn);
         return peList;
     }
 
-    public String getResourceAllocations() {
-        return resourceAllocations;
-    }
-
+    /**
+     * Identifies the REST resource type as 'job'
+     * 
+     * @return {@link String}
+     */
     public String getResourceType() {
         return resourceType;
     }
 
-    public String getRestid() {
-        return restid;
-    }
-
-    public String getSelf() {
-        return self;
-    }
-
+    /**
+     * Identifies the user ID that started this job
+     * 
+     * @return {@link String}
+     */
     public String getStartedBy() {
         return startedBy;
     }
 
+    /**
+     * Describes the status of this job
+     * 
+     * @return {@link String} that contains one of the following values:
+     *         <ul>
+     *         <li>canceling
+     *         <li>running
+     *         <li>canceled
+     *         <li>unknown
+     *         </ul>
+     */
     public String getStatus() {
         return status;
     }
 
-    public ArrayList<String> getSubmitParameters() {
+    /**
+     * Gets the list of parameters that were submitted to this job
+     * 
+     * @return {@link List} of {@link String}
+     */
+    public List<String> getSubmitParameters() {
         return submitParameters;
     }
 
+    /**
+     * Gets the Epoch time when this job was submitted
+     * 
+     * @return long
+     */
     public long getSubmitTime() {
         return submitTime;
-    }
-
-    public String getViews() {
-        return views;
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/rest/Metric.java
+++ b/java/src/com/ibm/streamsx/rest/Metric.java
@@ -42,7 +42,7 @@ public class Metric {
     /**
      * Gets the description for this metric
      * 
-     * @return {@link String}
+     * @return the metric description
      */
     public String getDescription() {
         return description;
@@ -51,7 +51,7 @@ public class Metric {
     /**
      * Gets the Epoch time when the metric was most recently retrieved
      * 
-     * @return long
+     * @return the epoch time when the metric was most recently retrieved as a long
      */
     public long getLastTimeRetrieved() {
         return lastTimeRetrieved;
@@ -60,7 +60,7 @@ public class Metric {
     /**
      * Describes the kind of metric that has been retrieved
      * 
-     * @return {@link String} that contains one of the following values:
+     * @return the metric kind that contains one of the following values:
      *         <ul>
      *         <li>counter
      *         <li>guage
@@ -75,7 +75,7 @@ public class Metric {
     /**
      * Describes the type of metric that has been retrieved
      * 
-     * @return {@link String} that contains one of the following values:
+     * @return the metric type that contains one of the following values:
      *         <ul>
      *         <li>system
      *         <li>custom
@@ -89,16 +89,16 @@ public class Metric {
     /**
      * Gets the name of this metric
      * 
-     * @return {@link String}
+     * @return the metric name
      */
     public String getName() {
         return name;
     }
 
     /**
-     * Identifies the REST resource type, which is "metric"
+     * Identifies the REST resource type
      * 
-     * @return {@link String}
+     * @return "metric"
      */
     public String getResourceType() {
         return resourceType;
@@ -107,7 +107,7 @@ public class Metric {
     /**
      * Gets the value for this metric
      * 
-     * @return long
+     * @return the metric value as a long
      */
     public long getValue() {
         return value;

--- a/java/src/com/ibm/streamsx/rest/Metric.java
+++ b/java/src/com/ibm/streamsx/rest/Metric.java
@@ -8,57 +8,107 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 
+/**
+ * An object describing an IBM Streams Metric
+ *
+ */
 public class Metric {
 
     @SuppressWarnings("unused")
     private StreamsConnection connection;
 
-    @Expose 
+    @Expose
     private String description;
-    @Expose 
+    @Expose
     private long lastTimeRetrieved;
-    @Expose 
+    @Expose
     private String metricKind;
-    @Expose 
+    @Expose
     private String metricType;
-    @Expose 
+    @Expose
     private String name;
-    @Expose 
+    @Expose
     private String resourceType;
-    @Expose 
+    @Expose
     private long value;
 
     /**
-      * this function is not intended for external consumption
-      */
+     * this function is not intended for external consumption
+     */
     void setConnection(final StreamsConnection sc) {
         connection = sc;
     }
 
+    /**
+     * Gets the description for this metric
+     * 
+     * @return {@link String}
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Gets the Epoch time when the metric was most recently retrieved
+     * 
+     * @return long
+     */
     public long getLastTimeRetrieved() {
         return lastTimeRetrieved;
     }
 
+    /**
+     * Describes the kind of metric that has been retrieved
+     * 
+     * @return {@link String} that contains one of the following values:
+     *         <ul>
+     *         <li>counter
+     *         <li>guage
+     *         <li>time
+     *         <li>unknown
+     *         </ul>
+     */
     public String getMetricKind() {
         return metricKind;
     }
 
+    /**
+     * Describes the type of metric that has been retrieved
+     * 
+     * @return {@link String} that contains one of the following values:
+     *         <ul>
+     *         <li>system
+     *         <li>custom
+     *         <li>unknown
+     *         </ul>
+     */
     public String getMetricType() {
         return metricType;
     }
 
+    /**
+     * Gets the name of this metric
+     * 
+     * @return {@link String}
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Identifies the REST resource type, which is "metric"
+     * 
+     * @return {@link String}
+     */
     public String getResourceType() {
         return resourceType;
     }
 
+    /**
+     * Gets the value for this metric
+     * 
+     * @return long
+     */
     public long getValue() {
         return value;
     }

--- a/java/src/com/ibm/streamsx/rest/Operator.java
+++ b/java/src/com/ibm/streamsx/rest/Operator.java
@@ -60,7 +60,7 @@ public class Operator {
     /**
      * Gets a list of {@link Metric metrics} for this operator
      * 
-     * @return List of {@link Metric}
+     * @return List of {@link Metric IBM Streams Metrics}
      * @throws IOException
      */
     public List<Metric> getMetrics() throws IOException {
@@ -74,7 +74,7 @@ public class Operator {
     /**
      * Gets the index of this operator within the {@link Job}
      * 
-     * @return long
+     * @return the index as a long
      */
     public long getIndexWithinJob() {
         return indexWithinJob;
@@ -84,7 +84,7 @@ public class Operator {
      * Gets a list of {@link InputPort input ports} for this operator
      *
      * 
-     * @return List of {@link InputPort}
+     * @return List of {@link InputPort Input Ports} for this operator
      * @throws IOException
      */
     public List<InputPort> getInputPorts() throws IOException {
@@ -96,7 +96,7 @@ public class Operator {
     /**
      * Name of this operator
      * 
-     * @return {@link String}
+     * @return the operator name
      */
     public String getName() {
         return name;
@@ -105,7 +105,7 @@ public class Operator {
     /**
      * SPL primitive operator type for this operator
      * 
-     * @return {@link String}
+     * @return the SPL primitive operator type
      */
     public String getOperatorKind() {
         return operatorKind;
@@ -114,7 +114,7 @@ public class Operator {
     /**
      * Gets a list of {@link OutputPort output ports} for this operator
      * 
-     * @return List of {@link OutputPort}
+     * @return List of {@link OutputPort Output Ports} for this operator
      * @throws IOException
      */
     public List<OutputPort> getOutputPorts() throws IOException {
@@ -124,9 +124,9 @@ public class Operator {
     }
 
     /**
-     * Identifies the REST resource type as 'operator'
+     * Identifies the REST resource type
      * 
-     * @return {@link String}
+     * @return "operator"
      */
     public String getResourceType() {
         return resourceType;

--- a/java/src/com/ibm/streamsx/rest/Operator.java
+++ b/java/src/com/ibm/streamsx/rest/Operator.java
@@ -10,6 +10,10 @@ import java.util.List;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 
+/**
+ * An object describing an IBM Streams Operator
+ *
+ */
 public class Operator {
 
     private StreamsConnection connection;
@@ -54,7 +58,9 @@ public class Operator {
     }
 
     /**
-     * @return List of {@Metric}
+     * Gets a list of {@link Metric metrics} for this operator
+     * 
+     * @return List of {@link Metric}
      * @throws IOException
      */
     public List<Metric> getMetrics() throws IOException {
@@ -65,68 +71,65 @@ public class Operator {
         return lMetrics;
     }
 
-    public String getConnections() {
-        return connections;
-    }
-
-    public String getDomain() {
-        return domain;
-    }
-
-    public String getHost() {
-        return host;
-    }
-
+    /**
+     * Gets the index of this operator within the {@link Job}
+     * 
+     * @return long
+     */
     public long getIndexWithinJob() {
         return indexWithinJob;
     }
 
+    /**
+     * Gets a list of {@link InputPort input ports} for this operator
+     *
+     * 
+     * @return List of {@link InputPort}
+     * @throws IOException
+     */
     public List<InputPort> getInputPorts() throws IOException {
         String sReturn = connection.getResponseString(inputPorts);
         List<InputPort> lInPorts = new InputPortsArray(connection, sReturn).getInputPorts();
         return lInPorts;
     }
 
-    public String getInstance() {
-        return instance;
-    }
-
-    public String getJob() {
-        return job;
-    }
-
+    /**
+     * Name of this operator
+     * 
+     * @return {@link String}
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * SPL primitive operator type for this operator
+     * 
+     * @return {@link String}
+     */
     public String getOperatorKind() {
         return operatorKind;
     }
 
+    /**
+     * Gets a list of {@link OutputPort output ports} for this operator
+     * 
+     * @return List of {@link OutputPort}
+     * @throws IOException
+     */
     public List<OutputPort> getOutputPorts() throws IOException {
         String sReturn = connection.getResponseString(outputPorts);
         List<OutputPort> lOutPorts = new OutputPortsArray(connection, sReturn).getOutputPorts();
         return lOutPorts;
     }
 
-    public String getPe() {
-        return pe;
-    }
-
-    public String getResourceAllocation() {
-        return resourceAllocation;
-    }
-
+    /**
+     * Identifies the REST resource type as 'operator'
+     * 
+     * @return {@link String}
+     */
     public String getResourceType() {
         return resourceType;
-    }
-
-    public String getRestid() {
-        return restid;
-    }
-
-    public String getSelf() {
-        return self;
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/rest/OutputPort.java
+++ b/java/src/com/ibm/streamsx/rest/OutputPort.java
@@ -52,7 +52,7 @@ public class OutputPort {
     /**
      * Gets the index of this output port within the {@link Operator}
      * 
-     * @return long
+     * @return the index as a long
      */
     public long getIndexWithinOperator() {
         return indexWithinOperator;
@@ -61,7 +61,7 @@ public class OutputPort {
     /**
      * Gets the {@link Metric metrics} for this output port
      * 
-     * @return {@link List} of {@link Metric}
+     * @return List of {@link Metric IBM Streams Metrics}
      */
     public List<Metric> getMetrics() throws IOException {
         String sReturn = connection.getResponseString(metrics);
@@ -73,16 +73,16 @@ public class OutputPort {
     /**
      * Gets the name for this output port
      * 
-     * @return {@link String}
+     * @return the output port name
      */
     public String getName() {
         return name;
     }
 
     /**
-     * Identifies the REST resource type, which is "outputport"
+     * Identifies the REST resource type
      * 
-     * @return {@link String}
+     * @return "outputport"
      */
     public String getResourceType() {
         return resourceType;
@@ -91,7 +91,7 @@ public class OutputPort {
     /**
      * Identifies the name of the output stream associated with this output port
      * 
-     * @return {@link String}
+     * @return the output stream name for this port
      */
     public String getStreamName() {
         return streamName;

--- a/java/src/com/ibm/streamsx/rest/OutputPort.java
+++ b/java/src/com/ibm/streamsx/rest/OutputPort.java
@@ -50,28 +50,18 @@ public class OutputPort {
     }
 
     /**
-     * @return the connections
-     */
-    public String getConnections() {
-        return connections;
-    }
-
-    /**
-     * @return the indexWithinOperator
+     * Gets the index of this output port within the {@link Operator}
+     * 
+     * @return long
      */
     public long getIndexWithinOperator() {
         return indexWithinOperator;
     }
 
     /**
-     * @return the job
-     */
-    public String getJob() {
-        return job;
-    }
-
-    /**
-     * @return the metrics
+     * Gets the {@link Metric metrics} for this output port
+     * 
+     * @return {@link List} of {@link Metric}
      */
     public List<Metric> getMetrics() throws IOException {
         String sReturn = connection.getResponseString(metrics);
@@ -81,56 +71,27 @@ public class OutputPort {
     }
 
     /**
-     * @return the name
+     * Gets the name for this output port
+     * 
+     * @return {@link String}
      */
     public String getName() {
         return name;
     }
 
     /**
-     * @return the operator
-     */
-    public String getOperator() {
-        return operator;
-    }
-
-    /**
-     * @return the pe
-     */
-    public String getPe() {
-        return pe;
-    }
-
-    /**
-     * @return the peOutputPorts
-     */
-    public String getPeOutputPorts() {
-        return peOutputPorts;
-    }
-
-    /**
-     * @return the resourceType
+     * Identifies the REST resource type, which is "outputport"
+     * 
+     * @return {@link String}
      */
     public String getResourceType() {
         return resourceType;
     }
 
     /**
-     * @return the restid
-     */
-    public String getRestid() {
-        return restid;
-    }
-
-    /**
-     * @return the self
-     */
-    public String getSelf() {
-        return self;
-    }
-
-    /**
-     * @return the streamName
+     * Identifies the name of the output stream associated with this output port
+     * 
+     * @return {@link String}
      */
     public String getStreamName() {
         return streamName;

--- a/java/src/com/ibm/streamsx/rest/ProcessingElement.java
+++ b/java/src/com/ibm/streamsx/rest/ProcessingElement.java
@@ -98,7 +98,7 @@ public class ProcessingElement {
     /**
      * Gets a list of {@link Metric metrics} for this processing element
      * 
-     * @return List of {@link Metric}
+     * @return List of {@link Metric IBM Streams Metrics}
      * @throws IOException
      */
     public List<Metric> getMetrics() throws IOException {
@@ -110,7 +110,7 @@ public class ProcessingElement {
     /**
      * Gets a list of {@link InputPort input ports} for this processing element
      * 
-     * @return List of {@link InputPort}
+     * @return List of {@link InputPort Input Ports}
      * @throws IOException
      */
     public List<InputPort> getInputPorts() throws IOException {
@@ -122,7 +122,7 @@ public class ProcessingElement {
     /**
      * Gets a list of {@link Operator operators} for this processing element
      * 
-     * @return List of {@link Operator}
+     * @return List of {@link Operator IBM Streams Operators}
      * @throws IOException
      */
     public List<Operator> getOperators() throws IOException {
@@ -135,7 +135,7 @@ public class ProcessingElement {
      * Gets a list of {@link OutputPort output ports} for this processing
      * element
      * 
-     * @return List of {@link OutputPort}
+     * @return List of {@link OutputPort Output Ports}
      * @throws IOException
      */
     public List<OutputPort> getOutputPorts() throws IOException {
@@ -147,7 +147,7 @@ public class ProcessingElement {
     /**
      * Gets the current working path of the processing element
      * 
-     * @return {@link String}
+     * @return the current working path
      */
     public String getCurrentWorkingPath() {
         return currentWorkingPath;
@@ -156,7 +156,7 @@ public class ProcessingElement {
     /**
      * Gets the health indicator for this processing element
      * 
-     * @return {@link String} that contains one of the following values:
+     * @return the health indicator that contains one of the following values:
      *         <ul>
      *         <li>healthy
      *         <li>partiallyHealthy
@@ -172,7 +172,7 @@ public class ProcessingElement {
     /**
      * Gets the id of this processing element
      * 
-     * @return {@link String}
+     * @return the processing element id
      */
     public String getId() {
         return id;
@@ -181,7 +181,7 @@ public class ProcessingElement {
     /**
      * Gets the index of this processing element within the {@link Job}
      * 
-     * @return long
+     * @return processing element index as a long
      */
     public long getIndexWithinJob() {
         return indexWithinJob;
@@ -191,7 +191,7 @@ public class ProcessingElement {
      * Gets the number of times this processing element was started manually or
      * automatically because of failures
      * 
-     * @return int
+     * @return number of times the processing element was started as an int
      */
     public int getLaunchCount() {
         return launchCount;
@@ -200,7 +200,7 @@ public class ProcessingElement {
     /**
      * Gets the status of optional connections for this processing element.
      * 
-     * @return {@link String} that contains one of the following values:
+     * @return the optional connection status that contains one of the following values:
      *         <ul>
      *         <li>connected
      *         <li>disconnected
@@ -215,7 +215,7 @@ public class ProcessingElement {
     /**
      * Gets a list of the operating system capabilities
      * 
-     * @return {@link List} of {@link String}
+     * @return List of the operating system capabilities
      */
     public List<String> getOsCapabilities() {
         return osCapabilities;
@@ -225,7 +225,7 @@ public class ProcessingElement {
      * Describes a pending change to the granularity of the trace information
      * that is stored for this processing element.
      * 
-     * @return {@link String} that contains one of the following values:
+     * @return the pending trace level change that contains one of the following values:
      *         <ul>
      *         <li>off
      *         <li>debug
@@ -241,7 +241,7 @@ public class ProcessingElement {
     /**
      * Gets the operating system process ID for this processing element
      * 
-     * @return {@link String}
+     * @return the operating sytem process ID
      */
     public String getProcessId() {
         return processId;
@@ -251,7 +251,7 @@ public class ProcessingElement {
      * Indicates whether or not this processing element can be relocated to a
      * different resource
      * 
-     * @return boolean
+     * @return boolean indicating whether or not relocation is possible
      */
     public boolean getRelocatable() {
         return relocatable;
@@ -260,7 +260,7 @@ public class ProcessingElement {
     /**
      * Status of the required connections for this processing element.
      * 
-     * @return {@link String} that contains one of the following values:
+     * @return required connection status that contains one of the following values:
      *         <ul>
      *         <li>connected
      *         <li>disconnected
@@ -275,16 +275,16 @@ public class ProcessingElement {
     /**
      * Gets a list of resource tags for this processing element
      * 
-     * @return {@link List} of {@link String}
+     * @return List of resource tags
      */
     public List<String> getResourceTags() {
         return resourceTags;
     }
 
     /**
-     * Identifies the REST resource type as 'pe'
+     * Identifies the REST resource type
      * 
-     * @return {@link String}
+     * @return "pe"
      */
     public String getResourceType() {
         return resourceType;
@@ -293,7 +293,7 @@ public class ProcessingElement {
     /**
      * Indicates whether or not this processing element can be restarted
      * 
-     * @return boolean
+     * @return the restart indicator as a boolean
      */
     public boolean getRestartable() {
         return restartable;
@@ -302,7 +302,7 @@ public class ProcessingElement {
     /**
      * Gets the status of this processing element
      * 
-     * @return (@link String}
+     * @return the processing element status
      */
     public String getStatus() {
         return status;
@@ -311,7 +311,7 @@ public class ProcessingElement {
     /**
      * Gets additional status for this processing element
      * 
-     * @return {@link String}
+     * @return any addition status for this processing element
      */
     public String getStatusReason() {
         return statusReason;
@@ -320,7 +320,7 @@ public class ProcessingElement {
     /**
      * Gets the granularity of the tracing level for this processing element
      * 
-     * @return {@link String} that contains one of the following values:
+     * @return the current tracing level that contains one of the following values:
      *         <ul>
      *         <li>off
      *         <li>debug

--- a/java/src/com/ibm/streamsx/rest/ProcessingElement.java
+++ b/java/src/com/ibm/streamsx/rest/ProcessingElement.java
@@ -11,6 +11,10 @@ import java.util.List;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 
+/**
+ * An object describing an IBM Streams Processing Element
+ *
+ */
 public class ProcessingElement {
 
     private StreamsConnection connection;
@@ -52,7 +56,7 @@ public class ProcessingElement {
     @Expose
     private String processId;
     @Expose
-    private String relocatable;
+    private boolean relocatable;
     @Expose
     private String requiredConnections;
     @Expose
@@ -81,11 +85,6 @@ public class ProcessingElement {
         connection = sc;
     }
 
-    /**
-     * @param sc StreamsConnection to access other REST apis
-     * @param peGSONList 
-     * @return
-     */
     final static List<ProcessingElement> getPEList(StreamsConnection sc, String peGSONList) {
         ProcessingElementArray peArray = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create()
                 .fromJson(peGSONList, ProcessingElementArray.class);
@@ -97,7 +96,9 @@ public class ProcessingElement {
     }
 
     /**
-     * @return List of {@Metric}
+     * Gets a list of {@link Metric metrics} for this processing element
+     * 
+     * @return List of {@link Metric}
      * @throws IOException
      */
     public List<Metric> getMetrics() throws IOException {
@@ -107,7 +108,9 @@ public class ProcessingElement {
     }
 
     /**
-     * @return List of {@InputPort}
+     * Gets a list of {@link InputPort input ports} for this processing element
+     * 
+     * @return List of {@link InputPort}
      * @throws IOException
      */
     public List<InputPort> getInputPorts() throws IOException {
@@ -117,7 +120,9 @@ public class ProcessingElement {
     }
 
     /**
-     * @return List of {@Operator}
+     * Gets a list of {@link Operator operators} for this processing element
+     * 
+     * @return List of {@link Operator}
      * @throws IOException
      */
     public List<Operator> getOperators() throws IOException {
@@ -127,7 +132,10 @@ public class ProcessingElement {
     }
 
     /**
-     * @return List of {@OutputPort}
+     * Gets a list of {@link OutputPort output ports} for this processing
+     * element
+     * 
+     * @return List of {@link OutputPort}
      * @throws IOException
      */
     public List<OutputPort> getOutputPorts() throws IOException {
@@ -137,175 +145,188 @@ public class ProcessingElement {
     }
 
     /**
-     * @return the connections
-     */
-    public String getConnections() {
-        return connections;
-    }
-
-    /**
-     * @return the currentWorkingPath
+     * Gets the current working path of the processing element
+     * 
+     * @return {@link String}
      */
     public String getCurrentWorkingPath() {
         return currentWorkingPath;
     }
 
     /**
-     * @return the domain
-     */
-    public String getDomain() {
-        return domain;
-    }
-
-    /**
-     * @return the health
+     * Gets the health indicator for this processing element
+     * 
+     * @return {@link String} that contains one of the following values:
+     *         <ul>
+     *         <li>healthy
+     *         <li>partiallyHealthy
+     *         <li>partiallyUnhealthy
+     *         <li>unhealthy
+     *         <li>unknown
+     *         </ul>
      */
     public String getHealth() {
         return health;
     }
 
     /**
-     * @return the host
-     */
-    public String getHost() {
-        return host;
-    }
-
-    /**
-     * @return the id
+     * Gets the id of this processing element
+     * 
+     * @return {@link String}
      */
     public String getId() {
         return id;
     }
 
     /**
-     * @return the indexWithinJob
+     * Gets the index of this processing element within the {@link Job}
+     * 
+     * @return long
      */
     public long getIndexWithinJob() {
         return indexWithinJob;
     }
 
     /**
-     * @return the instance
-     */
-    public String getInstance() {
-        return instance;
-    }
-
-    /**
-     * @return the job
-     */
-    public String getJob() {
-        return job;
-    }
-
-    /**
-     * @return the launchCount
+     * Gets the number of times this processing element was started manually or
+     * automatically because of failures
+     * 
+     * @return int
      */
     public int getLaunchCount() {
         return launchCount;
     }
 
     /**
-     * @return the optionalConnections
+     * Gets the status of optional connections for this processing element.
+     * 
+     * @return {@link String} that contains one of the following values:
+     *         <ul>
+     *         <li>connected
+     *         <li>disconnected
+     *         <li>partiallyConnected
+     *         <li>unknown
+     *         </ul>
      */
     public String getOptionalConnections() {
         return optionalConnections;
     }
 
     /**
-     * @return the osCapabilities
+     * Gets a list of the operating system capabilities
+     * 
+     * @return {@link List} of {@link String}
      */
     public List<String> getOsCapabilities() {
         return osCapabilities;
     }
 
     /**
-     * @return the pendingTracingLevel
+     * Describes a pending change to the granularity of the trace information
+     * that is stored for this processing element.
+     * 
+     * @return {@link String} that contains one of the following values:
+     *         <ul>
+     *         <li>off
+     *         <li>debug
+     *         <li>error
+     *         <li>trace
+     *         </ul>
+     *         a null value indicates no pending change to the trace level
      */
     public String getPendingTracingLevel() {
         return pendingTracingLevel;
     }
 
     /**
-     * @return the processId
+     * Gets the operating system process ID for this processing element
+     * 
+     * @return {@link String}
      */
     public String getProcessId() {
         return processId;
     }
 
     /**
-     * @return the relocatable
+     * Indicates whether or not this processing element can be relocated to a
+     * different resource
+     * 
+     * @return boolean
      */
-    public String getRelocatable() {
+    public boolean getRelocatable() {
         return relocatable;
     }
 
     /**
-     * @return the requiredConnections
+     * Status of the required connections for this processing element.
+     * 
+     * @return {@link String} that contains one of the following values:
+     *         <ul>
+     *         <li>connected
+     *         <li>disconnected
+     *         <li>partiallyConnected
+     *         <li>unknown
+     *         </ul>
      */
     public String getRequiredConnections() {
         return requiredConnections;
     }
 
     /**
-     * @return the resourceAllocation
-     */
-    public String getResourceAllocation() {
-        return resourceAllocation;
-    }
-
-    /**
-     * @return the resourceTags
+     * Gets a list of resource tags for this processing element
+     * 
+     * @return {@link List} of {@link String}
      */
     public List<String> getResourceTags() {
         return resourceTags;
     }
 
     /**
-     * @return the resourceType
+     * Identifies the REST resource type as 'pe'
+     * 
+     * @return {@link String}
      */
     public String getResourceType() {
         return resourceType;
     }
 
     /**
-     * @return the restartable
+     * Indicates whether or not this processing element can be restarted
+     * 
+     * @return boolean
      */
     public boolean getRestartable() {
         return restartable;
     }
 
     /**
-     * @return the restid
-     */
-    public String getRestid() {
-        return restid;
-    }
-
-    /**
-     * @return the self
-     */
-    public String getSelf() {
-        return self;
-    }
-
-    /**
-     * @return the status
+     * Gets the status of this processing element
+     * 
+     * @return (@link String}
      */
     public String getStatus() {
         return status;
     }
 
     /**
-     * @return the statusReason
+     * Gets additional status for this processing element
+     * 
+     * @return {@link String}
      */
     public String getStatusReason() {
         return statusReason;
     }
 
     /**
-     * @return the tracingLevel
+     * Gets the granularity of the tracing level for this processing element
+     * 
+     * @return {@link String} that contains one of the following values:
+     *         <ul>
+     *         <li>off
+     *         <li>debug
+     *         <li>error
+     *         <li>trace
+     *         </ul>
      */
     public String getTracingLevel() {
         return tracingLevel;

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
@@ -22,6 +22,10 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 
+/**
+  * Basic connection to a Streaming Analytics Instance
+  *
+  */
 public class StreamingAnalyticsConnection extends StreamsConnection {
 
     static final Logger traceLog = Logger.getLogger("com.ibm.streamsx.rest.StreamingAnalyticsConnection");
@@ -80,7 +84,7 @@ public class StreamingAnalyticsConnection extends StreamsConnection {
             throw new IllegalStateException("Missing restURL for service");
         }
 
-        streamingConnection.setURL(restURL);
+        streamingConnection.setStreamsRESTURL(restURL);
         String[] rTokens = resourcesPath.split("/");
         if (rTokens[3].equals("service_instances")) {
             streamingConnection.setInstanceId(rTokens[4]);
@@ -102,15 +106,25 @@ public class StreamingAnalyticsConnection extends StreamsConnection {
      * Streaming Analytics only allows one instance per service, so each
      * connection can only ever access a single instance that we've known about
      * since object creation
+     *
+     * @return {@link Instance}
+     *
+     * @throws Exception
      */
     public Instance getInstance() throws IOException {
         return super.getInstance(instanceId);
     }
 
     /**
+     * Cancels a job that has been submitted to IBM Streams
+     *
      * @param jobId
-     *            string indicating the job id to be cancelled
-     * @return true if job is cancelled, false otherwise
+     *            string indicating the job id to be canceled
+     * @return boolean
+     *         <ul>
+     *         <li>true - if job is cancelled
+     *         <li>false -if the job still exists
+     *         </ul>
      * @throws Exception
      */
     public boolean cancelJob(String jobId) throws IOException {
@@ -138,10 +152,8 @@ public class StreamingAnalyticsConnection extends StreamsConnection {
     /**
      * main currently exists to test this object
      * 
-     * @param credentials
-     *            String representing the VCAP_SERVICES, or a file location
-     * @param serviceName
-     *            String representing the service name
+     * credentials - String representing the VCAP_SERVICES, or a file location
+     * serviceName - String representing the service name
      */
     public static void main(String[] args) {
         String credentials = args[0];

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
@@ -107,9 +107,9 @@ public class StreamingAnalyticsConnection extends StreamsConnection {
      * connection can only ever access a single instance that we've known about
      * since object creation
      *
-     * @return {@link Instance}
+     * @return an {@link Instance IBM Streams Instance} associated with this connection
      *
-     * @throws Exception
+     * @throws IOException
      */
     public Instance getInstance() throws IOException {
         return super.getInstance(instanceId);
@@ -120,12 +120,12 @@ public class StreamingAnalyticsConnection extends StreamsConnection {
      *
      * @param jobId
      *            string indicating the job id to be canceled
-     * @return boolean
+     * @return boolean indicating
      *         <ul>
      *         <li>true - if job is cancelled
-     *         <li>false -if the job still exists
+     *         <li>false - if the job still exists
      *         </ul>
-     * @throws Exception
+     * @throws IOException
      */
     public boolean cancelJob(String jobId) throws IOException {
         boolean rc = false;

--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -109,10 +109,6 @@ public class StreamsConnection {
 
         if (HttpStatus.SC_OK == rcResponse) {
             sReturn = EntityUtils.toString(hResponse.getEntity());
-        } else if ((HttpStatus.SC_UNAUTHORIZED == rcResponse) || (HttpStatus.SC_REQUEST_TIMEOUT == rcResponse)) {
-            throw new RESTHTTPException(rcResponse);
-        } else if (HttpStatus.SC_NOT_FOUND == rcResponse) {
-            throw new RESTException(rcResponse);
         } else {
             // all other errors...
             String httpError = "HttpStatus is " + rcResponse + " for url " + inputString;
@@ -127,7 +123,7 @@ public class StreamsConnection {
      * Gets a list of {@link Instance instances} that are available to this
      * streams connection
      * 
-     * @return List of {@link Instance}
+     * @return List of {@link Instance IBM Streams Instances} available to this connection
      * @throws IOException
      */
     public List<Instance> getInstances() throws IOException {
@@ -145,7 +141,7 @@ public class StreamsConnection {
      * 
      * @param instanceId
      *            name of the instance to be retrieved
-     * @return {@link Instance}
+     * @return a single {@link Instance}
      * @throws IOException
      */
     public Instance getInstance(String instanceId) throws IOException {
@@ -171,10 +167,10 @@ public class StreamsConnection {
      *            <li>true - disables checking
      *            <li>false - enables checking (default)
      *            </ul>
-     * @return boolean
+     * @return a boolean indicating the state of the connection after this method was called.
      *         <ul>
-     *         <li>true - checking disabled
-     *         <li>false - checking enabled
+     *         <li>true - if checking is disabled
+     *         <li>false - if checking is enabled
      *         </ul>
      */
     public boolean allowInsecureHosts(boolean allowInsecure) {
@@ -197,7 +193,9 @@ public class StreamsConnection {
             executor = Executor.newInstance();
             allowInsecureHosts = false;
         }
-        traceLog.info("Insecure Host Connection enabled");
+        if ( allowInsecureHosts ) {
+            traceLog.info("Insecure Host Connection enabled");
+        }
         return allowInsecureHosts;
     }
 
@@ -206,10 +204,10 @@ public class StreamsConnection {
      * 
      * @param jobId
      *            string identifying the job to be cancelled
-     * @return boolean
+     * @return a boolean indicating
      *         <ul>
-     *         <li>true - job is cancelled
-     *         <li>false - job did not get cancelled
+     *         <li>true if the jobId is cancelled
+     *         <li>false if the jobId did not get cancelled
      *         </ul>
      * @throws Exception
      */


### PR DESCRIPTION
in addition to the javadoc, i've also removed any functions that should be returning structures instead of strings.  (i.e, things like getHost() or getInstance() and have left them out until we need to add them in