### PR TITLE
Add layout note and initial use with hidden.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -193,6 +193,7 @@ class _SPLInvocation(object):
 
         self.inputPorts = []
         self.outputPorts = []
+        self._layout = {}
 
     def addOutputPort(self, oWidth=None, name=None, inputPort=None, schema= CommonSchema.Python,partitioned_keys=None):
         if name is None:
@@ -284,6 +285,9 @@ class _SPLInvocation(object):
         if self.sl is not None:
            _op['sourcelocation'] = self.sl.spl_json()
 
+        if self._layout:
+            _op['layout'] = self._layout
+
         # Callout to allow a ExtensionOperator
         # to augment the JSON
         if hasattr(self, '_ex_op'):
@@ -330,6 +334,12 @@ class _SPLInvocation(object):
             colocate_id = '__spl_' + why + '_' + str(self.index)
             self._placement['explicitColocate'] = colocate_id
         other._placement['explicitColocate'] = colocate_id
+
+    def layout(self, hidden=None, kind=None):
+        if hidden:
+           self._layout['hidden'] = True
+        if kind:
+           self._layout['kind'] = str(kind)
 
     def _printOperator(self):
         print(self.name+":")

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -700,6 +700,7 @@ class Stream(object):
             if func is not None:
                 keys = ['__spl_hash']
                 hash_adder = self.topology.graph.addOperator(self.topology.opnamespace+"::HashAdder", func)
+                hash_adder.layout(hidden=True)
                 hash_schema = self.oport.schema.extend(StreamSchema("tuple<int64 __spl_hash>"))
                 hash_adder.addInputPort(outputPort=self.oport, name=self.name)
                 parallel_input = hash_adder.addOutputPort(schema=hash_schema)
@@ -711,6 +712,7 @@ class Stream(object):
             if func is not None:
                 # use the Functor passthru operator to remove the hash attribute by removing it from output port schema
                 hrop = self.topology.graph.addPassThruOperator()
+                hrop.layout(hidden=True)
                 hrop.addInputPort(outputPort=parallel_op_port)
                 parallel_op_port = hrop.addOutputPort(schema=self.oport.schema)
 

--- a/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
@@ -267,6 +267,14 @@ public class BOperatorInvocation extends BOperator {
 
         return input;
     }
+    
+    public JSONObject layout() {
+        JSONObject layout = (JSONObject) json().get("layout");
+        if (layout == null) {
+            json().put("layout", layout = new JSONObject());
+        }
+        return layout;
+    }
 
     @Override
     public JSONObject complete() {

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -77,22 +77,34 @@ class OperatorGenerator {
 
     private static void noteAnnotations(JsonObject op, StringBuilder sb) throws IOException {
 
+        layoutNote(op, sb);
         sourceLocationNote(op, sb);
         portTypesNote(op, sb);
     }
 
+    private static void layoutNote(JsonObject op, StringBuilder sb) {
+        JsonObject layout = object(op, "layout");
+        if (layout != null)
+            appendNoteAnnotation(sb, "__spl_layout", layout);
+    }
+
     private static void sourceLocationNote(JsonObject op, StringBuilder sb) throws IOException {
 
-        JsonArray ja = GsonUtilities.array(op, "sourcelocation");
+        JsonArray ja = array(op, "sourcelocation");
         if (ja == null)
             return;
 
         JsonElement jsource = ja.size() == 1 ? (JsonElement) ja.get(0) : ja;
 
-        sb.append("@spl_note(id=\"__spl_sourcelocation\"");
+        appendNoteAnnotation(sb, "__spl_sourcelocation", jsource);
+    }
+
+    private static void appendNoteAnnotation(StringBuilder sb, String type, Object textObject) {
+        sb.append("@spl_note(id=\"");
+        sb.append(type);
+        sb.append("\"");
         sb.append(", text=");
-        String sourceInfo = jsource.toString();
-        SPLGenerator.stringLiteral(sb, sourceInfo);
+        SPLGenerator.stringLiteral(sb, textObject.toString());
         sb.append(")\n");
     }
 
@@ -104,10 +116,7 @@ class OperatorGenerator {
             String type = GsonUtilities.jstring(output, "type.native");
             if (type == null || type.isEmpty())
                 return;
-            sb.append("@spl_note(id=\"__spl_nativeType_output_" + id[0]++ + "\"");
-            sb.append(", text=");
-            SPLGenerator.stringLiteral(sb, type);
-            sb.append(")\n");
+            appendNoteAnnotation(sb, "__spl_nativeType_output_" + id[0]++, type);
         });
     }
 

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -645,8 +645,12 @@ public class SPLGenerator {
         return sb.toString();
     }
 
+    /**
+     * Use single quotes for strings to allow clearer
+     * representation of JSON objects.
+     */
     static void stringLiteral(StringBuilder sb, String value) {
-        sb.append('"');
+        sb.append("'");
 
         // Replace any backslash with an escaped version
         // to stop SPL treating the value as an escape leadin
@@ -656,10 +660,10 @@ public class SPLGenerator {
         // which is \\n as a Java string literal
         value = value.replace("\n", "\\n");
 
-        value = value.replace("\"", "\\\"");
+        value = value.replace("'", "\\'");
 
         sb.append(value);
-        sb.append('"');
+        sb.append("'");
     }
 
     /**

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -490,6 +490,7 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
             BOperatorInvocation hashAdder = JavaFunctional.addFunctionalOperator(this,
                     "HashAdder",
                     HashAdder.class, hasher);
+            hashAdder.layout().put("hidden", true);
             // hashAdder.json().put("routing", routing.toString());
             BInputPort ip = connectTo(hashAdder, true, null);
 
@@ -510,6 +511,7 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
                     parallelOutput, getTupleType());
             BOperatorInvocation hashRemover = builder().addOperator(
                     HashRemover.class, null);
+            hashRemover.layout().put("hidden", true);
             BInputPort pip = parallelStream.connectTo(hashRemover, true, null);
             parallelOutput = hashRemover.addOutput(pip.port().getStreamSchema()
                     .remove("__spl_hash"));


### PR DESCRIPTION
Adds an optional layout object to the JSON graph for an operator and indicates the hash adder/remover operators should be hidden for Java & Python.