### PR TITLE
Remove builder opgraph

### DIFF
--- a/java/src/com/ibm/streamsx/topology/Topology.java
+++ b/java/src/com/ibm/streamsx/topology/Topology.java
@@ -26,7 +26,6 @@ import com.google.gson.JsonObject;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONArtifact;
 import com.ibm.json.java.JSONObject;
-import com.ibm.streams.flow.declare.OperatorGraph;
 import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.builder.GraphBuilder;

--- a/java/src/com/ibm/streamsx/topology/TopologyElement.java
+++ b/java/src/com/ibm/streamsx/topology/TopologyElement.java
@@ -4,7 +4,6 @@
  */
 package com.ibm.streamsx.topology;
 
-import com.ibm.streams.flow.declare.OperatorGraph;
 import com.ibm.streamsx.topology.builder.GraphBuilder;
 
 /**

--- a/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
@@ -13,7 +13,6 @@ import static com.ibm.streamsx.topology.generator.operator.OpProperties.MODEL_SP
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +27,6 @@ import com.ibm.streams.operator.Type.MetaType;
 import com.ibm.streams.operator.model.Namespace;
 import com.ibm.streams.operator.model.PrimitiveOperator;
 import com.ibm.streamsx.topology.function.Supplier;
-import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.tuple.JSONAble;
 
 // Union(A,B)
@@ -111,6 +109,13 @@ public class BOperatorInvocation extends BOperator {
     public void setModel(String model, String language) {
         json().put(MODEL, model);
         json().put(LANGUAGE, language);
+    }
+    
+    public String name() {
+        return op().getName();
+    }
+    public Class<? extends Operator> operatorClass() {
+        return op().getOperatorClass();
     }
 
     public void setParameter(String name, Object value) {
@@ -243,7 +248,7 @@ public class BOperatorInvocation extends BOperator {
             outputs = new HashMap<>();
 
         final BOutputPort stream = new BOutputPort(this, outputs.size(),
-                this.op().getName() + "_OUT" + outputs.size(),
+                this.name() + "_OUT" + outputs.size(),
                 schema);
         assert !outputs.containsKey(stream.name());
         outputs.put(stream.name(), stream);
@@ -309,7 +314,7 @@ public class BOperatorInvocation extends BOperator {
     // has a 'jar' parameter by calling 
     //
     // op instance of FunctionFunctor
-    public OperatorInvocation<? extends Operator> op() {
+    private OperatorInvocation<? extends Operator> op() {
         return op;
     }
 

--- a/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
-import com.ibm.streams.flow.declare.OperatorInvocation;
 import com.ibm.streams.operator.Attribute;
 import com.ibm.streams.operator.Operator;
 import com.ibm.streams.operator.StreamSchema;
@@ -28,12 +27,6 @@ import com.ibm.streams.operator.model.Namespace;
 import com.ibm.streams.operator.model.PrimitiveOperator;
 import com.ibm.streamsx.topology.function.Supplier;
 import com.ibm.streamsx.topology.tuple.JSONAble;
-
-// Union(A,B)
-//   OpC(A,B)
-//   Union(A,B) --> 
-
-// Parallel
 
 /**
  * JSON representation.
@@ -49,18 +42,20 @@ import com.ibm.streamsx.topology.tuple.JSONAble;
 
 public class BOperatorInvocation extends BOperator {
 
-    private final OperatorInvocation<? extends Operator> op;
     private List<BInputPort> inputs;
     private Map<String, BOutputPort> outputs;
     private final JSONObject jparams = new JSONObject();
+    private final String name;
+    private final Class<? extends Operator> opClass;
 
     public BOperatorInvocation(GraphBuilder bt,
             Class<? extends Operator> opClass,
             Map<String, ? extends Object> params) {
         super(bt);
         
-        op = bt.graph().addOperator(opClass);
-        json().put("name", op.getName());
+        this.opClass = opClass;
+        this.name =  bt.userSuppliedName(opClass.getSimpleName());
+        json().put("name", name());
         json().put("parameters", jparams);
         
         if (!Operator.class.equals(opClass)) {   
@@ -80,8 +75,9 @@ public class BOperatorInvocation extends BOperator {
             Class<? extends Operator> opClass,           
             Map<String, ? extends Object> params) {
         super(bt);
-        op = bt.graph().addOperator(name, opClass);
-        json().put("name", op.getName());
+        this.name = name;
+        this.opClass = opClass;
+        json().put("name", name());
         json().put("parameters", jparams);
         
         if (!Operator.class.equals(opClass)) {   
@@ -112,10 +108,10 @@ public class BOperatorInvocation extends BOperator {
     }
     
     public String name() {
-        return op().getName();
+        return name;
     }
     public Class<? extends Operator> operatorClass() {
-        return op().getOperatorClass();
+        return opClass;
     }
 
     public void setParameter(String name, Object value) {
@@ -171,40 +167,40 @@ public class BOperatorInvocation extends BOperator {
         }
                 
         if (value instanceof String) {
-            op.setStringParameter(name, (String) value);
+            //op.setStringParameter(name, (String) value);
             if (jsonType == null)
                 jsonType = MetaType.RSTRING.name();
         } else if (value instanceof Byte) {
-            op.setByteParameter(name, (Byte) value);
+            //op.setByteParameter(name, (Byte) value);
             if (jsonType == null)
                 jsonType = MetaType.INT8.name();
         } else if (value instanceof Short) {
-            op.setShortParameter(name, (Short) value);
+            //op.setShortParameter(name, (Short) value);
             if (jsonType == null)
                 jsonType = MetaType.INT16.name();
         } else if (value instanceof Integer) {
-            op.setIntParameter(name, (Integer) value);
+            //op.setIntParameter(name, (Integer) value);
             if (jsonType == null)
                 jsonType = MetaType.INT32.name();
         } else if (value instanceof Long) {
-            op.setLongParameter(name, (Long) value);
+            //op.setLongParameter(name, (Long) value);
             if (jsonType == null)
                 jsonType = MetaType.INT64.name();
         } else if (value instanceof Float) {
-            op.setFloatParameter(name, (Float) value);
+            //op.setFloatParameter(name, (Float) value);
             jsonType = MetaType.FLOAT32.name();
         } else if (value instanceof Double) {
-            op.setDoubleParameter(name, (Double) value);
+            //op.setDoubleParameter(name, (Double) value);
             jsonType = MetaType.FLOAT64.name();
         } else if (value instanceof Boolean) {
-            op.setBooleanParameter(name, (Boolean) value);
+            //op.setBooleanParameter(name, (Boolean) value);
             jsonType = MetaType.BOOLEAN.name();
         } else if (value instanceof BigDecimal) {
-            op.setBigDecimalParameter(name, (BigDecimal) value);
+            //op.setBigDecimalParameter(name, (BigDecimal) value);
             jsonValue = value.toString(); // Need to maintain exact value
             jsonType = MetaType.DECIMAL128.name();
         } else if (value instanceof Enum) {
-            op.setCustomLiteralParameter(name, (Enum<?>) value);
+            //op.setCustomLiteralParameter(name, (Enum<?>) value);
             jsonValue = ((Enum<?>) value).name();
             jsonType = JParamTypes.TYPE_ENUM;
         } else if (value instanceof StreamSchema) {
@@ -216,12 +212,12 @@ public class BOperatorInvocation extends BOperator {
             for (String vs : sa)
                 a.add(vs);
             jsonValue = a;
-            op.setStringParameter(name, sa);
+            //op.setStringParameter(name, sa);
         } else if (value instanceof Attribute) {
             Attribute attr = (Attribute) value;
             jsonValue = attr.getName();
             jsonType = JParamTypes.TYPE_ATTRIBUTE;
-            op.setAttributeParameter(name, attr.getName());
+            //op.setAttributeParameter(name, attr.getName());
         } else if (value instanceof JSONObject) {
             JSONObject jo = (JSONObject) value;
             jsonType = (String) jo.get("type");
@@ -257,7 +253,7 @@ public class BOperatorInvocation extends BOperator {
 
     public BInputPort inputFrom(BOutput output, BInputPort input) {
         if (input != null) {
-            assert input.operator() == this.op;
+            assert input.operator() == this;
             assert inputs != null;
 
             output.connectTo(input);
@@ -267,7 +263,7 @@ public class BOperatorInvocation extends BOperator {
             inputs = new ArrayList<>();
         }
 
-        input = new BInputPort(this, inputs.size(), this.op.getName() + "_IN" + inputs.size(), output.schema());
+        input = new BInputPort(this, inputs.size(), name + "_IN" + inputs.size(), output.schema());
         inputs.add(input);
         output.connectTo(input);
 
@@ -309,15 +305,6 @@ public class BOperatorInvocation extends BOperator {
 
         return json;
     }
-
-    // Needed by the DependencyResolver to determine whether the operator
-    // has a 'jar' parameter by calling 
-    //
-    // op instance of FunctionFunctor
-    private OperatorInvocation<? extends Operator> op() {
-        return op;
-    }
-
    
     private static String getKind(Class<?> opClass) {
         

--- a/java/src/com/ibm/streamsx/topology/builder/BOutputPort.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOutputPort.java
@@ -4,18 +4,15 @@
  */
 package com.ibm.streamsx.topology.builder;
 
-import com.ibm.streams.flow.declare.OutputPortDeclaration;
 import com.ibm.streams.operator.StreamSchema;
 
 public class BOutputPort extends BOutput implements BPort {
 
     private final BOperatorInvocation op;
-    private final OutputPortDeclaration port;
 
     BOutputPort(BOperatorInvocation op, int index, String name, StreamSchema schema) {
         this.op = op;
         addPortInfo(index, name, schema);
-        this.port = op.op().addOutput(name, schema);
     }
 
     public BOperatorInvocation operator() {
@@ -26,21 +23,15 @@ public class BOutputPort extends BOutput implements BPort {
         return op.builder();
     }
 
-    private OutputPortDeclaration port() {
-        return port;
-    }
-
-    @Override
-    public StreamSchema schema() {
-        return port.getStreamSchema();
-    }
-
     @Override
     public void connectTo(BInputPort input) {
         connect(input);
         input.connect(this);
                
-        input.port().connect(port());
         input.operator().copyRegions(operator());
+    }
+    @Override
+    public StreamSchema schema() {
+        return __schema();
     }
 }

--- a/java/src/com/ibm/streamsx/topology/builder/BPort.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BPort.java
@@ -7,6 +7,7 @@ package com.ibm.streamsx.topology.builder;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streams.operator.StreamSchema;
+import com.ibm.streams.operator.Type;
 
 interface BPort {
     
@@ -25,6 +26,12 @@ interface BPort {
     }
     default int index() {
         return ((Number) (json().get("index"))).intValue();
+    }
+    default String _schema() {
+        return json().get("type").toString();
+    }
+    default StreamSchema __schema() {
+        return Type.Factory.getTupleType(_schema()).getTupleSchema();
     }
     
     default void connect(BPort other) {

--- a/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
+++ b/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
@@ -23,8 +23,6 @@ import com.google.gson.JsonObject;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.json.java.OrderedJSONObject;
-import com.ibm.streams.flow.declare.OperatorGraph;
-import com.ibm.streams.flow.declare.OperatorGraphFactory;
 import com.ibm.streams.operator.Operator;
 import com.ibm.streams.operator.version.Product;
 import com.ibm.streamsx.topology.function.Consumer;
@@ -48,13 +46,9 @@ import com.ibm.streamsx.topology.tuple.JSONAble;
  * , which can then be used to generate SPL using
  * {@link com.ibm.streamsx.topology.generator.spl.SPLGenerator}.
  * 
- * If the graph only contains Java operators and functional operators, then it
- * may be executed using its {@code OperatorGraph} from {@link #graph()}.
  * 
  */
 public class GraphBuilder extends BJSONObject {
-
-    private final OperatorGraph graph = OperatorGraphFactory.newGraph();
 
     private final List<BOperator> ops = new ArrayList<>();
     
@@ -257,10 +251,6 @@ public class GraphBuilder extends BJSONObject {
 
     public String getRegionMarker(String name) {
         return regionMarkers.get(name);
-    }
-
-    OperatorGraph graph() {
-        return graph;
     }
     
     public JSONObject getConfig() {

--- a/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
+++ b/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
@@ -206,7 +206,7 @@ public class GraphBuilder extends BJSONObject {
         op.json().put("kind", virtualMarker.kind());
 
         if (createRegion) {
-            final String regionName = op.op().getName();
+            final String regionName = op.name();
             regionMarkers.put(regionName, virtualMarker.kind());
             op.addRegion(regionName);
         }
@@ -215,7 +215,7 @@ public class GraphBuilder extends BJSONObject {
         BInputPort input = op.inputFrom(output, null);
 
         // Create the output port.
-        return op.addOutput(input.port().getStreamSchema());
+        return op.addOutput(input.schema());
     }
     
     public BOutput addPassThroughOperator(BOutput output) {
@@ -223,7 +223,7 @@ public class GraphBuilder extends BJSONObject {
         // Create the input port that consumes the output
         BInputPort input = op.inputFrom(output, null);
         // Create the output port.
-        return op.addOutput(input.port().getStreamSchema());
+        return op.addOutput(input.schema());
     }
 
     public BOperator addVirtualMarkerOperator(BVirtualMarker kind) {

--- a/java/src/com/ibm/streamsx/topology/internal/context/EmbeddedStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/EmbeddedStreamsContext.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.concurrent.Future;
 
 import com.ibm.streams.flow.declare.OperatorGraph;
-import com.ibm.streams.flow.javaprimitives.JavaOperatorTester;
 import com.ibm.streams.flow.javaprimitives.JavaTestableGraph;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.internal.embedded.EmbeddedGraph;

--- a/java/src/com/ibm/streamsx/topology/internal/core/DependencyResolver.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/DependencyResolver.java
@@ -214,8 +214,7 @@ public class DependencyResolver {
             for (BOperator op : ops) {
                 if (op instanceof BOperatorInvocation) {
                     BOperatorInvocation bop = (BOperatorInvocation) op;
-                    if (Functional.class.isAssignableFrom(bop.op()
-                            .getOperatorClass())) {
+                    if (Functional.class.isAssignableFrom(bop.operatorClass())) {
                         JSONObject params = (JSONObject) bop.json().get(
                                 "parameters");
                         JSONObject op_jars = (JSONObject) params.get("jar");

--- a/java/src/com/ibm/streamsx/topology/internal/core/TopologyItem.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/TopologyItem.java
@@ -4,7 +4,6 @@
  */
 package com.ibm.streamsx.topology.internal.core;
 
-import com.ibm.streams.flow.declare.OperatorGraph;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.TopologyElement;
 import com.ibm.streamsx.topology.builder.GraphBuilder;

--- a/java/src/com/ibm/streamsx/topology/internal/tester/embedded/EmbeddedTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/embedded/EmbeddedTesterRuntime.java
@@ -5,17 +5,14 @@
 package com.ibm.streamsx.topology.internal.tester.embedded;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.ibm.streams.flow.declare.OutputPortDeclaration;
 import com.ibm.streams.flow.handlers.StreamHandler;
-import com.ibm.streams.flow.javaprimitives.JavaOperatorTester;
 import com.ibm.streams.flow.javaprimitives.JavaTestableGraph;
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.topology.TStream;


### PR DESCRIPTION
No longer use the flow declaration `OperatorGraph` during building the topology, it's only created when needed for embedded execution.