### PR TITLE
Java testing refactor

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/context/DistributedTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/DistributedTester.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Future;
 
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.internal.tester.DistributedTesterContextFuture;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
 import com.ibm.streamsx.topology.internal.tester.TupleCollection;
 
 public class DistributedTester extends DistributedStreamsContext {
@@ -26,7 +27,7 @@ public class DistributedTester extends DistributedStreamsContext {
         if (app == null)
             return future;
         return new DistributedTesterContextFuture(future.get(),
-                (TupleCollection) (app.getTester()));
+                ((TupleCollection) (app.getTester())).getRuntime());
     }
     
     
@@ -35,8 +36,8 @@ public class DistributedTester extends DistributedStreamsContext {
     void preInvoke(AppEntity entity, File bundle) {
         Topology app = entity.app;
         if (app != null && app.hasTester()) {
-            TupleCollection collector = (TupleCollection) app.getTester();
-            collector.startLocalCollector();
+            TesterRuntime trt = ((TupleCollection) app.getTester()).getRuntime();
+            trt.start();
         }
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/context/StandaloneTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/StandaloneTester.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Future;
 
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.internal.tester.StandaloneTesterContextFuture;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
 import com.ibm.streamsx.topology.internal.tester.TupleCollection;
 
 public class StandaloneTester extends StandaloneStreamsContext {
@@ -22,8 +23,8 @@ public class StandaloneTester extends StandaloneStreamsContext {
     void preInvoke(AppEntity entity, File bundle) {
         Topology app = entity.app;
         if (app != null && app.hasTester()) {
-            TupleCollection collector = (TupleCollection) app.getTester();
-            collector.startLocalCollector();
+            TesterRuntime trt = ((TupleCollection) app.getTester()).getRuntime();
+            trt.start();
         }
     }
 
@@ -33,6 +34,6 @@ public class StandaloneTester extends StandaloneStreamsContext {
         if (app == null)
             return future;
         return new StandaloneTesterContextFuture<Integer>(future,
-                (TupleCollection) (app.getTester()));
+                ((TupleCollection) app.getTester()).getRuntime());
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/DistributedTesterContextFuture.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/DistributedTesterContextFuture.java
@@ -20,12 +20,12 @@ import com.ibm.streamsx.topology.internal.streams.InvokeCancel;
 public class DistributedTesterContextFuture implements Future<BigInteger> {
 
     private final BigInteger jobId;
-    private final TupleCollection tester;
+    private final TesterRuntime trt;
     private boolean cancelled;
 
-    public DistributedTesterContextFuture(BigInteger jobId, TupleCollection tester) {
+    public DistributedTesterContextFuture(BigInteger jobId, TesterRuntime trt) {
         this.jobId = jobId;
-        this.tester = tester;
+        this.trt = trt;
     }
 
     @Override
@@ -81,7 +81,7 @@ public class DistributedTesterContextFuture implements Future<BigInteger> {
 
     void shutdownTester() {
         try {
-            tester.shutdown();
+            trt.shutdown();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/StandaloneTesterContextFuture.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/StandaloneTesterContextFuture.java
@@ -12,11 +12,11 @@ import java.util.concurrent.TimeoutException;
 public class StandaloneTesterContextFuture<T> implements Future<T> {
 
         private final Future<T> topologyFuture;
-        private final TupleCollection tester;
+        private final TesterRuntime trt;
 
-        public StandaloneTesterContextFuture(Future<T> topologyFuture, TupleCollection tester) {
+        public StandaloneTesterContextFuture(Future<T> topologyFuture, TesterRuntime trt) {
             this.topologyFuture = topologyFuture;
-            this.tester = tester;
+            this.trt = trt;
         }
 
         @Override
@@ -29,7 +29,7 @@ public class StandaloneTesterContextFuture<T> implements Future<T> {
         
         void shutdownTester() {
             try {
-                tester.shutdown();
+                trt.shutdown();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
@@ -1,0 +1,26 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017 
+ */
+package com.ibm.streamsx.topology.internal.tester;
+
+/**
+ * Separation of the runtime aspects of a
+ * Tester from definition time.
+ *
+ */
+public class TesterRuntime {
+    private final TupleCollection tester;
+    
+    protected TesterRuntime(TupleCollection tester) {
+        this.tester = tester;
+    }
+    
+    public void start() {
+        tester.startLocalCollector();
+    }
+
+    public void shutdown() throws Exception {
+        tester.shutdown();  
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
@@ -4,23 +4,37 @@
  */
 package com.ibm.streamsx.topology.internal.tester;
 
+import java.util.Map;
+import java.util.Set;
+
+import com.ibm.streams.flow.handlers.StreamHandler;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+
 /**
  * Separation of the runtime aspects of a
  * Tester from definition time.
  *
  */
-public class TesterRuntime {
+public abstract class TesterRuntime {
     private final TupleCollection tester;
     
     protected TesterRuntime(TupleCollection tester) {
         this.tester = tester;
     }
     
-    public void start() {
-        tester.startLocalCollector();
+    protected TupleCollection tester() {
+        return tester;
     }
+    
+    protected Topology topology() {
+        return tester().getTopology();
+    }
+    
+    public abstract void start();
 
-    public void shutdown() throws Exception {
-        tester.shutdown();  
-    }
+    public abstract void shutdown() throws Exception;
+    
+    public abstract void finalizeTester(Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers) throws Exception;  
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TupleCollection.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TupleCollection.java
@@ -4,7 +4,6 @@
  */
 package com.ibm.streamsx.topology.internal.tester;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,36 +18,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.mina.core.service.IoHandlerAdapter;
-import org.apache.mina.core.session.IoSession;
-
-import com.ibm.streams.flow.declare.InputPortDeclaration;
-import com.ibm.streams.flow.declare.OperatorGraph;
-import com.ibm.streams.flow.declare.OperatorGraphFactory;
-import com.ibm.streams.flow.declare.OperatorInvocation;
-import com.ibm.streams.flow.declare.OutputPortDeclaration;
 import com.ibm.streams.flow.handlers.StreamCollector;
 import com.ibm.streams.flow.handlers.StreamCounter;
 import com.ibm.streams.flow.handlers.StreamHandler;
-import com.ibm.streams.flow.javaprimitives.JavaOperatorTester;
 import com.ibm.streams.flow.javaprimitives.JavaTestableGraph;
-import com.ibm.streams.operator.OutputTuple;
-import com.ibm.streams.operator.StreamingOutput;
 import com.ibm.streams.operator.Tuple;
-import com.ibm.streams.operator.samples.operators.PassThrough;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
-import com.ibm.streamsx.topology.builder.BInputPort;
-import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.builder.BOutput;
 import com.ibm.streamsx.topology.builder.BOutputPort;
 import com.ibm.streamsx.topology.context.StreamsContext;
 import com.ibm.streamsx.topology.context.StreamsContext.Type;
 import com.ibm.streamsx.topology.function.Predicate;
 import com.ibm.streamsx.topology.internal.test.handlers.StringTupleTester;
-import com.ibm.streamsx.topology.internal.tester.ops.TesterSink;
-import com.ibm.streamsx.topology.internal.tester.tcp.TCPTestServer;
-import com.ibm.streamsx.topology.internal.tester.tcp.TestTuple;
+import com.ibm.streamsx.topology.internal.tester.tcp.TCPTesterRuntime;
 import com.ibm.streamsx.topology.spl.SPLStream;
 import com.ibm.streamsx.topology.streams.StringStreams;
 import com.ibm.streamsx.topology.tester.Condition;
@@ -65,42 +48,13 @@ import com.ibm.streamsx.topology.tester.Tester;
 public class TupleCollection implements Tester {
 
     private final Topology topology;
-    private OperatorGraph collectorGraph;
-    private JavaTestableGraph localCollector;
-    private Future<JavaTestableGraph> localRunningCollector;
     private AtomicBoolean used = new AtomicBoolean();
-
-    private final Map<TStream<?>, StreamTester> testers = new HashMap<>();
 
     private final Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers = new HashMap<>();
 
     public TupleCollection(Topology topology) {
         this.topology = topology;
     }
-
-    /**
-     * Holds the information in the declared collector graph about the testers
-     * so that the handlers can be attached once the graph is executed.
-     */
-    private static class StreamTester {
-        final int testerId;
-        final InputPortDeclaration input;
-        final OutputPortDeclaration output;
-
-        // In the graph executing locally, add a PassThrough operator that
-        // the TCP server will inject tuples to. It's output will be where
-        // the StreamHandlers are attached to.
-        StreamTester(OperatorGraph graph, int testerId, TStream<?> stream) {
-            this.testerId = testerId;
-            OperatorInvocation<PassThrough> operator = graph
-                    .addOperator(PassThrough.class);
-            input = operator.addInput(stream.output().schema());
-            output = operator.addOutput(stream.output().schema());
-        }
-    }
-
-    private Map<Integer, TestTupleInjector> injectors = Collections
-            .synchronizedMap(new HashMap<Integer, TestTupleInjector>());
 
     /*
      * Graph declaration time.
@@ -334,117 +288,24 @@ public class TupleCollection implements Tester {
             break;
         case DISTRIBUTED_TESTER:
         case STANDALONE_TESTER:
-            finalizeStandaloneTester();
+            synchronized (this) {
+                runtime = new TCPTesterRuntime(this);
+            }
+            runtime.finalizeTester(handlers);
             break;
         default: // nothing to do
             break;
         }
     }
 
-    private TCPTestServer tcpServer;
-    private BOperatorInvocation testerSinkOp;
 
-    // private SPLOperator testerSinkSplOp;
-
-    /**
-     * 
-     * @param graphItems
-     * @throws Exception
-     */
-    private void finalizeStandaloneTester()
-            throws Exception {
-
-        addTCPServerAndSink();
-        collectorGraph = OperatorGraphFactory.newGraph();
-        for (TStream<?> stream : handlers.keySet()) {
-            int testerId = connectToTesterSink(stream);
-            testers.put(stream, new StreamTester(collectorGraph, testerId,
-                    stream));
-        }
-
-        localCollector = new JavaOperatorTester()
-                .executable(collectorGraph);
-        setupTestHandlers();
-    }
 
     private void finalizeEmbeddedTester()
             throws Exception {
 
     }
 
-    /**
-     * Connect a stream in the real topology to the TestSink operator that was
-     * added.
-     */
-    private int connectToTesterSink(TStream<?> stream) {
-        BInputPort inputPort = stream.connectTo(testerSinkOp, true, null);
-        // testerSinkSplOp.addInput(inputPort);
-        return inputPort.port().getPortNumber();
-    }
 
-    /**
-     * Add a TCP server that will list for tuples to be directed to handlers.
-     * Adds a sink to the topology to capture those tuples and deliver them to
-     * the current jvm to run Junit type tests.
-     */
-    private void addTCPServerAndSink() throws Exception {
-
-        tcpServer = new TCPTestServer(0, new IoHandlerAdapter() {
-            @Override
-            public void messageReceived(IoSession session, Object message)
-                    throws Exception {
-                TestTuple tuple = (TestTuple) message;
-                TestTupleInjector injector = injectors.get(tuple.getTesterId());
-                injector.tuple(tuple.getTupleData());
-            }
-        });
-
-        InetSocketAddress testAddr = tcpServer.start();
-        addTesterSink(testAddr);
-    }
-
-    public void shutdown() throws Exception {
-        tcpServer.shutdown();
-        localRunningCollector.cancel(true);       
-    }
-
-    private void addTesterSink(InetSocketAddress testAddr) {
-
-        Map<String, Object> hostInfo = new HashMap<>();
-        hostInfo.put("host", testAddr.getHostString());
-        hostInfo.put("port", testAddr.getPort());
-        this.testerSinkOp = topology.builder().addOperator(TesterSink.class,
-                hostInfo);
-
-        /*
-         * 
-         * testerSinkOp = topology.graph().addOperator(TesterSink.class);
-         * 
-         * testerSinkSplOp = topology.splgraph().addOperator(testerSinkOp);
-         * testerSinkOp.setStringParameter("host", testAddr.getHostString());
-         * testerSinkOp.setIntParameter("port", testAddr.getPort());
-         * 
-         * Map<String, Object> params = new HashMap<>(); params.put("host",
-         * testAddr.getHostString()); params.put("port", testAddr.getPort());
-         * testerSinkSplOp.setParameters(params);
-         */
-    }
-
-    private void setupTestHandlers() throws Exception {
-
-        for (TStream<?> stream : handlers.keySet()) {
-            Set<StreamHandler<Tuple>> streamHandlers = handlers.get(stream);
-            StreamTester tester = testers.get(stream);
-
-            StreamingOutput<OutputTuple> injectPort = localCollector
-                    .getInputTester(tester.input);
-            injectors.put(tester.testerId, new TestTupleInjector(injectPort));
-
-            for (StreamHandler<Tuple> streamHandler : streamHandlers) {
-                localCollector.registerStreamHandler(tester.output, streamHandler);
-            }
-        }
-    }
 
     public void setupEmbeddedTestHandlers(JavaTestableGraph tg)
             throws Exception {
@@ -546,13 +407,11 @@ public class TupleCollection implements Tester {
         complete(context, config, expectedCount, timeout, unit);
         return expectedContents;
     }
-
-    void startLocalCollector() {
-        assert this.localCollector != null;
-        localRunningCollector = localCollector.execute();       
-    } 
     
-    public TesterRuntime getRuntime() {
-        return new TesterRuntime(this);
+    private TesterRuntime runtime;
+    public synchronized TesterRuntime getRuntime() {
+        if (runtime == null)
+            throw new IllegalStateException();
+        return runtime;
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TupleCollection.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TupleCollection.java
@@ -547,8 +547,12 @@ public class TupleCollection implements Tester {
         return expectedContents;
     }
 
-    public void startLocalCollector() {
+    void startLocalCollector() {
         assert this.localCollector != null;
         localRunningCollector = localCollector.execute();       
-    }   
+    } 
+    
+    public TesterRuntime getRuntime() {
+        return new TesterRuntime(this);
+    }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TupleCollection.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TupleCollection.java
@@ -47,6 +47,8 @@ import com.ibm.streamsx.topology.context.StreamsContext.Type;
 import com.ibm.streamsx.topology.function.Predicate;
 import com.ibm.streamsx.topology.internal.test.handlers.StringTupleTester;
 import com.ibm.streamsx.topology.internal.tester.ops.TesterSink;
+import com.ibm.streamsx.topology.internal.tester.tcp.TCPTestServer;
+import com.ibm.streamsx.topology.internal.tester.tcp.TestTuple;
 import com.ibm.streamsx.topology.spl.SPLStream;
 import com.ibm.streamsx.topology.streams.StringStreams;
 import com.ibm.streamsx.topology.tester.Condition;

--- a/java/src/com/ibm/streamsx/topology/internal/tester/ops/TesterSink.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/ops/TesterSink.java
@@ -22,8 +22,8 @@ import com.ibm.streams.operator.model.Libraries;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
 import com.ibm.streams.operator.samples.patterns.TupleConsumer;
-import com.ibm.streamsx.topology.internal.tester.TCPTestClient;
-import com.ibm.streamsx.topology.internal.tester.TestTuple;
+import com.ibm.streamsx.topology.internal.tester.tcp.TCPTestClient;
+import com.ibm.streamsx.topology.internal.tester.tcp.TestTuple;
 
 @PrimitiveOperator
 @InputPortSet

--- a/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTestClient.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTestClient.java
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2015  
  */
-package com.ibm.streamsx.topology.internal.tester;
+package com.ibm.streamsx.topology.internal.tester.tcp;
 
 import java.net.InetSocketAddress;
 

--- a/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTestServer.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTestServer.java
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2015  
  */
-package com.ibm.streamsx.topology.internal.tester;
+package com.ibm.streamsx.topology.internal.tester.tcp;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;

--- a/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTesterRuntime.java
@@ -1,0 +1,183 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017 
+ */
+package com.ibm.streamsx.topology.internal.tester.tcp;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+import org.apache.mina.core.service.IoHandlerAdapter;
+import org.apache.mina.core.session.IoSession;
+
+import com.ibm.streams.flow.declare.InputPortDeclaration;
+import com.ibm.streams.flow.declare.OperatorGraph;
+import com.ibm.streams.flow.declare.OperatorGraphFactory;
+import com.ibm.streams.flow.declare.OperatorInvocation;
+import com.ibm.streams.flow.declare.OutputPortDeclaration;
+import com.ibm.streams.flow.handlers.StreamHandler;
+import com.ibm.streams.flow.javaprimitives.JavaOperatorTester;
+import com.ibm.streams.flow.javaprimitives.JavaTestableGraph;
+import com.ibm.streams.operator.OutputTuple;
+import com.ibm.streams.operator.StreamingOutput;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streams.operator.samples.operators.PassThrough;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.builder.BInputPort;
+import com.ibm.streamsx.topology.builder.BOperatorInvocation;
+import com.ibm.streamsx.topology.internal.tester.TestTupleInjector;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
+import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.ops.TesterSink;
+
+public class TCPTesterRuntime extends TesterRuntime {
+    
+    private OperatorGraph collectorGraph;
+    private JavaTestableGraph localCollector;
+    private Future<JavaTestableGraph> localRunningCollector;
+    private TCPTestServer tcpServer;
+    private BOperatorInvocation testerSinkOp;
+    private final Map<TStream<?>, StreamTester> testers = new HashMap<>();
+    
+    private Map<Integer, TestTupleInjector> injectors = Collections
+            .synchronizedMap(new HashMap<Integer, TestTupleInjector>());
+
+
+    public TCPTesterRuntime(TupleCollection tester) {
+        super(tester);
+        // TODO Auto-generated constructor stub
+    }
+    
+    
+
+
+    // private SPLOperator testerSinkSplOp;
+
+    /**
+     * 
+     * @param graphItems
+     * @throws Exception
+     */
+    public void finalizeTester(Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers)
+            throws Exception {
+
+        addTCPServerAndSink();
+        collectorGraph = OperatorGraphFactory.newGraph();
+        for (TStream<?> stream : handlers.keySet()) {
+            int testerId = connectToTesterSink(stream);
+            testers.put(stream, new StreamTester(collectorGraph, testerId,
+                    stream));
+        }
+
+        localCollector = new JavaOperatorTester()
+                .executable(collectorGraph);
+        setupTestHandlers(handlers);
+    }
+    
+    @Override
+    public void start() {
+        assert this.localCollector != null;
+        localRunningCollector = localCollector.execute();
+    }   
+    
+    /**
+     * Add a TCP server that will list for tuples to be directed to handlers.
+     * Adds a sink to the topology to capture those tuples and deliver them to
+     * the current jvm to run Junit type tests.
+     */
+    private void addTCPServerAndSink() throws Exception {
+
+        tcpServer = new TCPTestServer(0, new IoHandlerAdapter() {
+            @Override
+            public void messageReceived(IoSession session, Object message)
+                    throws Exception {
+                TestTuple tuple = (TestTuple) message;
+                TestTupleInjector injector = injectors.get(tuple.getTesterId());
+                injector.tuple(tuple.getTupleData());
+            }
+        });
+
+        InetSocketAddress testAddr = tcpServer.start();
+        addTesterSink(testAddr);
+    }
+
+    public void shutdown() throws Exception {
+        tcpServer.shutdown();
+        localRunningCollector.cancel(true);       
+    }
+
+    private void addTesterSink(InetSocketAddress testAddr) {
+
+        Map<String, Object> hostInfo = new HashMap<>();
+        hostInfo.put("host", testAddr.getHostString());
+        hostInfo.put("port", testAddr.getPort());
+        this.testerSinkOp = topology().builder().addOperator(TesterSink.class,
+                hostInfo);
+
+        /*
+         * 
+         * testerSinkOp = topology.graph().addOperator(TesterSink.class);
+         * 
+         * testerSinkSplOp = topology.splgraph().addOperator(testerSinkOp);
+         * testerSinkOp.setStringParameter("host", testAddr.getHostString());
+         * testerSinkOp.setIntParameter("port", testAddr.getPort());
+         * 
+         * Map<String, Object> params = new HashMap<>(); params.put("host",
+         * testAddr.getHostString()); params.put("port", testAddr.getPort());
+         * testerSinkSplOp.setParameters(params);
+         */
+    }
+    
+    /**
+     * Connect a stream in the real topology to the TestSink operator that was
+     * added.
+     */
+    private int connectToTesterSink(TStream<?> stream) {
+        BInputPort inputPort = stream.connectTo(testerSinkOp, true, null);
+        // testerSinkSplOp.addInput(inputPort);
+        return inputPort.port().getPortNumber();
+    }
+
+
+
+    private void setupTestHandlers(Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers) throws Exception {
+
+        for (TStream<?> stream : handlers.keySet()) {
+            Set<StreamHandler<Tuple>> streamHandlers = handlers.get(stream);
+            StreamTester tester = testers.get(stream);
+
+            StreamingOutput<OutputTuple> injectPort = localCollector
+                    .getInputTester(tester.input);
+            injectors.put(tester.testerId, new TestTupleInjector(injectPort));
+
+            for (StreamHandler<Tuple> streamHandler : streamHandlers) {
+                localCollector.registerStreamHandler(tester.output, streamHandler);
+            }
+        }
+    }
+    
+    /**
+     * Holds the information in the declared collector graph about the testers
+     * so that the handlers can be attached once the graph is executed.
+     */
+    private static class StreamTester {
+        final int testerId;
+        final InputPortDeclaration input;
+        final OutputPortDeclaration output;
+
+        // In the graph executing locally, add a PassThrough operator that
+        // the TCP server will inject tuples to. It's output will be where
+        // the StreamHandlers are attached to.
+        StreamTester(OperatorGraph graph, int testerId, TStream<?> stream) {
+            this.testerId = testerId;
+            OperatorInvocation<PassThrough> operator = graph
+                    .addOperator(PassThrough.class);
+            input = operator.addInput(stream.output().schema());
+            output = operator.addOutput(stream.output().schema());
+        }
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TestTuple.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TestTuple.java
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2015  
  */
-package com.ibm.streamsx.topology.internal.tester;
+package com.ibm.streamsx.topology.internal.tester.tcp;
 
 public class TestTuple {
 

--- a/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TestTupleDecoder.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TestTupleDecoder.java
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2015  
  */
-package com.ibm.streamsx.topology.internal.tester;
+package com.ibm.streamsx.topology.internal.tester.tcp;
 
 import org.apache.mina.core.buffer.IoBuffer;
 import org.apache.mina.core.session.IoSession;

--- a/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TestTupleEncoder.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TestTupleEncoder.java
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2015  
  */
-package com.ibm.streamsx.topology.internal.tester;
+package com.ibm.streamsx.topology.internal.tester.tcp;
 
 import org.apache.mina.core.buffer.IoBuffer;
 import org.apache.mina.core.session.IoSession;


### PR DESCRIPTION
Moves the TCP code into a separate runner object to allow a REST implementation.