### PR TITLE
Initial use of remote build service for Java.

### DIFF
--- a/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
+++ b/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
@@ -77,8 +77,15 @@ public class GraphBuilder extends BJSONObject {
         json().put("parameters", params);
         
         // The version of IBM Streams being used to build
-        // the topology
-        config.put(CFG_STREAMS_VERSION, Product.getVersion().toString());
+        // the topology. When Streams install is not
+        // set we assume we are building against the
+        // Streaming Analytics service.
+        final String pv;
+        if (System.getenv("STREAMS_INSTALL") != null)
+            pv = Product.getVersion().toString();
+        else
+            pv = "4.2.1";
+        config.put(CFG_STREAMS_VERSION, pv);
     }
 
    public BOperatorInvocation addOperator(Class<? extends Operator> opClass,

--- a/java/src/com/ibm/streamsx/topology/context/StreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/context/StreamsContext.java
@@ -197,8 +197,20 @@ public interface StreamsContext<T> {
          * streams, sub-topologies, and, SPL primitive operators and composites.
          */
         DISTRIBUTED_TESTER,
+              
+        /**
+         * The topology is submitted to a Streams instance running
+         * in Streaming Analytics service on
+         * <a href="http://www.ibm.com/Bluemix‎" target="_blank">IBM Bluemix</a>
+         * cloud platform.
+         * 
+         * <P>
+         * This is a synonym for {@link #STREAMING_ANALYTICS_SERVICE}.
+         * </P>
+         */
+        ANALYTICS_SERVICE,
         
-        
+
         /**
          * The topology is submitted to a Streams instance running
          * in Streaming Analytics service on
@@ -222,18 +234,6 @@ public interface StreamsContext<T> {
          * This takes precedence over the environment variable.</LI>
          * <LI>Using the environment variable {@code VCAP_SERVICES}</LI>
          * </UL>
-         * </P>
-         */
-        ANALYTICS_SERVICE,
-        
-        /**
-         * The topology is submitted to a Streams instance running
-         * in Streaming Analytics service on
-         * <a href="http://www.ibm.com/Bluemix‎" target="_blank">IBM Bluemix</a>
-         * cloud platform.
-         * 
-         * <P>
-         * This is a synonym for {@link #ANALYTICS_SERVICE}.
          * </P>
          */
         STREAMING_ANALYTICS_SERVICE,

--- a/java/src/com/ibm/streamsx/topology/context/StreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/context/StreamsContext.java
@@ -75,7 +75,7 @@ public interface StreamsContext<T> {
          * <LI> Streaming Analytics REST API </LI>
          * </UL>
          * <BR>
-         * The {@link #ANALYTICS_SERVICE} context submits a topology directly to a
+         * The {@link #STREAMING_ANALYTICS_SERVICE} context submits a topology directly to a
          * Streaming Analytics service.
          * </P>
          * <P>
@@ -201,7 +201,7 @@ public interface StreamsContext<T> {
         /**
          * The topology is submitted to a Streams instance running
          * in Streaming Analytics service on
-         * <a href="http://www.ibm.com/Bluemix‎" target="_blank">IBM Bluemix</a>
+         * <a href="http://www.ibm.com/Bluemix" target="_blank">IBM Bluemix</a>
          * cloud platform.
          * 
          * <P>
@@ -214,7 +214,7 @@ public interface StreamsContext<T> {
         /**
          * The topology is submitted to a Streams instance running
          * in Streaming Analytics service on
-         * <a href="http://www.ibm.com/Bluemix‎" target="_blank">IBM Bluemix</a>
+         * <a href="http://www.ibm.com/Bluemix" target="_blank">IBM Bluemix</a>
          * cloud platform.
          * <P>
          * The returned type for the {@code submit} calls is

--- a/java/src/com/ibm/streamsx/topology/context/StreamsContextFactory.java
+++ b/java/src/com/ibm/streamsx/topology/context/StreamsContextFactory.java
@@ -11,6 +11,7 @@ import com.ibm.streamsx.topology.internal.context.DistributedStreamsContext;
 import com.ibm.streamsx.topology.internal.context.DistributedTester;
 import com.ibm.streamsx.topology.internal.context.EmbeddedStreamsContext;
 import com.ibm.streamsx.topology.internal.context.EmbeddedTester;
+import com.ibm.streamsx.topology.internal.context.RemoteStreamingAnalyticsServiceStreamsContext;
 import com.ibm.streamsx.topology.internal.context.StandaloneStreamsContext;
 import com.ibm.streamsx.topology.internal.context.StandaloneTester;
 import com.ibm.streamsx.topology.internal.context.ToolkitStreamsContext;
@@ -83,8 +84,12 @@ public class StreamsContextFactory {
             return new EmbeddedTester();
         case DISTRIBUTED_TESTER:
             return new DistributedTester();
-        case ANALYTICS_SERVICE:
+        
         case STREAMING_ANALYTICS_SERVICE:
+            if (System.getenv("STREAMS_INSTALL") == null)
+                return new RemoteStreamingAnalyticsServiceStreamsContext();
+            // fallthrough
+        case ANALYTICS_SERVICE:
             return new AnalyticsServiceStreamsContext(type);
         default:
             throw new IllegalArgumentException("Unknown type:" + type);

--- a/java/src/com/ibm/streamsx/topology/context/StreamsContextFactory.java
+++ b/java/src/com/ibm/streamsx/topology/context/StreamsContextFactory.java
@@ -85,11 +85,10 @@ public class StreamsContextFactory {
         case DISTRIBUTED_TESTER:
             return new DistributedTester();
         
+        case ANALYTICS_SERVICE:
         case STREAMING_ANALYTICS_SERVICE:
             if (System.getenv("STREAMS_INSTALL") == null)
                 return new RemoteStreamingAnalyticsServiceStreamsContext();
-            // fallthrough
-        case ANALYTICS_SERVICE:
             return new AnalyticsServiceStreamsContext(type);
         default:
             throw new IllegalArgumentException("Unknown type:" + type);

--- a/java/src/com/ibm/streamsx/topology/internal/context/RemoteStreamingAnalyticsServiceStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/RemoteStreamingAnalyticsServiceStreamsContext.java
@@ -1,0 +1,51 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.context;
+
+import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
+import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.object;
+
+import java.math.BigInteger;
+import java.util.concurrent.Future;
+
+import com.google.gson.JsonObject;
+import com.ibm.streamsx.topology.context.StreamsContext;
+import com.ibm.streamsx.topology.context.remote.RemoteContext;
+import com.ibm.streamsx.topology.internal.context.remote.RemoteBuildAndSubmitRemoteContext;
+import com.ibm.streamsx.topology.internal.process.CompletedFuture;
+
+/**
+ * Context that submits the SPL to the Streaming Analytics service
+ * for a remote build.
+ * 
+ * This delegates to the true remote context: RemoteBuildAndSubmitRemoteContext.
+ */
+public class RemoteStreamingAnalyticsServiceStreamsContext extends JSONStreamsContext<BigInteger> {
+    
+    private final RemoteBuildAndSubmitRemoteContext remoteContext;
+    
+    public RemoteStreamingAnalyticsServiceStreamsContext() {
+        remoteContext = new RemoteBuildAndSubmitRemoteContext();
+    }
+
+    @Override
+    public com.ibm.streamsx.topology.context.StreamsContext.Type getType() {
+        return StreamsContext.Type.STREAMING_ANALYTICS_SERVICE;
+    }
+
+    @Override
+    Future<BigInteger> action(com.ibm.streamsx.topology.internal.context.JSONStreamsContext.AppEntity entity) throws Exception {
+        remoteContext.submit(entity.submission).get();
+        
+        JsonObject results = object(entity.submission, RemoteContext.SUBMISSION_RESULTS);
+        if (results != null) {
+            String jobId = jstring(results, "jobId");
+            if (jobId != null)
+                return new CompletedFuture<>(new BigInteger(jobId));
+        }
+        
+        throw new IllegalStateException("Job submission failed!");
+    }
+}


### PR DESCRIPTION
If `$STREAMS_INSTALL` environment variable is not set when submitting to `STREAMING_ANALYTICS_SERVICE` then the application is compiled using the remote build service.

The `forceRemoteBuild` is not yet supported.

The classpath must still contain the required jar from `$STREAMS_INSTALL`.

See #1137