### PR TITLE
Cleanup tests to not catch exceptions, fix cancelJob()

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/streams/InvokeCancel.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/InvokeCancel.java
@@ -31,7 +31,7 @@ public class InvokeCancel {
         this.userName = null;
     }
 
-    public void invoke() throws Exception, InterruptedException {
+    public int invoke(boolean throwOnError) throws Exception, InterruptedException {
         String si = Util.getStreamsInstall();
         File sj = new File(si, "bin/streamtool");
         
@@ -57,8 +57,8 @@ public class InvokeCancel {
         sjProcess.getOutputStream().close();
         int rc = sjProcess.waitFor();
         trace.info("streamtool canceljob complete: return code=" + rc);
-        if (rc != 0)
+        if (throwOnError && rc != 0)
             throw new Exception("streamtool canceljob failed!");
-
+        return rc;
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/DistributedTesterContextFuture.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/DistributedTesterContextFuture.java
@@ -41,7 +41,7 @@ public class DistributedTesterContextFuture implements Future<BigInteger> {
             cancelled = true;
         }
         try {
-            cancel.invoke();
+            cancel.invoke(true);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Cleaned up the tests to not catch exceptions and then fail the test, instead use the common pattern of having the test method declared to throw `Exception` and let JUnit handle the test failure due to an exception.

This uncovered two issues with the cancel not existent job test:

1.  `StreamsConnection.cancelJob()` always returned `true`.
1.  The streaming analytics version of the test was actually failing due to an NPE, and was not testing the intended functionality.
