### PR TITLE
Refactoring of Java testing.

### DIFF
--- a/java/src/com/ibm/streamsx/topology/Topology.java
+++ b/java/src/com/ibm/streamsx/topology/Topology.java
@@ -49,7 +49,7 @@ import com.ibm.streamsx.topology.internal.logic.LimitedSupplier;
 import com.ibm.streamsx.topology.internal.logic.LogicUtils;
 import com.ibm.streamsx.topology.internal.logic.SingleToIterableSupplier;
 import com.ibm.streamsx.topology.internal.spljava.Schemas;
-import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
 import com.ibm.streamsx.topology.json.JSONSchemas;
 import com.ibm.streamsx.topology.spl.SPL;
 import com.ibm.streamsx.topology.spl.SPLStream;
@@ -103,7 +103,7 @@ public class Topology implements TopologyElement {
     /**
      * Optional tester of the topology.
      */
-    private TupleCollection tester;
+    private ConditionTesterImpl tester;
 
     
     /**
@@ -740,7 +740,7 @@ public class Topology implements TopologyElement {
      */
     public Tester getTester() {
         if (tester == null)
-            tester = new TupleCollection(this);
+            tester = new ConditionTesterImpl(this);
 
         return tester;
     }

--- a/java/src/com/ibm/streamsx/topology/internal/context/BundleUserStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/BundleUserStreamsContext.java
@@ -28,7 +28,7 @@ abstract class BundleUserStreamsContext<T> extends JSONStreamsContext<T> {
         Future<T> future = invoke(entity, bundle);       
         return postInvoke(entity, bundle, future);
     }
-    void preInvoke(AppEntity entity, File bundle) {      
+    void preInvoke(AppEntity entity, File bundle) throws Exception {      
     }
     
     abstract Future<T> invoke(AppEntity entity, File bundle) throws Exception;

--- a/java/src/com/ibm/streamsx/topology/internal/context/DistributedTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/DistributedTester.java
@@ -33,11 +33,11 @@ public class DistributedTester extends DistributedStreamsContext {
     
 
     @Override
-    void preInvoke(AppEntity entity, File bundle) {
+    void preInvoke(AppEntity entity, File bundle) throws Exception {
         Topology app = entity.app;
         if (app != null && app.hasTester()) {
             TesterRuntime trt = ((TupleCollection) app.getTester()).getRuntime();
-            trt.start();
+            trt.start(null);
         }
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/context/DistributedTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/DistributedTester.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Future;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.internal.tester.DistributedTesterContextFuture;
 import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
-import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
 
 public class DistributedTester extends DistributedStreamsContext {
 
@@ -27,7 +27,7 @@ public class DistributedTester extends DistributedStreamsContext {
         if (app == null)
             return future;
         return new DistributedTesterContextFuture(future.get(),
-                ((TupleCollection) (app.getTester())).getRuntime());
+                ((ConditionTesterImpl) (app.getTester())).getRuntime());
     }
     
     
@@ -36,7 +36,7 @@ public class DistributedTester extends DistributedStreamsContext {
     void preInvoke(AppEntity entity, File bundle) throws Exception {
         Topology app = entity.app;
         if (app != null && app.hasTester()) {
-            TesterRuntime trt = ((TupleCollection) app.getTester()).getRuntime();
+            TesterRuntime trt = ((ConditionTesterImpl) app.getTester()).getRuntime();
             trt.start(null);
         }
     }

--- a/java/src/com/ibm/streamsx/topology/internal/context/EmbeddedTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/EmbeddedTester.java
@@ -11,7 +11,7 @@ import com.ibm.streams.flow.javaprimitives.JavaOperatorTester;
 import com.ibm.streams.flow.javaprimitives.JavaTestableGraph;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.internal.functional.ops.SubmissionParameterManager;
-import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
 
 public class EmbeddedTester extends StreamsContextImpl<JavaTestableGraph> {
 
@@ -28,7 +28,7 @@ public class EmbeddedTester extends StreamsContextImpl<JavaTestableGraph> {
 
         app.builder().checkSupportsEmbeddedMode();
         
-        TupleCollection tester = (TupleCollection) app.getTester();
+        ConditionTesterImpl tester = (ConditionTesterImpl) app.getTester();
         if (tester != null)
             tester.finalizeGraph(getType());
         

--- a/java/src/com/ibm/streamsx/topology/internal/context/EmbeddedTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/EmbeddedTester.java
@@ -28,13 +28,16 @@ public class EmbeddedTester extends StreamsContextImpl<JavaTestableGraph> {
 
         app.builder().checkSupportsEmbeddedMode();
         
+        TupleCollection tester = (TupleCollection) app.getTester();
+        if (tester != null)
+            tester.finalizeGraph(getType());
+        
         SubmissionParameterManager.initializeEmbedded(app.builder(), config);
         
         JavaTestableGraph tg = jot.executable(app.graph());
 
-        TupleCollection tester = (TupleCollection) app.getTester();
-        tester.setupEmbeddedTestHandlers(tg);
-
+        if (tester != null)
+            tester.getRuntime().start(tg);
         return tg.execute();
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/context/StandaloneTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/StandaloneTester.java
@@ -20,11 +20,11 @@ public class StandaloneTester extends StandaloneStreamsContext {
     }
     
     @Override
-    void preInvoke(AppEntity entity, File bundle) {
+    void preInvoke(AppEntity entity, File bundle) throws Exception {
         Topology app = entity.app;
         if (app != null && app.hasTester()) {
             TesterRuntime trt = ((TupleCollection) app.getTester()).getRuntime();
-            trt.start();
+            trt.start(null);
         }
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/context/StandaloneTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/StandaloneTester.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Future;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.internal.tester.StandaloneTesterContextFuture;
 import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
-import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
 
 public class StandaloneTester extends StandaloneStreamsContext {
 
@@ -23,7 +23,7 @@ public class StandaloneTester extends StandaloneStreamsContext {
     void preInvoke(AppEntity entity, File bundle) throws Exception {
         Topology app = entity.app;
         if (app != null && app.hasTester()) {
-            TesterRuntime trt = ((TupleCollection) app.getTester()).getRuntime();
+            TesterRuntime trt = ((ConditionTesterImpl) app.getTester()).getRuntime();
             trt.start(null);
         }
     }
@@ -34,6 +34,6 @@ public class StandaloneTester extends StandaloneStreamsContext {
         if (app == null)
             return future;
         return new StandaloneTesterContextFuture<Integer>(future,
-                ((TupleCollection) app.getTester()).getRuntime());
+                ((ConditionTesterImpl) app.getTester()).getRuntime());
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
@@ -19,13 +19,13 @@ import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
  *
  */
 public abstract class TesterRuntime {
-    private final TupleCollection tester;
+    private final ConditionTesterImpl tester;
     
-    protected TesterRuntime(TupleCollection tester) {
+    protected TesterRuntime(ConditionTesterImpl tester) {
         this.tester = tester;
     }
     
-    protected TupleCollection tester() {
+    protected ConditionTesterImpl tester() {
         return tester;
     }
     

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
@@ -33,10 +33,10 @@ public abstract class TesterRuntime {
         return tester().getTopology();
     }
     
-    public abstract void start();
+    public abstract void start(Object info) throws Exception;
 
     public abstract void shutdown() throws Exception;
     
     public abstract void finalizeTester(Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers,
-            Map<TStream<?>, Set<UserCondition<?>>> condition) throws Exception;  
+            Map<TStream<?>, Set<UserCondition<?>>> conditions) throws Exception;  
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
@@ -11,6 +11,7 @@ import com.ibm.streams.flow.handlers.StreamHandler;
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
 
 /**
  * Separation of the runtime aspects of a
@@ -36,5 +37,6 @@ public abstract class TesterRuntime {
 
     public abstract void shutdown() throws Exception;
     
-    public abstract void finalizeTester(Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers) throws Exception;  
+    public abstract void finalizeTester(Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers,
+            Map<TStream<?>, Set<UserCondition<?>>> condition) throws Exception;  
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TupleCollection.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TupleCollection.java
@@ -78,7 +78,7 @@ public class TupleCollection implements Tester {
 
         streamHandlers.add(handler);
     }
-    private void addCondition(TStream<?> stream, UserCondition<?> condition) {
+    private <T> Condition<T> addCondition(TStream<?> stream, UserCondition<T> condition) {
         Set<UserCondition<?>> streamConditions = conditions.get(stream);
         if (streamConditions == null) {
             streamConditions = new HashSet<>();
@@ -86,6 +86,7 @@ public class TupleCollection implements Tester {
         }
 
         streamConditions.add(condition);
+        return condition;
     }
 
     @Override
@@ -103,70 +104,12 @@ public class TupleCollection implements Tester {
     @Override
     public Condition<Long> tupleCount(TStream<?> stream, final long expectedCount) {
         
-        CounterUserCondition userCondition = new CounterUserCondition(expectedCount, true);
-        
-        addCondition(stream, userCondition);
-        
-        return userCondition;
-        
-        /*
-        final StreamCounter<Tuple> counter = new StreamCounter<Tuple>();
-
-        addHandler(stream, counter);
-
-        return new Condition<Long>() {
-            
-            @Override
-            public Long getResult() {
-                return counter.getTupleCount();
-            }
-
-            @Override
-            public boolean valid() {
-                return counter.getTupleCount() == expectedCount;
-            }
-
-            @Override
-            public String toString() {
-                return "Expected tuple count: " + expectedCount
-                        + " != received: " + counter.getTupleCount();
-            }
-        };
-        */
+        return addCondition(stream, new CounterUserCondition(expectedCount, true));
     }
   
     @Override
-    public Condition<Long> atLeastTupleCount(TStream<?> stream, final long expectedCount) {
-        
-        CounterUserCondition userCondition = new CounterUserCondition(expectedCount, false);
-        
-        addCondition(stream, userCondition);
-        
-        return userCondition;
-        /*
-        final StreamCounter<Tuple> counter = new StreamCounter<Tuple>();
-
-        addHandler(stream, counter);
-
-        return new Condition<Long>() {
-            
-            @Override
-            public Long getResult() {
-                return counter.getTupleCount();
-            }
-
-            @Override
-            public boolean valid() {
-                return counter.getTupleCount() >= expectedCount;
-            }
-
-            @Override
-            public String toString() {
-                return "At least tuple count: " + expectedCount
-                        + ", received: " + counter.getTupleCount();
-            }
-        };
-        */
+    public Condition<Long> atLeastTupleCount(TStream<?> stream, final long expectedCount) {       
+        return addCondition(stream, new CounterUserCondition(expectedCount, false));
     }
     
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/ContentsUserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/ContentsUserCondition.java
@@ -24,4 +24,8 @@ public final class ContentsUserCondition<T> extends UserCondition<List<T>> {
     public List<T> getExpected() {
         return expected;
     }
+    @Override
+    public String toString() {
+        return "Received Tuples: " + getResult();
+    }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/ContentsUserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/ContentsUserCondition.java
@@ -9,15 +9,20 @@ import java.util.List;
 
 public final class ContentsUserCondition<T> extends UserCondition<List<T>> {
     
+    private final Class<T> clazz;
     private final List<T> expected;
     private final boolean ordered;
     
-    public ContentsUserCondition(List<T> expected, boolean ordered) {
+    public ContentsUserCondition(Class<T> clazz, List<T> expected, boolean ordered) {
         super(Collections.emptyList());
+        this.clazz = clazz;
         this.expected = expected;
         this.ordered = ordered;
     }
     
+    public Class<T> getTupleClass() {
+        return clazz;
+    }
     public boolean isOrdered() {
         return ordered;
     }
@@ -28,4 +33,6 @@ public final class ContentsUserCondition<T> extends UserCondition<List<T>> {
     public String toString() {
         return "Received Tuples: " + getResult();
     }
+    
+    
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/ContentsUserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/ContentsUserCondition.java
@@ -1,0 +1,27 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.tester.conditions;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class ContentsUserCondition<T> extends UserCondition<List<T>> {
+    
+    private final List<T> expected;
+    private final boolean ordered;
+    
+    public ContentsUserCondition(List<T> expected, boolean ordered) {
+        super(Collections.emptyList());
+        this.expected = expected;
+        this.ordered = ordered;
+    }
+    
+    public boolean isOrdered() {
+        return ordered;
+    }
+    public List<T> getExpected() {
+        return expected;
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/CounterUserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/CounterUserCondition.java
@@ -1,0 +1,30 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.tester.conditions;
+
+public final class CounterUserCondition extends UserCondition<Long> {
+    
+    private final long expected;
+    private final boolean exact;
+    
+    public CounterUserCondition(long expected, boolean exact) {
+        super(-1L);
+        this.expected = expected;
+        this.exact = exact;
+    }
+    
+    public long getExpected() {
+        return expected;
+    }
+    public boolean isExact() {
+        return exact;
+    }
+    
+    @Override
+    public String toString() {
+        return "Tuple count (exact=" + isExact() + "): " + getExpected()
+                + ", received: " + getResult();
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/UserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/UserCondition.java
@@ -1,0 +1,52 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.tester.conditions;
+
+import com.ibm.streamsx.topology.tester.Condition;
+
+/**
+ * Condition that gets returned to the caller.
+ * 
+ * Under the covers it delegates to a implementation 
+ * condition that is created once the job under test is submitted.
+ */
+public class UserCondition<R> implements Condition<R> {
+    
+    private Condition<R> impl;
+    private final R noResult;
+    
+    UserCondition(R noResult) {
+        this.noResult = noResult;
+    }
+    
+    public synchronized final void setImpl(Condition<R> impl) {
+        this.impl = impl;
+    }
+    
+    private synchronized Condition<R> getImpl() {
+        return impl;
+    }
+
+    @Override
+    public final boolean valid() {
+        if (getImpl()  == null)
+            return false;
+        return getImpl().valid();
+    }
+
+    @Override
+    public final R getResult() {
+        if (getImpl() == null)
+            return noResult;
+        return getImpl().getResult();
+    }
+    
+    @Override
+    public String toString() {
+        if (getImpl() != null)
+            return getImpl().toString();
+        return super.toString();
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/UserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/UserCondition.java
@@ -44,7 +44,7 @@ public abstract class UserCondition<R> implements Condition<R> {
     }
     
     @Override
-    public final String toString() {
+    public String toString() {
         if (getImpl() != null)
             return getImpl().toString();
         return super.toString();

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/UserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/UserCondition.java
@@ -12,7 +12,7 @@ import com.ibm.streamsx.topology.tester.Condition;
  * Under the covers it delegates to a implementation 
  * condition that is created once the job under test is submitted.
  */
-public class UserCondition<R> implements Condition<R> {
+public abstract class UserCondition<R> implements Condition<R> {
     
     private Condition<R> impl;
     private final R noResult;
@@ -44,7 +44,7 @@ public class UserCondition<R> implements Condition<R> {
     }
     
     @Override
-    public String toString() {
+    public final String toString() {
         if (getImpl() != null)
             return getImpl().toString();
         return super.toString();

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/ContentsHandlerCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/ContentsHandlerCondition.java
@@ -1,0 +1,31 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.tester.conditions.handlers;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.ibm.streams.flow.handlers.StreamCollector;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserCondition;
+
+public class ContentsHandlerCondition extends HandlerCondition<List<Tuple>, StreamCollector<LinkedList<Tuple>, Tuple>, ContentsUserCondition<Tuple>> {
+    
+    public ContentsHandlerCondition(ContentsUserCondition<Tuple> userCondition) {
+        super(userCondition, StreamCollector.newLinkedListCollector());
+    }
+
+    @Override
+    public List<Tuple> getResult() {
+        return handler.getTuples();
+    }
+
+    @Override
+    public boolean valid() {
+        synchronized (handler) {
+            return handler.getTuples().equals(userCondition.getExpected());
+        }
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/CounterHandlerCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/CounterHandlerCondition.java
@@ -1,0 +1,29 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.tester.conditions.handlers;
+
+import com.ibm.streams.flow.handlers.StreamCounter;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streamsx.topology.internal.tester.conditions.CounterUserCondition;
+
+public class CounterHandlerCondition extends HandlerCondition<Long, StreamCounter<Tuple>, CounterUserCondition> {
+    
+    public CounterHandlerCondition(CounterUserCondition userCondition) {
+        super(userCondition, new StreamCounter<Tuple>());
+    }
+    
+    @Override
+    public Long getResult() {
+        return handler.getTupleCount();
+    }
+
+    @Override
+    public boolean valid() {
+        if (userCondition.isExact())
+            return handler.getTupleCount() == userCondition.getExpected();
+        
+        return handler.getTupleCount() >= userCondition.getExpected();
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
@@ -50,12 +50,15 @@ public abstract class HandlerCondition<R, H extends StreamHandler<Tuple>, U exte
         }
     }
     
+    @SuppressWarnings("unchecked")
     private static StreamHandler<Tuple> createHandler(UserCondition<?> userCondition) {
         
         HandlerCondition<?,?,?> handlerCondition;
         
         if (userCondition instanceof CounterUserCondition) {
             handlerCondition = new CounterHandlerCondition((CounterUserCondition) userCondition);           
+        } else if (userCondition instanceof ContentsUserCondition) {
+            handlerCondition = new ContentsHandlerCondition((ContentsUserCondition<Tuple>) userCondition); 
         }
         else
             throw new IllegalStateException();

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
@@ -33,36 +33,4 @@ public abstract class HandlerCondition<R, H extends StreamHandler<Tuple>, U exte
         this.userCondition = userCondition;
         userCondition.setImpl(this);
     }
-    
-    public static void setupHandlersFromConditions(
-            Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers,
-            Map<TStream<?>, Set<UserCondition<?>>> conditions) {
-        
-        for (TStream<?> stream : conditions.keySet()) {
-            Set<UserCondition<?>> streamConditions = conditions.get(stream);
-            
-            Set<StreamHandler<Tuple>> streamHandlers = handlers.get(stream);
-            if (streamHandlers == null)
-                handlers.put(stream, streamHandlers = new HashSet<>());
-            
-            for (UserCondition<?> userCondition : streamConditions)
-                streamHandlers.add(createHandler(userCondition));
-        }
-    }
-    
-    @SuppressWarnings("unchecked")
-    private static StreamHandler<Tuple> createHandler(UserCondition<?> userCondition) {
-        
-        HandlerCondition<?,?,?> handlerCondition;
-        
-        if (userCondition instanceof CounterUserCondition) {
-            handlerCondition = new CounterHandlerCondition((CounterUserCondition) userCondition);           
-        } else if (userCondition instanceof ContentsUserCondition) {
-            handlerCondition = new ContentsHandlerCondition((ContentsUserCondition<Tuple>) userCondition); 
-        }
-        else
-            throw new IllegalStateException();
-        
-        return handlerCondition.handler;
-    }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
@@ -1,0 +1,65 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.tester.conditions.handlers;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.ibm.streams.flow.handlers.StreamHandler;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserCondition;
+import com.ibm.streamsx.topology.internal.tester.conditions.CounterUserCondition;
+import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
+import com.ibm.streamsx.topology.tester.Condition;
+
+/**
+ * Condition implementation that uses a StreamHandler.
+ *
+ * @param <R> Return type of condition.
+ * @param <H> StreamHandler type
+ * @param <U> UserCondition type
+ */
+public abstract class HandlerCondition<R, H extends StreamHandler<Tuple>, U extends UserCondition<R>> implements Condition<R> {
+    
+    final U userCondition;
+    final H handler;
+    
+    HandlerCondition(U userCondition, H handler) {
+        this.handler = handler;
+        this.userCondition = userCondition;
+        userCondition.setImpl(this);
+    }
+    
+    public static void setupHandlersFromConditions(
+            Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers,
+            Map<TStream<?>, Set<UserCondition<?>>> conditions) {
+        
+        for (TStream<?> stream : conditions.keySet()) {
+            Set<UserCondition<?>> streamConditions = conditions.get(stream);
+            
+            Set<StreamHandler<Tuple>> streamHandlers = handlers.get(stream);
+            if (streamHandlers == null)
+                handlers.put(stream, streamHandlers = new HashSet<>());
+            
+            for (UserCondition<?> userCondition : streamConditions)
+                streamHandlers.add(createHandler(userCondition));
+        }
+    }
+    
+    private static StreamHandler<Tuple> createHandler(UserCondition<?> userCondition) {
+        
+        HandlerCondition<?,?,?> handlerCondition;
+        
+        if (userCondition instanceof CounterUserCondition) {
+            handlerCondition = new CounterHandlerCondition((CounterUserCondition) userCondition);           
+        }
+        else
+            throw new IllegalStateException();
+        
+        return handlerCondition.handler;
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
@@ -4,15 +4,8 @@
  */
 package com.ibm.streamsx.topology.internal.tester.conditions.handlers;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import com.ibm.streams.flow.handlers.StreamHandler;
 import com.ibm.streams.operator.Tuple;
-import com.ibm.streamsx.topology.TStream;
-import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserCondition;
-import com.ibm.streamsx.topology.internal.tester.conditions.CounterUserCondition;
 import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
 import com.ibm.streamsx.topology.tester.Condition;
 

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerTesterRuntime.java
@@ -1,0 +1,74 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.tester.conditions.handlers;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.ibm.streams.flow.handlers.StreamHandler;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
+import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserCondition;
+import com.ibm.streamsx.topology.internal.tester.conditions.CounterUserCondition;
+import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
+import com.ibm.streamsx.topology.tester.Condition;
+
+/**
+ * Tester runtime that uses handlers to validate conditions.
+ */
+public abstract class HandlerTesterRuntime extends TesterRuntime {
+    
+    protected Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers = new HashMap<>();
+
+
+    
+    protected HandlerTesterRuntime(TupleCollection tester) {
+        super(tester);
+    }
+    
+    @Override
+    public void finalizeTester(Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers,
+            Map<TStream<?>, Set<UserCondition<?>>> conditions) throws Exception {
+        this.handlers.putAll(handlers);
+        
+        setupHandlersFromConditions(this.handlers, conditions);
+    }
+
+    private static void setupHandlersFromConditions(
+            Map<TStream<?>, Set<StreamHandler<Tuple>>> handlers,
+            Map<TStream<?>, Set<UserCondition<?>>> conditions) {
+        
+        for (TStream<?> stream : conditions.keySet()) {
+            Set<UserCondition<?>> streamConditions = conditions.get(stream);
+            
+            Set<StreamHandler<Tuple>> streamHandlers = handlers.get(stream);
+            if (streamHandlers == null)
+                handlers.put(stream, streamHandlers = new HashSet<>());
+            
+            for (UserCondition<?> userCondition : streamConditions)
+                streamHandlers.add(createHandler(userCondition));
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    private static StreamHandler<Tuple> createHandler(UserCondition<?> userCondition) {
+        
+        HandlerCondition<?,?,?> handlerCondition;
+        
+        if (userCondition instanceof CounterUserCondition) {
+            handlerCondition = new CounterHandlerCondition((CounterUserCondition) userCondition);           
+        } else if (userCondition instanceof ContentsUserCondition) {
+            handlerCondition = new ContentsHandlerCondition((ContentsUserCondition<Tuple>) userCondition); 
+        }
+        else
+            throw new IllegalStateException();
+        
+        return handlerCondition.handler;
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerTesterRuntime.java
@@ -17,7 +17,6 @@ import com.ibm.streamsx.topology.internal.tester.TupleCollection;
 import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserCondition;
 import com.ibm.streamsx.topology.internal.tester.conditions.CounterUserCondition;
 import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
-import com.ibm.streamsx.topology.tester.Condition;
 
 /**
  * Tester runtime that uses handlers to validate conditions.
@@ -59,14 +58,19 @@ public abstract class HandlerTesterRuntime extends TesterRuntime {
     @SuppressWarnings("unchecked")
     private static StreamHandler<Tuple> createHandler(UserCondition<?> userCondition) {
         
-        HandlerCondition<?,?,?> handlerCondition;
+        HandlerCondition<?,?,?> handlerCondition = null;
         
         if (userCondition instanceof CounterUserCondition) {
             handlerCondition = new CounterHandlerCondition((CounterUserCondition) userCondition);           
         } else if (userCondition instanceof ContentsUserCondition) {
-            handlerCondition = new ContentsHandlerCondition((ContentsUserCondition<Tuple>) userCondition); 
+            ContentsUserCondition<?> uc = (ContentsUserCondition<?>) userCondition;
+            if (uc.getTupleClass().equals(Tuple.class))
+                handlerCondition = new ContentsHandlerCondition((ContentsUserCondition<Tuple>) userCondition);
+            else if (uc.getTupleClass().equals(String.class))
+                handlerCondition = new StringHandlerCondition((ContentsUserCondition<String>) userCondition);
         }
-        else
+        
+        if (handlerCondition == null)
             throw new IllegalStateException();
         
         return handlerCondition.handler;

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerTesterRuntime.java
@@ -13,7 +13,7 @@ import com.ibm.streams.flow.handlers.StreamHandler;
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
-import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
 import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserCondition;
 import com.ibm.streamsx.topology.internal.tester.conditions.CounterUserCondition;
 import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
@@ -27,7 +27,7 @@ public abstract class HandlerTesterRuntime extends TesterRuntime {
 
 
     
-    protected HandlerTesterRuntime(TupleCollection tester) {
+    protected HandlerTesterRuntime(ConditionTesterImpl tester) {
         super(tester);
     }
     

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/StringHandlerCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/StringHandlerCondition.java
@@ -1,0 +1,54 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.internal.tester.conditions.handlers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.ibm.streams.flow.handlers.StreamCollector;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserCondition;
+
+public class StringHandlerCondition extends HandlerCondition<List<String>, StreamCollector<LinkedList<Tuple>, Tuple>, ContentsUserCondition<String>> {
+    
+    public StringHandlerCondition(ContentsUserCondition<String> userCondition) {
+        super(userCondition, StreamCollector.newLinkedListCollector());
+    }
+
+    @Override
+    public List<String> getResult() {
+        List<String> strings = new ArrayList<>(handler.getTupleCount());
+        synchronized (handler.getTuples()) {
+            for (Tuple tuple : handler.getTuples()) {
+                strings.add(tuple.getString(0));
+            }
+        }
+        return strings;
+    }
+
+    @Override
+    public boolean valid() {
+        List<String> expected = userCondition.getExpected();
+        if (expected.size() != handler.getTupleCount())
+            return false;
+
+        List<String> got = getResult();
+        if (expected.size() != got.size())
+            return false;
+        
+        if (userCondition.isOrdered())
+            return expected.equals(got);
+        
+        // don't modify the original expected.
+        expected = new ArrayList<>(expected);
+        
+        Collections.sort(expected);
+        Collections.sort(got);
+        
+        return expected.equals(got);
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/embedded/EmbeddedTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/embedded/EmbeddedTesterRuntime.java
@@ -13,7 +13,7 @@ import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.builder.BOutput;
 import com.ibm.streamsx.topology.builder.BOutputPort;
-import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
 import com.ibm.streamsx.topology.internal.tester.conditions.handlers.HandlerTesterRuntime;
 
 /**
@@ -24,7 +24,7 @@ import com.ibm.streamsx.topology.internal.tester.conditions.handlers.HandlerTest
  */
 public class EmbeddedTesterRuntime extends HandlerTesterRuntime {
     
-    public EmbeddedTesterRuntime(TupleCollection tester) {
+    public EmbeddedTesterRuntime(ConditionTesterImpl tester) {
         super(tester);
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/tester/embedded/EmbeddedTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/embedded/EmbeddedTesterRuntime.java
@@ -1,0 +1,61 @@
+package com.ibm.streamsx.topology.internal.tester.embedded;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.ibm.streams.flow.declare.OutputPortDeclaration;
+import com.ibm.streams.flow.handlers.StreamHandler;
+import com.ibm.streams.flow.javaprimitives.JavaTestableGraph;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.builder.BOutput;
+import com.ibm.streamsx.topology.builder.BOutputPort;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
+import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
+import com.ibm.streamsx.topology.internal.tester.conditions.handlers.HandlerCondition;
+import com.ibm.streamsx.topology.internal.tester.conditions.handlers.HandlerTesterRuntime;
+
+/**
+ * Embedded tester that takes the conditions and
+ * adds corresponding handlers directly into the
+ * application graph.
+ *
+ */
+public class EmbeddedTesterRuntime extends HandlerTesterRuntime {
+    
+    public EmbeddedTesterRuntime(TupleCollection tester) {
+        super(tester);
+    }
+
+    @Override
+    public void start(Object info) throws Exception {
+        JavaTestableGraph tg = (JavaTestableGraph) info;
+        setupEmbeddedTestHandlers(tg);
+    }
+
+    @Override
+    public void shutdown() throws Exception {
+    }
+    
+    private void setupEmbeddedTestHandlers(JavaTestableGraph tg) throws Exception {
+
+        for (TStream<?> stream : handlers.keySet()) {
+            Set<StreamHandler<Tuple>> streamHandlers = handlers.get(stream);
+
+            final BOutput output = stream.output();
+            if (output instanceof BOutputPort) {
+                final BOutputPort outputPort = (BOutputPort) output;
+                final OutputPortDeclaration portDecl = outputPort.port();
+                for (StreamHandler<Tuple> streamHandler : streamHandlers) {
+                    tg.registerStreamHandler(portDecl, streamHandler);
+                }
+            }
+        }
+    }
+
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/embedded/EmbeddedTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/embedded/EmbeddedTesterRuntime.java
@@ -1,10 +1,9 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
 package com.ibm.streamsx.topology.internal.tester.embedded;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import com.ibm.streams.flow.declare.OutputPortDeclaration;
@@ -14,10 +13,7 @@ import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.builder.BOutput;
 import com.ibm.streamsx.topology.builder.BOutputPort;
-import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
 import com.ibm.streamsx.topology.internal.tester.TupleCollection;
-import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
-import com.ibm.streamsx.topology.internal.tester.conditions.handlers.HandlerCondition;
 import com.ibm.streamsx.topology.internal.tester.conditions.handlers.HandlerTesterRuntime;
 
 /**

--- a/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTesterRuntime.java
@@ -30,13 +30,18 @@ import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.builder.BInputPort;
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.internal.tester.TestTupleInjector;
-import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
-import com.ibm.streamsx.topology.internal.tester.TupleCollection;
+import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
 import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
-import com.ibm.streamsx.topology.internal.tester.conditions.handlers.HandlerCondition;
 import com.ibm.streamsx.topology.internal.tester.conditions.handlers.HandlerTesterRuntime;
 import com.ibm.streamsx.topology.internal.tester.ops.TesterSink;
 
+/**
+ * Create a local graph that will collect tuples from the tcp server and connect
+ * them to the handlers using this local operator graph, hence reusing the
+ * existing infrastructure. The graph will contain a single pass-through
+ * operator for any stream under test, the TCP server will inject tuples into
+ * the operator and the handlers are connected to the output.
+ */
 public class TCPTesterRuntime extends HandlerTesterRuntime {
     
     private OperatorGraph collectorGraph;
@@ -50,7 +55,7 @@ public class TCPTesterRuntime extends HandlerTesterRuntime {
             .synchronizedMap(new HashMap<Integer, TestTupleInjector>());
 
 
-    public TCPTesterRuntime(TupleCollection tester) {
+    public TCPTesterRuntime(ConditionTesterImpl tester) {
         super(tester);
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/tcp/TCPTesterRuntime.java
@@ -92,7 +92,7 @@ public class TCPTesterRuntime extends TesterRuntime {
     }
     
     @Override
-    public void start() {
+    public void start(Object info) {
         assert this.localCollector != null;
         localRunningCollector = localCollector.execute();
     }   

--- a/java/src/com/ibm/streamsx/topology/tester/spl/ExpectedTuples.java
+++ b/java/src/com/ibm/streamsx/topology/tester/spl/ExpectedTuples.java
@@ -19,7 +19,7 @@ import com.ibm.streamsx.topology.tester.Tester;
  */
 public class ExpectedTuples {
     
-    private final Tuple[] EMPTY = new Tuple[0];
+    private final static Tuple[] EMPTY = new Tuple[0];
     
     private final StreamSchema schema;
     private final List<Tuple> tuples = new ArrayList<>();
@@ -41,7 +41,7 @@ public class ExpectedTuples {
     }
     
     /**
-     * Get the current of tuples. 
+     * Get the expected tuples. 
      * Modifying the returned list modifies
      * the expected tuples.
      *  

--- a/test/java/src/com/ibm/streamsx/topology/test/tester/ConditionTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/tester/ConditionTest.java
@@ -9,14 +9,23 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
+import com.ibm.streams.operator.StreamSchema;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streams.operator.types.RString;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.spl.SPLSchemas;
+import com.ibm.streamsx.topology.spl.SPLStream;
+import com.ibm.streamsx.topology.spl.SPLStreams;
 import com.ibm.streamsx.topology.test.TestTopology;
 import com.ibm.streamsx.topology.tester.Condition;
+import com.ibm.streamsx.topology.tester.spl.ExpectedTuples;
 
 public class ConditionTest extends TestTopology {
     @Test
@@ -67,9 +76,56 @@ public class ConditionTest extends TestTopology {
         Condition<Long> tupleCount = topology.getTester().atLeastTupleCount(source, 26);
 
         boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);
-        assertTrue(passed);
+        
 
         assertTrue(tupleCount.toString(), tupleCount.valid());
         assertTrue(tupleCount.toString(), tupleCount.getResult() >= 26);
+        assertTrue(passed);
     }
+    
+    @Test
+    public void testSPLContentsGood() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+        StreamSchema schema = SPLSchemas.STRING.extend("int32", "id");
+        SPLStream tested = SPLStreams.convertStream(source, (s,t) -> {t.setString(0, s); t.setInt(1, s.charAt(0)); return t;}, schema);
+        
+        
+        ExpectedTuples expected = new ExpectedTuples(schema);
+        int id = "A".charAt(0);
+        expected.addAsTuple(new RString("A"), id);
+        expected.addAsTuple(new RString("B"), ++id);
+        expected.addAsTuple(new RString("C"), ++id);
+        expected.addAsTuple(new RString("D"), ++id);
+
+        Condition<List<Tuple>> contents = expected.contents(tested);
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertTrue(contents.toString(), contents.valid());
+        assertTrue(passed);
+    }
+    
+    @Test
+    public void testSPLContentsBad() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+        StreamSchema schema = SPLSchemas.STRING.extend("int32", "id");
+        SPLStream tested = SPLStreams.convertStream(source, (s,t) -> {t.setString(0, s); t.setInt(1, s.charAt(0)); return t;}, schema);
+        
+        
+        ExpectedTuples expected = new ExpectedTuples(schema);
+        int id = "A".charAt(0);
+        expected.addAsTuple(new RString("A"), id);
+        expected.addAsTuple(new RString("B"), ++id);
+        expected.addAsTuple(new RString("C"), 1241241);
+        expected.addAsTuple(new RString("D"), ++id);
+
+        Condition<List<Tuple>> contents = expected.contents(tested);
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertFalse(passed);
+
+        assertFalse(contents.toString(), contents.valid());
+    }
+     
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/tester/ConditionTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/tester/ConditionTest.java
@@ -1,0 +1,75 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017  
+ */
+package com.ibm.streamsx.topology.test.tester;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.test.TestTopology;
+import com.ibm.streamsx.topology.tester.Condition;
+
+public class ConditionTest extends TestTopology {
+    @Test
+    public void testExactCountGood() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("hello", "goodbye", "farewell");
+
+        Condition<Long> tupleCount = topology.getTester().tupleCount(source, 3);
+
+        boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);
+        assertTrue(passed);
+
+        assertTrue(tupleCount.valid());
+        assertEquals(3L, (long) tupleCount.getResult());
+    }
+    
+    @Test
+    public void testExactCountBad1() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("hello", "goodbye", "farewell", "toomuch");
+
+        Condition<Long> tupleCount = topology.getTester().tupleCount(source, 3);
+
+        boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);
+        assertFalse(passed);      
+        assertFalse(tupleCount.valid());
+    }
+    
+    @Test
+    public void testExactCountBad2() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("hello", "goodbye");
+
+        Condition<Long> tupleCount = topology.getTester().tupleCount(source, 3);
+
+        boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);
+        assertFalse(passed);
+        assertFalse(tupleCount.valid());
+    }
+    
+    @Test
+    public void testAtLeastGood() throws Exception {
+        final Topology topology = new Topology();
+        String[] data = new String[32];
+        Arrays.fill(data, "A");
+        TStream<String> source = topology.strings(data);
+
+        Condition<Long> tupleCount = topology.getTester().atLeastTupleCount(source, 26);
+
+        boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);
+        assertTrue(passed);
+
+        assertTrue(tupleCount.toString(), tupleCount.valid());
+        assertTrue(tupleCount.toString(), tupleCount.getResult() >= 26);
+    }
+}

--- a/test/java/src/com/ibm/streamsx/topology/test/tester/ConditionTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/tester/ConditionTest.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.ibm.streams.operator.StreamSchema;
@@ -127,5 +126,94 @@ public class ConditionTest extends TestTopology {
 
         assertFalse(contents.toString(), contents.valid());
     }
-     
+    
+    @Test
+    public void testStringContentsGood() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+
+        Condition<List<String>> contents = topology.getTester().stringContents(source, "A", "B", "C", "D");
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertTrue(contents.toString(), contents.valid());
+        assertTrue(passed);
+    }
+    @Test
+    public void testStringContentsUnorderedGood() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+
+        Condition<List<String>> contents = topology.getTester().stringContentsUnordered(source, "C", "D", "A", "B");
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertTrue(contents.toString(), contents.valid());
+        assertTrue(passed);
+    }
+    @Test
+    public void testStringContentsBad() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+
+        Condition<List<String>> contents = topology.getTester().stringContents(source, "A", "X", "C", "D");
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertFalse(contents.toString(), contents.valid());
+        assertFalse(passed);
+    }
+    @Test
+    public void testStringContentsBad2() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+
+        Condition<List<String>> contents = topology.getTester().stringContents(source, "A", "X", "C", "D", "S");
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertFalse(contents.toString(), contents.valid());
+        assertFalse(passed);
+    }
+    @Test
+    public void testStringContentsBad3() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+
+        Condition<List<String>> contents = topology.getTester().stringContents(source, "A", "B", "C");
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertFalse(contents.toString(), contents.valid());
+        assertFalse(passed);
+    }
+    @Test
+    public void testStringContentsUnorderedBad() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+
+        Condition<List<String>> contents = topology.getTester().stringContentsUnordered(source, "C", "D", "A", "Y");
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertFalse(contents.toString(), contents.valid());
+        assertFalse(passed);
+    }
+    
+    @Test
+    public void testStringContentsUnorderedBad2() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+
+        Condition<List<String>> contents = topology.getTester().stringContentsUnordered(source, "C", "D", "A", "Y", "Z");
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertFalse(contents.toString(), contents.valid());
+        assertFalse(passed);
+    }
+    @Test
+    public void testStringContentsUnorderedBad3() throws Exception {
+        final Topology topology = new Topology();
+        TStream<String> source = topology.strings("A", "B", "C", "D");
+
+        Condition<List<String>> contents = topology.getTester().stringContentsUnordered(source, "A", "B");
+
+        boolean passed = complete(topology.getTester(), contents, 10, TimeUnit.SECONDS);
+        assertFalse(contents.toString(), contents.valid());
+        assertFalse(passed);
+    }
 }


### PR DESCRIPTION
Separates the Tester into a test/condition definition `Tester` and a runtime `TesterRuntime` that takes the conditions and adds testing elements to the graph.

- Embedded tester adds handlers for each condition and adds them directory into the graph.
- Standalone/distributed adds handlers for each condition and adds them into the local graph and connects the application graph up to the TCP client operator.

This is basically what was done before, but delays the handler creation until they are needed.

This will allow (in a future PR) different implementation of the conditions for running against streaming analytics service, using metrics as in Python.

[A couple of handlers are still directly used by the `Tester` impl `ConditionTesterImpl`, at least one is required, but with this PR a streaming analytics service tester can be quickly created handling the most used conditions.