### PR TITLE
fix #1098: NPE if Java REST api response is 404.

### DIFF
--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -116,8 +116,14 @@ public class StreamsConnection {
             sReturn = EntityUtils.toString(hResponse.getEntity());
         } else if (HttpStatus.SC_NOT_FOUND == rcResponse) {
             // with a 404 message, we are likely to have a message from Streams
+            // but if not, provide a better message
             sReturn = EntityUtils.toString(hResponse.getEntity());
-            throw RESTException.create(rcResponse, sReturn);
+            if ((sReturn != null) && (!sReturn.equals(""))) {
+                throw RESTException.create(rcResponse, sReturn);
+            } else {
+                String httpError = "HttpStatus is " + rcResponse + " for url " + inputString;
+                throw new RESTException(rcResponse, httpError);
+            }
         } else {
             // all other errors...
             String httpError = "HttpStatus is " + rcResponse + " for url " + inputString;


### PR DESCRIPTION
the additions to RESTException.java prevents an NPE in the class.
the changes to StreamsConnection.java is to give a better error message on the exception specifically on a 404 error message that has no other information from IBM Streams... 