### PR TITLE
Add ability to set resource tags for python functions

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -262,6 +262,10 @@ class _SPLInvocation(object):
         _op["config"]["viewConfigs"] = self.view_configs
         if self._placement:
             _op["config"]["placement"] = self._placement
+            if 'resourceTags' in self._placement:
+                # Convert the set to a list for JSON
+                tags = _op['config']['placement']['resourceTags']
+                _op['config']['placement']['resourceTags'] = list(tags)
         _params = {}
         # Add parameters as their string representation
         # unless they value has a spl_json() function,

--- a/test/python/topology/test2_placement.py
+++ b/test/python/topology/test2_placement.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+import unittest
+import sys
+import itertools
+import logging
+import socket
+
+from streamsx.topology.topology import *
+from streamsx.topology.tester import Tester
+
+import test_vers
+
+def host_name():
+    return [socket.gethostname()]
+
+class RemoveDup(object):
+    def __init__(self):
+        self.last = None
+    def __call__(self, t):
+         if self.last is None:
+             self.last = t
+             return t
+         if t == self.last:
+             return None
+         return t
+
+@unittest.skipIf(not test_vers.tester_supported() , "Tester not supported")
+class TestPlacement(unittest.TestCase):
+  def setUp(self):
+      Tester.setup_streaming_analytics(self, force_remote_build=True)
+
+  def test_ResourceTags(self):
+     topo = Topology()
+     h1 = topo.source(host_name)
+     h1.resource_tags.add('host1')
+
+     h2 = topo.source(host_name)
+     h2.resource_tags.add('host2')
+
+     h = h1.union({h2})
+     h.print()
+     h = h.map(RemoveDup())
+     
+     tester = Tester(topo)
+     tester.tuple_count(h, 2)
+     
+     sr = tester.test(self.test_ctxtype, self.test_config)


### PR DESCRIPTION
```
s = topo.source(...)

# resource_tags is a set containing required tags.
s.resource_tags.add('ingest')
```