### PR TITLE
fix #1101 - remove additional test units in unittest.restapi.base

### DIFF
--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -313,29 +313,6 @@
        </batchtest>
      </junit>
    </jacoco:coverage>
-   <jacoco:coverage enabled="${topology.test.coverage}">
-     <junit fork="yes" dir="${topology.test.dir}" printsummary="yes"
-           threads="${topology.test.threads}"
-           haltonfailure="${topology.test.haltonfailure}" failureproperty="topology.tests.failed">
-       <sysproperty key="topology.test.root" value="${topology.test.root}"/>
-       <sysproperty key="topology.test.type" value="${topology.test.type}"/>
-       <sysproperty key="topology.test.sc_ok" value="${topology.test.sc_ok}"/>
-       <sysproperty key="topology.test.perf_ok" value="${topology.test.perf_ok}"/>
-       <sysproperty key="topology.install.compile" value="${topology.install.compile}"/>
-       <sysproperty key="log4j.configuration" value="${topology.log4j}"/>
-
-       <classpath>
-         <path refid="test.sample.classpath"/>
-       </classpath>
-       <assertions><enable/></assertions>
-       <formatter type="xml"/>
-       <batchtest todir="${topology.test.dir}">
-          <fileset dir="${classes}">
-             <include name="**/*Test.class"/>
-          </fileset>
-       </batchtest>
-     </junit>
-   </jacoco:coverage>
    <fail message="Unittests failed" if="topology.tests.failed"/>
    </target>
 


### PR DESCRIPTION
removing extra section in the unittest.restapi.base