### PR TITLE
New STREAMING_ANALYTICS_SERVICE_TEST Java context.

### DIFF
--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -4,10 +4,13 @@
  */
 package com.ibm.streamsx.rest;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
@@ -116,6 +119,8 @@ public class Instance extends Element {
      * @throws IOException
      */
     public Job getJob(String jobId) throws IOException {
+        requireNonNull(jobId);
+        
         String sGetJobURI = jobs + "/" + jobId;
 
         String sReturn = connection().getResponseString(sGetJobURI);

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
@@ -44,7 +44,7 @@ public class StreamingAnalyticsConnection extends StreamsConnection {
     private StreamingAnalyticsConnection(String userName, String authToken, String url) {
         super(userName, authToken, url);
     }
-
+    
     /**
      * Connection to IBM Streaming Analytics service
      *
@@ -58,12 +58,17 @@ public class StreamingAnalyticsConnection extends StreamsConnection {
     public static StreamingAnalyticsConnection createInstance(String credentialsFile, String serviceName)
             throws IOException {
 
-        JsonObject streamingAnalyticsCredentials = new JsonObject();
+        JsonObject config = new JsonObject();
 
-        streamingAnalyticsCredentials.addProperty(SERVICE_NAME, serviceName);
-        streamingAnalyticsCredentials.addProperty(VCAP_SERVICES, credentialsFile);
+        config.addProperty(SERVICE_NAME, serviceName);
+        config.addProperty(VCAP_SERVICES, credentialsFile);
+        
+        return newInstance(config);
+    }
+        
+    public static StreamingAnalyticsConnection newInstance(JsonObject config) throws IOException{
 
-        JsonObject service = VcapServices.getVCAPService(streamingAnalyticsCredentials);
+        JsonObject service = VcapServices.getVCAPService(config);
 
         JsonObject credential = new JsonObject();
         credential = service.get("credentials").getAsJsonObject();

--- a/java/src/com/ibm/streamsx/topology/context/StreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/context/StreamsContext.java
@@ -237,6 +237,13 @@ public interface StreamsContext<T> {
          * </P>
          */
         STREAMING_ANALYTICS_SERVICE,
+        
+        /**
+         * Testing variant of {@link #STREAMING_ANALYTICS_SERVICE}.
+         * 
+         * @since 1.7
+         */
+        STREAMING_ANALYTICS_SERVICE_TESTER,
         ;
     }
 

--- a/java/src/com/ibm/streamsx/topology/context/StreamsContextFactory.java
+++ b/java/src/com/ibm/streamsx/topology/context/StreamsContextFactory.java
@@ -12,6 +12,7 @@ import com.ibm.streamsx.topology.internal.context.DistributedTester;
 import com.ibm.streamsx.topology.internal.context.EmbeddedStreamsContext;
 import com.ibm.streamsx.topology.internal.context.EmbeddedTester;
 import com.ibm.streamsx.topology.internal.context.RemoteStreamingAnalyticsServiceStreamsContext;
+import com.ibm.streamsx.topology.internal.context.RemoteStreamingAnalyticsTester;
 import com.ibm.streamsx.topology.internal.context.StandaloneStreamsContext;
 import com.ibm.streamsx.topology.internal.context.StandaloneTester;
 import com.ibm.streamsx.topology.internal.context.ToolkitStreamsContext;
@@ -90,6 +91,9 @@ public class StreamsContextFactory {
             if (System.getenv("STREAMS_INSTALL") == null)
                 return new RemoteStreamingAnalyticsServiceStreamsContext();
             return new AnalyticsServiceStreamsContext(type);
+            
+        case STREAMING_ANALYTICS_SERVICE_TESTER:
+            return new RemoteStreamingAnalyticsTester();
         default:
             throw new IllegalArgumentException("Unknown type:" + type);
         }

--- a/java/src/com/ibm/streamsx/topology/internal/context/RemoteStreamingAnalyticsTester.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/RemoteStreamingAnalyticsTester.java
@@ -1,0 +1,32 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+ */
+package com.ibm.streamsx.topology.internal.context;
+
+import java.math.BigInteger;
+import java.util.concurrent.Future;
+
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
+
+public class RemoteStreamingAnalyticsTester extends RemoteStreamingAnalyticsServiceStreamsContext {
+
+    @Override
+    public Type getType() {
+        return Type.STREAMING_ANALYTICS_SERVICE_TESTER;
+    }
+    
+    @Override
+    Future<BigInteger> postSubmit(com.ibm.streamsx.topology.internal.context.JSONStreamsContext.AppEntity entity,
+            Future<BigInteger> future) throws Exception {
+                
+        Topology app = entity.app;
+        if (app != null && app.hasTester()) {
+            TesterRuntime trt = ((ConditionTesterImpl) app.getTester()).getRuntime();
+            trt.start(entity.submission);
+        }
+        return future;
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/streaminganalytics/VcapServices.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streaminganalytics/VcapServices.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -45,7 +46,7 @@ public class VcapServices {
         String vcapString;
         String vcapContents = null;
 
-        if (rawServices == null) {
+        if (rawServices == null || rawServices.isJsonNull()) {
             // if rawServices is null, then pull from the environment
             vcapString = System.getenv("VCAP_SERVICES");
             if (vcapString == null) {
@@ -86,6 +87,7 @@ public class VcapServices {
      * @throws IOException
      */
     public static JsonObject getVCAPService(JsonObject deploy) throws IOException {
+        
         JsonObject services = getVCAPServices(deploy.get(VCAP_SERVICES));
 
         JsonArray streamsServices = array(services, "streaming-analytics");

--- a/java/src/com/ibm/streamsx/topology/internal/tester/ConditionTesterImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/ConditionTesterImpl.java
@@ -34,6 +34,7 @@ import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserConditio
 import com.ibm.streamsx.topology.internal.tester.conditions.CounterUserCondition;
 import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
 import com.ibm.streamsx.topology.internal.tester.embedded.EmbeddedTesterRuntime;
+import com.ibm.streamsx.topology.internal.tester.rest.RESTTesterRuntime;
 import com.ibm.streamsx.topology.internal.tester.tcp.TCPTesterRuntime;
 import com.ibm.streamsx.topology.spl.SPLStream;
 import com.ibm.streamsx.topology.streams.StringStreams;
@@ -176,6 +177,9 @@ public class ConditionTesterImpl implements Tester {
             case STANDALONE_TESTER:
                 runtime = new TCPTesterRuntime(contextType, this);
                 break;
+            case STREAMING_ANALYTICS_SERVICE_TESTER:
+                runtime = new RESTTesterRuntime(this);
+                break;
             default: // nothing to do
                 return;
             }
@@ -235,8 +239,9 @@ public class ConditionTesterImpl implements Tester {
         while (state == null || (System.currentTimeMillis() - start) < totalWait) {
             
             state = getRuntime().checkTestState(context, config, future, endCondition);
-            
             switch (state) {
+            case NOT_READY:
+                continue;
             case NO_PROGRESS:
                 if (seenValid)
                     break;

--- a/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/TesterRuntime.java
@@ -23,6 +23,7 @@ import com.ibm.streamsx.topology.tester.Condition;
  */
 public abstract class TesterRuntime {
     public enum TestState {
+        NOT_READY,
         NO_PROGRESS,
         PROGRESS,
         VALID,

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/ContentsUserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/ContentsUserCondition.java
@@ -31,7 +31,13 @@ public final class ContentsUserCondition<T> extends UserCondition<List<T>> {
     }
     @Override
     public String toString() {
-        return "Received Tuples: " + getResult();
+        String result;
+        if (getImpl() == null)
+            result = getResult().toString();
+        else
+            result = getImpl().toString();
+        
+        return "Received Tuples: " + result;
     }
     
     

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/UserCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/UserCondition.java
@@ -25,7 +25,7 @@ public abstract class UserCondition<R> implements Condition<R> {
         this.impl = impl;
     }
     
-    private synchronized Condition<R> getImpl() {
+    synchronized Condition<R> getImpl() {
         return impl;
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/conditions/handlers/HandlerCondition.java
@@ -35,4 +35,9 @@ public abstract class HandlerCondition<R, H extends StreamHandler<Tuple>, U exte
     synchronized void fail() {
         failed = true;
     }
+    
+    @Override
+    public final String toString() {
+        return getResult().toString();
+    }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/fns/ConditionChecker.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/fns/ConditionChecker.java
@@ -1,0 +1,108 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017 
+ */
+package com.ibm.streamsx.topology.internal.tester.fns;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+import com.ibm.streamsx.topology.function.Consumer;
+import com.ibm.streamsx.topology.function.FunctionContext;
+import com.ibm.streamsx.topology.function.Initializable;
+import com.ibm.streamsx.topology.internal.tester.rest.RESTTesterRuntime;
+import com.ibm.streamsx.topology.tester.Tester;
+
+public abstract class ConditionChecker<T> implements Consumer<T>, Initializable {
+    
+    static Logger TEST_TRACE = Logger.getLogger(Tester.class.getName());
+    
+    public static final String METRIC_PREFIX = "streamsx.condition:";
+    
+    public static String metricName(String type, String name) {
+        return METRIC_PREFIX + type + ":" + name;
+    }
+
+    private static final long serialVersionUID = 1L;
+    
+    private final String name;
+    private transient AtomicBoolean valid;
+    private transient AtomicLong seq;
+    private transient AtomicBoolean fail;
+    private transient long count;
+    
+    public ConditionChecker(String name) {
+        this.name = name;
+    }
+    
+    @Override
+    public void initialize(FunctionContext functionContext) throws Exception {
+        
+        valid = new AtomicBoolean();
+        seq = new AtomicLong();
+        fail = new AtomicBoolean();
+       
+        functionContext.createCustomMetric(metricName("valid", name),
+                "Condition: " + name + " is valid", "gauge",
+                () -> valid.get() ? 1L: 0L);
+        
+        functionContext.createCustomMetric(metricName("seq", name),
+                "Condition: " + name + " sequence", "counter",
+                seq::get);
+        
+        functionContext.createCustomMetric(metricName("fail", name),
+                "Condition: " + name + " failed", "gauge",
+                () -> fail.get() ? 1L: 0L);       
+    }
+    
+    /**
+     * Once failed the condition can never become valid.
+     * @throws InterruptedException 
+     */
+    void setFailed(String why) {
+        TEST_TRACE.severe(name + ": " + why);
+        fail.set(true);
+        valid.set(false);
+    }
+    
+    void failTooMany(long expected) {
+        String why = String.format("Too many tuples: Expected %d, received %d.", expected, this.tupleCount());
+        setFailed(why);
+    }
+    
+    void failUnexpectedTuple(T tuple, List<T> expected) {
+        setFailed(String.format("Tuple %s not expected, not in: %s", tuple, expected));
+    }   
+    
+    void setValid() {
+        if (!fail.get()) {
+            valid.set(true);
+        }
+    }
+    
+    void progress() {
+        seq.incrementAndGet();
+    }
+    
+    long tupleCount() {
+        return count;
+    }
+    
+    boolean failed() {
+        return fail.get();
+    }
+    
+    @Override
+    public final void accept(T tuple) {
+        if (failed())
+            return;
+        
+        progress();
+        count++;
+        checkValid(tuple);
+    }
+    
+    abstract void checkValid(T tuple);
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/fns/TupleContents.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/fns/TupleContents.java
@@ -1,0 +1,77 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017 
+ */
+package com.ibm.streamsx.topology.internal.tester.fns;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class TupleContents<T> extends ConditionChecker<T> {
+    private static final long serialVersionUID = 1L;
+    
+    private final List<T> expected;
+    private final boolean ordered;
+    private List<T> got;
+
+    public TupleContents(String name, boolean ordered, List<T> expected) {
+        super(name);
+        this.ordered = ordered;
+        this.expected = expected;
+        if (!ordered)
+            got = new ArrayList<>(expected.size());
+    }
+
+    @Override
+    public void checkValid(T tuple) {
+            
+        if (tupleCount() > expected.size()) {
+            // too many tuples
+            failTooMany(expected.size());
+            return;
+        }
+        
+
+        
+        if (ordered)
+            checkOrdered(tuple);
+        else
+            checkUnordered(tuple);
+    }
+
+    private void checkOrdered(T tuple) {
+        int tupleIndex = (int) (tupleCount() - 1);
+        
+        if (tuple.equals(expected.get(tupleIndex))) {
+            if (tupleCount() == expected.size())
+                setValid();
+        } else {
+            failUnexpectedTuple(tuple, expected);
+        }
+    }
+    
+    private void checkUnordered(T tuple) {
+        
+        if (!expected.contains(tuple)) {
+            failUnexpectedTuple(tuple, expected);
+            return;
+        }
+        
+        got.add(tuple);
+        
+        if (got.size() == expected.size()) {
+            
+            // Copy expected to avoid modifying it.
+            List<T> ce = new ArrayList<>(expected.size());
+            ce.addAll(expected);
+            
+            for (T t : got) {
+                if (!ce.remove(t)) {
+                    setFailed(String.format("Expected %s Received %s.", got, expected));
+                    return;
+                }   
+            }
+            setValid();
+        }
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/fns/TupleCount.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/fns/TupleCount.java
@@ -1,0 +1,35 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017 
+ */
+package com.ibm.streamsx.topology.internal.tester.fns;
+
+import com.ibm.streamsx.topology.function.FunctionContext;
+
+public final class TupleCount<T> extends ConditionChecker<T> {
+    private static final long serialVersionUID = 1L;
+    
+    private final long expected;
+    private final boolean exact;
+
+    public TupleCount(String name, long expected, boolean exact) {
+        super(name);
+        this.expected = expected;
+        this.exact = exact;
+    }
+    @Override
+    public void initialize(FunctionContext functionContext) throws Exception {
+        super.initialize(functionContext);
+        if (expected == 0)
+            setValid();
+    }
+
+    @Override
+    void checkValid(T v) {        
+        if (tupleCount() == expected)
+            setValid();
+        else if (exact && tupleCount() > expected)
+            // can never become valid again
+            failTooMany(expected);
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/rest/CounterMetricCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/rest/CounterMetricCondition.java
@@ -1,0 +1,23 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017 
+ */
+package com.ibm.streamsx.topology.internal.tester.rest;
+
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime.TestState;
+import com.ibm.streamsx.topology.internal.tester.conditions.CounterUserCondition;
+
+class CounterMetricCondition extends MetricCondition<Long> {
+
+    CounterMetricCondition(String name, CounterUserCondition userCondition) {
+        super(name, userCondition);
+    }
+    
+    @Override
+    public Long getResult() {
+        if (getState() == TestState.NOT_READY)
+            return -77L;
+        
+        return lastSeq;
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/rest/MetricCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/rest/MetricCondition.java
@@ -1,0 +1,122 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017 
+ */
+package com.ibm.streamsx.topology.internal.tester.rest;
+
+import java.io.IOException;
+
+import com.ibm.streamsx.rest.Metric;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
+import com.ibm.streamsx.topology.internal.tester.conditions.UserCondition;
+import com.ibm.streamsx.topology.tester.Condition;
+
+public class MetricCondition<T> implements Condition<T> {
+
+    final String name;
+       
+    private Metric valid;
+    private Metric seq;
+    private Metric fail;
+    long lastSeq;
+    private TesterRuntime.TestState state;
+    private boolean frozen;
+
+    public MetricCondition(String name, UserCondition<T> userCondition) {
+        this.name = name;
+        setState(TesterRuntime.TestState.NOT_READY);
+        userCondition.setImpl(this);
+    }
+    
+    /**
+     * Maintains the state of the condition
+     * after the job is canceled.
+     */
+    synchronized void freeze() throws IOException {
+        frozen = true;
+        if (seq != null) {
+            seq.refresh();
+            lastSeq = seq.getValue();
+        }
+        valid = seq = fail = null;      
+    }
+    synchronized boolean isFrozen() {
+        return frozen;
+    }
+    
+
+    @Override
+    public synchronized boolean valid() {
+        return getState() == TesterRuntime.TestState.VALID;
+    }
+    
+    @Override
+    public boolean failed() {
+        return getState() == TesterRuntime.TestState.FAIL;
+    }
+    
+    @Override
+    public T getResult() {
+        throw new UnsupportedOperationException();
+    }
+
+    synchronized boolean hasMetrics() {
+        return valid != null && seq != null && fail != null;
+    }
+    
+    synchronized void setValidMetric(Metric valid) {
+        this.valid = valid;
+    }
+    synchronized void setSeqMetric(Metric seq) {
+        this.seq = seq;
+    }
+    synchronized void setFailMetric(Metric fail) {
+        this.fail = fail;
+    }
+    
+    private synchronized TesterRuntime.TestState setState(TesterRuntime.TestState state) {
+        return this.state = state;
+    }
+    
+    synchronized TesterRuntime.TestState getState() {
+        return this.state;
+    }
+
+    /**
+     * Check the condition based upon the metrics.
+     * 
+     * Outcome is one of the states:
+     */
+    TesterRuntime.TestState oneCheck() throws IOException {
+        if (isFrozen())
+            return getState();
+        
+        if (!hasMetrics())
+            return setState(TesterRuntime.TestState.NOT_READY);
+        
+        if (getState() == TesterRuntime.TestState.FAIL)
+            return TesterRuntime.TestState.FAIL;
+
+        fail.refresh();
+        valid.refresh(); 
+        seq.refresh();
+        System.err.println(name + " FAIL:" + fail.getValue());
+        System.err.println(name + " VALID:" + valid.getValue());
+        System.err.println(name + " SEQ:" + seq.getValue());
+        
+        if (fail.getValue() != 0L) {
+            return setState(TesterRuntime.TestState.FAIL);
+        }     
+        
+        if (valid.getValue() == 1L)
+            return setState(TesterRuntime.TestState.VALID);
+        
+        long s = seq.getValue();
+        synchronized (this) {          
+            if (s == lastSeq)
+                return setState(TesterRuntime.TestState.NO_PROGRESS);
+            lastSeq = s;
+            return setState(TesterRuntime.TestState.PROGRESS);
+        }
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/rest/MetricCondition.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/rest/MetricCondition.java
@@ -70,7 +70,7 @@ public class MetricCondition<T> implements Condition<T> {
     synchronized void setSeqMetric(Metric seq) {
         this.seq = seq;
     }
-    synchronized void setFailMetric(Metric fail) {
+    synchronized void setFailMetric(Metric fail) {      
         this.fail = fail;
     }
     
@@ -100,9 +100,6 @@ public class MetricCondition<T> implements Condition<T> {
         fail.refresh();
         valid.refresh(); 
         seq.refresh();
-        System.err.println(name + " FAIL:" + fail.getValue());
-        System.err.println(name + " VALID:" + valid.getValue());
-        System.err.println(name + " SEQ:" + seq.getValue());
         
         if (fail.getValue() != 0L) {
             return setState(TesterRuntime.TestState.FAIL);
@@ -118,5 +115,10 @@ public class MetricCondition<T> implements Condition<T> {
             lastSeq = s;
             return setState(TesterRuntime.TestState.PROGRESS);
         }
+    }
+    
+    @Override
+    public String toString() {
+        return "Result not available";
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/rest/MetricConditionChecker.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/rest/MetricConditionChecker.java
@@ -1,0 +1,157 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017 
+ */
+package com.ibm.streamsx.topology.internal.tester.rest;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.ibm.streamsx.rest.Job;
+import com.ibm.streamsx.rest.Metric;
+import com.ibm.streamsx.rest.Operator;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
+import com.ibm.streamsx.topology.internal.tester.TesterRuntime.TestState;
+import com.ibm.streamsx.topology.internal.tester.fns.ConditionChecker;
+
+public class MetricConditionChecker {
+
+    private Job job;
+    private boolean seenHealthy;
+    
+    private final Map<String,MetricCondition<?>> conditions = new HashMap<>();
+
+    public MetricConditionChecker() {
+    } 
+    
+    void addCondition(String name, MetricCondition<?> condition) {
+        if (condition == null)
+            throw new IllegalStateException();
+        conditions.put(name, condition);
+    }
+    
+    void setup(Job job) throws IOException, TimeoutException, InterruptedException {
+        this.job = job;
+    }
+    
+    TesterRuntime.TestState checkTestState() throws IOException, InterruptedException {
+        System.err.println("OVERALL:checkTestState:seenHealthy:" + seenHealthy + " jobid" + job.getId());
+        System.err.println("HEALTH: " + job.getHealth());
+        for (int i = 0; i < 20; i++) {
+            Thread.sleep(200);
+            job.refresh();
+            System.err.println("HEALTH: " + i + ": "+ job.getHealth());
+        }
+        if (!seenHealthy) {
+            try {
+                job.waitForHealthy(5, TimeUnit.SECONDS);
+                System.err.println("OVERALL:Job Now healthy:" + job.getHealth());
+                seenHealthy = true;
+                findConditionMetrics();
+            } catch (TimeoutException te) {
+                return TesterRuntime.TestState.NOT_READY;
+            }
+        } else {
+            for (int i = 0; i < 20; i++) {            
+                job.refresh();
+                System.err.println("HEALTH_A: " + i + ": "+ job.getHealth());
+                Thread.sleep(200);
+            }
+            job.refresh();
+            System.err.println("OVERALL:Job Health:" + job.getHealth());
+            if (!"healthy".equals(job.getHealth()))
+                return TestState.FAIL;
+        }
+        
+        Thread.sleep(1000);
+        TesterRuntime.TestState state = oneCheck();
+        if (state == TestState.NOT_READY) {
+            Thread.sleep(200);
+            findConditionMetrics();
+        }
+        return state;
+    }
+    
+    private TesterRuntime.TestState oneCheck() throws IOException, InterruptedException {
+        
+        int validCount = 0;
+        int progressCount = 0;
+        int noProgressCount = 0;
+               
+        for (MetricCondition<?> condition : conditions.values()) {
+            TestState state = condition.oneCheck();
+            System.err.println("MetricState:" +condition.name + " -- "+ state);
+            switch (state) {
+            case NOT_READY:
+                return TesterRuntime.TestState.NOT_READY;
+            case NO_PROGRESS:
+                noProgressCount++;
+                break;
+            case PROGRESS:
+                progressCount++;
+                break;
+            case VALID:
+                validCount++;
+                break;
+            case FAIL:
+                return TesterRuntime.TestState.FAIL;
+            }
+        }
+        
+        if (validCount == conditions.size())
+            return TesterRuntime.TestState.VALID;
+        
+        if (noProgressCount == conditions.size())
+            return TesterRuntime.TestState.NO_PROGRESS;
+        
+        return TesterRuntime.TestState.PROGRESS;
+    }
+
+    private void findConditionMetrics() throws IOException {
+        
+        job.refresh();
+
+        for (Operator op : job.getOperators()) {
+            for (Metric metric : op.getMetrics()) {
+
+                final String metricName = metric.getName();
+                if (!metricName.startsWith(ConditionChecker.METRIC_PREFIX))
+                    continue;
+
+                String conditionName = metricName.substring(metricName.lastIndexOf(':') + 1);
+                if (conditions.containsKey(conditionName)) {
+                    MetricCondition<?> condition = conditions.get(conditionName);
+                    if (condition.hasMetrics())
+                        continue;
+
+                    final String validName = ConditionChecker.metricName("valid", conditionName);
+                    final String seqName = ConditionChecker.metricName("seq", conditionName);
+                    final String failName = ConditionChecker.metricName("fail", conditionName);
+
+                    if (metricName.equals(validName))
+                        condition.setValidMetric(metric);
+                    else if (metricName.equals(seqName))
+                        condition.setSeqMetric(metric);
+                    else if (metricName.equals(failName))
+                        condition.setFailMetric(metric);
+                }
+            }
+        }
+    }
+
+
+    void shutdown() throws IOException, Exception {
+        for (MetricCondition<?> condition : this.conditions.values()) {
+            condition.freeze();
+        }
+        try {
+            if (job != null)
+                job.cancel(); 
+        } finally {
+            job = null;
+        }
+    }
+}

--- a/java/src/com/ibm/streamsx/topology/internal/tester/rest/MetricConditionChecker.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/rest/MetricConditionChecker.java
@@ -38,30 +38,16 @@ public class MetricConditionChecker {
     }
     
     TesterRuntime.TestState checkTestState() throws IOException, InterruptedException {
-        System.err.println("OVERALL:checkTestState:seenHealthy:" + seenHealthy + " jobid" + job.getId());
-        System.err.println("HEALTH: " + job.getHealth());
-        for (int i = 0; i < 20; i++) {
-            Thread.sleep(200);
-            job.refresh();
-            System.err.println("HEALTH: " + i + ": "+ job.getHealth());
-        }
         if (!seenHealthy) {
             try {
                 job.waitForHealthy(5, TimeUnit.SECONDS);
-                System.err.println("OVERALL:Job Now healthy:" + job.getHealth());
                 seenHealthy = true;
                 findConditionMetrics();
             } catch (TimeoutException te) {
                 return TesterRuntime.TestState.NOT_READY;
             }
         } else {
-            for (int i = 0; i < 20; i++) {            
-                job.refresh();
-                System.err.println("HEALTH_A: " + i + ": "+ job.getHealth());
-                Thread.sleep(200);
-            }
             job.refresh();
-            System.err.println("OVERALL:Job Health:" + job.getHealth());
             if (!"healthy".equals(job.getHealth()))
                 return TestState.FAIL;
         }
@@ -83,7 +69,6 @@ public class MetricConditionChecker {
                
         for (MetricCondition<?> condition : conditions.values()) {
             TestState state = condition.oneCheck();
-            System.err.println("MetricState:" +condition.name + " -- "+ state);
             switch (state) {
             case NOT_READY:
                 return TesterRuntime.TestState.NOT_READY;

--- a/java/src/com/ibm/streamsx/topology/tester/Tester.java
+++ b/java/src/com/ibm/streamsx/topology/tester/Tester.java
@@ -39,7 +39,8 @@ import com.ibm.streamsx.topology.spl.SPLStream;
  * is submitted to a tester {@link StreamsContext}, of type
  * {@link com.ibm.streamsx.topology.context.StreamsContext.Type#EMBEDDED_TESTER},
  * {@link com.ibm.streamsx.topology.context.StreamsContext.Type#STANDALONE_TESTER},
- * {@link com.ibm.streamsx.topology.context.StreamsContext.Type#DISTRIBUTED_TESTER}.
+ * {@link com.ibm.streamsx.topology.context.StreamsContext.Type#DISTRIBUTED_TESTER},
+ * {@link com.ibm.streamsx.topology.context.StreamsContext.Type#STREAMING_ANALYTICS_SERVICE_TESTER}.
  * </P>
  * <P>
  * When running a test using {@link com.ibm.streamsx.topology.context.StreamsContext.Type#STANDALONE_TESTER}
@@ -59,6 +60,12 @@ public interface Tester {
 
     /**
      * Adds {@code handler} to capture the output of {@code stream}.
+     * 
+     * <P>
+     * Not supported when testing using
+     * {@link com.ibm.streamsx.topology.context.StreamsContext.Type#STREAMING_ANALYTICS_SERVICE_TESTER STREAMING_ANALYTICS_SERVICE_TESTER}
+     * context.
+     * </P>
      * @param stream Stream to have its tuples captured.
      * @param handler {@code StreamHandler} to capture tuples.
      * @return {@code handler}

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -159,6 +159,12 @@
      </antcall>
      <fail message="Unittests failed" if="topology.tests.failed"/>
   </target>
+  <target name="unittest.streaminganalytics">
+     <antcall target="unittest.base" inheritAll="no">
+       <param name="topology.test.type" value="STREAMING_ANALYTICS_SERVICE_TESTER"/>
+     </antcall>
+     <fail message="Unittests failed" if="topology.tests.failed"/>
+  </target>
 
   <target name="unittest.base.scala">
     <ant dir="../scala" target="unittest" useNativeBasedir="true" inheritAll="no">

--- a/test/java/src/com/ibm/streamsx/topology/test/TestTopology.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/TestTopology.java
@@ -75,15 +75,12 @@ public class TestTopology {
     
     @Before
     public void setupConfig() {
-        
-        
-        List<String> vmArgs = new ArrayList<>();
-        config.put(ContextProperties.VMARGS, vmArgs);
-        
-        if (getTesterType() != Type.EMBEDDED_TESTER) {
            
+        if (getTesterType() == Type.STANDALONE_TESTER || getTesterType() == Type.DISTRIBUTED_TESTER) {
+                       
             File agentJar = new File(System.getProperty("user.home"), ".ant/lib/jacocoagent.jar");
             if (agentJar.exists()) {
+                List<String> vmArgs = new ArrayList<>();
                 String now = Long.toHexString(System.currentTimeMillis());
                 String destFile = "jacoco_" + getTesterType().name() + now + ".exec";
      
@@ -93,8 +90,10 @@ public class TestTopology {
                         + "=destfile="
                         + destFile;
                 vmArgs.add(arg);
+                config.put(ContextProperties.VMARGS, vmArgs);
             }
         }
+            
         // Look for a different compiler
         String differentCompile = System.getProperty(ContextProperties.COMPILE_INSTALL_DIR);
         if (differentCompile != null) {

--- a/test/java/src/com/ibm/streamsx/topology/test/api/IsolateTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/IsolateTest.java
@@ -44,8 +44,8 @@ public class IsolateTest extends TestTopology {
 
         Tester tester = topology.getTester();
 
-        Condition<List<String>> condss1 = tester.stringContents(ss1, "");
-        Condition<List<String>> condss2 = tester.stringContents(ss2, "");
+        Condition<List<String>> condss1 = tester.stringContents(ss1);
+        Condition<List<String>> condss2 = tester.stringContents(ss2);
 
         Condition<Long> condss1Cnt = tester.tupleCount(ss1, 1);
         Condition<Long> condss2Cnt = tester.tupleCount(ss2, 1);

--- a/test/java/src/com/ibm/streamsx/topology/test/api/LowLatencyTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/LowLatencyTest.java
@@ -150,8 +150,8 @@ public class LowLatencyTest extends TestTopology {
         
         Condition<Long> uCount = tester.tupleCount(all, strs.length);
         
-        Condition<List<String>> contents = tester.stringContents(all, "");
-        Condition<List<String>> s2contents = tester.stringContents(s2, "");
+        Condition<List<String>> contents = tester.stringContents(all);
+        Condition<List<String>> s2contents = tester.stringContents(s2);
 
         complete(tester, uCount, 10, TimeUnit.SECONDS);
 
@@ -223,7 +223,7 @@ public class LowLatencyTest extends TestTopology {
         
         Condition<Long> uCount = tester.tupleCount(s2.filter(new AllowAll<String>()), 1);
         Condition<List<String>> contents = tester.stringContents(
-                s2.filter(new AllowAll<String>()), "");
+                s2.filter(new AllowAll<String>()));
 
         complete(tester, uCount, 10, TimeUnit.SECONDS);
 

--- a/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/PlaceableTest.java
@@ -392,7 +392,7 @@ public class PlaceableTest extends TestTopology {
         
         sa = sa.union(sb);
         
-        Condition<List<String>> pes = t.getTester().stringContents(sa, "");
+        Condition<List<String>> pes = t.getTester().stringContents(sa);
         
         Condition<Long> tc = t.getTester().tupleCount(sa, 2);
         

--- a/test/java/src/com/ibm/streamsx/topology/test/api/TopologySourceTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/TopologySourceTest.java
@@ -101,7 +101,7 @@ public class TopologySourceTest extends TestTopology {
         TStream<String> st = StringStreams.toString(timestamps);
         
         Condition<Long> c = topology.getTester().atLeastTupleCount(st, 20);
-        Condition<List<String>> tuples = topology.getTester().stringContents(st, "notused");
+        Condition<List<String>> tuples = topology.getTester().stringContents(st);
 
         long start = System.currentTimeMillis();
         complete(topology.getTester(), c, 30, TimeUnit.SECONDS);
@@ -139,7 +139,7 @@ public class TopologySourceTest extends TestTopology {
                 500, TimeUnit.MILLISECONDS);
         
         Condition<Long> ending = topology.getTester().atLeastTupleCount(ms, 60);
-        Condition<List<String>> tuples = topology.getTester().stringContents(ms, "notused");
+        Condition<List<String>> tuples = topology.getTester().stringContents(ms);
 
         long start = System.currentTimeMillis();
         complete(topology.getTester(), ending, 30, TimeUnit.SECONDS);

--- a/test/java/src/com/ibm/streamsx/topology/test/tester/ConditionTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/tester/ConditionTest.java
@@ -35,10 +35,12 @@ public class ConditionTest extends TestTopology {
         Condition<Long> tupleCount = topology.getTester().tupleCount(source, 3);
 
         boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);
-        assertTrue(passed);
 
-        assertTrue(tupleCount.valid());
-        assertEquals(3L, (long) tupleCount.getResult());
+        assertTrue(tupleCount.toString(), tupleCount.valid());
+        assertEquals(tupleCount.toString(), 3L, (long) tupleCount.getResult());
+        assertFalse(tupleCount.failed());
+        
+        assertTrue(passed);
     }
     
     @Test
@@ -48,9 +50,10 @@ public class ConditionTest extends TestTopology {
 
         Condition<Long> tupleCount = topology.getTester().tupleCount(source, 3);
 
-        boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);
-        assertFalse(passed);      
-        assertFalse(tupleCount.valid());
+        boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);             
+        assertFalse(tupleCount.toString(), tupleCount.valid());
+        assertTrue(tupleCount.failed());
+        assertFalse(passed);
     }
     
     @Test
@@ -61,8 +64,10 @@ public class ConditionTest extends TestTopology {
         Condition<Long> tupleCount = topology.getTester().tupleCount(source, 3);
 
         boolean passed = complete(topology.getTester(), tupleCount, 10, TimeUnit.SECONDS);
+
+        assertFalse(tupleCount.toString(), tupleCount.valid());
+        assertFalse(tupleCount.failed());
         assertFalse(passed);
-        assertFalse(tupleCount.valid());
     }
     
     @Test
@@ -80,6 +85,7 @@ public class ConditionTest extends TestTopology {
         assertTrue(tupleCount.toString(), tupleCount.valid());
         assertTrue(tupleCount.toString(), tupleCount.getResult() >= 26);
         assertTrue(passed);
+        assertFalse(tupleCount.failed());
     }
     
     @Test


### PR DESCRIPTION
New Java tester for testing against the Streaming Analytics service. 

The application is always built remotely using the build service.

Currently only conditions that are tuple count or the contents of the stream are supported. Any none supported condition results in a failed test.

Since the contents of the streams are not available at the client side (ie. the jvm running the junit test) any test that tries to get the contents of a stream using `Condition.getResults()` will fail. The tester rejects any such condition.