### PR TITLE
Improve naming for parallel regions.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -109,7 +109,10 @@ class SPLGraph(object):
 
         if name is None:
             name = self._requested_name(None,action="Op", func = function)
-
+        
+        else:
+            name = self._requested_name(name, action="Op", func = function)
+            
         if(kind.startswith("$")):    
             op = Marker(len(self.operators), kind, name, {}, self)                           
         else:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -109,10 +109,7 @@ class SPLGraph(object):
 
         if name is None:
             name = self._requested_name(None,action="Op", func = function)
-        
-        else:
-            name = self._requested_name(name, action="Op", func = function)
-            
+
         if(kind.startswith("$")):    
             op = Marker(len(self.operators), kind, name, {}, self)                           
         else:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -684,6 +684,9 @@ class Stream(object):
         """
         if name is None:
             name = self.name
+            
+        name = self.topology.graph._requested_name(name, action='parallel', func=func)
+
         if routing == None or routing == Routing.ROUND_ROBIN:
             op2 = self.topology.graph.addOperator("$Parallel$", name=name)
             op2.addInputPort(outputPort=self.oport)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -676,14 +676,14 @@ class Stream(object):
             func: Optional function called when :py:const:`Routing.HASH_PARTITIONED` routing is specified.
                 The function provides an integer value to be used as the hash that determines
                 the tuple channel routing.
-            name (String): The name to display for the parallel region.
+            name (str): The name to display for the parallel region.
 
         Returns:
             Stream: A stream for which subsequent transformations will be executed in parallel.
 
         """
         if name is None:
-            name = "parallel"
+            name = self.name
         if routing == None or routing == Routing.ROUND_ROBIN:
             op2 = self.topology.graph.addOperator("$Parallel$", name=name)
             op2.addInputPort(outputPort=self.oport)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -649,7 +649,7 @@ class Stream(object):
         oport = op.addOutputPort()
         return Stream(self.topology, oport)
     
-    def parallel(self, width, routing=Routing.ROUND_ROBIN, func=None):
+    def parallel(self, width, routing=Routing.ROUND_ROBIN, func=None, name=None):
         """
         Parallelizes the stream into `width` parallel channels.
         Tuples are routed to parallel channels such that an even distribution is maintained.
@@ -676,13 +676,16 @@ class Stream(object):
             func: Optional function called when :py:const:`Routing.HASH_PARTITIONED` routing is specified.
                 The function provides an integer value to be used as the hash that determines
                 the tuple channel routing.
+            name (String): The name to display for the parallel region.
 
         Returns:
             Stream: A stream for which subsequent transformations will be executed in parallel.
 
         """
+        if name is None:
+            name = "parallel"
         if routing == None or routing == Routing.ROUND_ROBIN:
-            op2 = self.topology.graph.addOperator("$Parallel$")
+            op2 = self.topology.graph.addOperator("$Parallel$", name=name)
             op2.addInputPort(outputPort=self.oport)
             oport = op2.addOutputPort(width)
             return Stream(self.topology, oport)
@@ -704,7 +707,7 @@ class Stream(object):
                 hash_adder.addInputPort(outputPort=self.oport, name=self.name)
                 parallel_input = hash_adder.addOutputPort(schema=hash_schema)
 
-            parallel_op = self.topology.graph.addOperator("$Parallel$")
+            parallel_op = self.topology.graph.addOperator("$Parallel$", name=name)
             parallel_op.addInputPort(outputPort=parallel_input)
             parallel_op_port = parallel_op.addOutputPort(oWidth=width, schema=parallel_input.schema, partitioned_keys=keys)
 

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -411,8 +411,14 @@ public class SPLGenerator {
         JsonObject compositeInvocation = new JsonObject();
 
         compositeInvocation.addProperty("kind", compositeKind);
-        compositeInvocation.addProperty("name", "paraComp_" + numParallelComposites);
-        compositeInvocation.add("inputs", startOp.get("inputs"));
+        String parallelCompositeName = jstring(startOp, "name");
+	if(parallelCompositeName != null){
+	    compositeInvocation.addProperty("name", parallelCompositeName);
+	}
+	else{
+	    compositeInvocation.addProperty("name", "parallel_" + numParallelComposites);
+        }
+	compositeInvocation.add("inputs", startOp.get("inputs"));
         
         numParallelComposites++;
         

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -399,7 +399,7 @@ public class SPLGenerator {
      */
     private JsonObject createCompositeDefinition(JsonObject graph, List<JsonObject> unvisited, JsonObject startOp) {
         
-        String compositeKind = "__parallel_Composite_" + numParallelComposites;
+        String compositeKind = "__parallel__" + numParallelComposites;
                 
         // The new composite definition, represented in JSON
         JsonObject compositeDefinition = new JsonObject();


### PR DESCRIPTION
Users may now specify the composite name which prefixes operators in a parallel region. The default is now `parallel` instead of `paraComp`. Here we see a parallel region created with the name `CUSTOM`, and another with the default `parallel`.

```python
s = s.parallel(5, name="CUSTOM")
...
s = s.parallel(7)
...
```

![newname](https://user-images.githubusercontent.com/4752570/27925829-f96ec5a6-623a-11e7-9afe-8eb815037818.JPG)

fixes #1002 
