### PR TITLE
Allow concurrent test execution

### DIFF
--- a/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
@@ -122,7 +122,10 @@ public class StreamsConnectionTest {
     public void setupJob() throws Exception {
         setupInstance();
         if (jobId == null) {
-            Topology topology = new Topology("JobForRESTApiTest");
+            
+            Topology topology = new Topology(
+                    getClass().getSimpleName(), // avoid clashes with sub-class tests
+                    "JobForRESTApiTest");
 
             TStream<Integer> source = topology.periodicSource(randomGenerator(), 200, TimeUnit.MILLISECONDS);
             TStream<Integer> sourceDouble = source.transform(doubleNumber());


### PR DESCRIPTION
Was hitting the issue that running concurrently the two REST tests were always creating sabs with the same name, thus treading over each other. E.g. submits failing due to the sab not being found.