### PR TITLE
Remove addSPLOperator with broken name generator.

### DIFF
--- a/java/src/com/ibm/streamsx/topology/Topology.java
+++ b/java/src/com/ibm/streamsx/topology/Topology.java
@@ -900,7 +900,7 @@ public class Topology implements TopologyElement {
     public void addJobControlPlane() {
         if (!hasJCP) {
             // no inputs, outputs or parameters.
-            builder.addSPLOperator("spl.control::JobControlPlane", Collections.emptyMap());
+            builder.addSPLOperator("JobControlPlane", "spl.control::JobControlPlane", Collections.emptyMap());
             hasJCP = true;
         }        
     }

--- a/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
+++ b/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
@@ -228,14 +228,6 @@ public class GraphBuilder extends BJSONObject {
         return op;
     }
 
-    public BOperatorInvocation addSPLOperator(String kind,
-            Map<String, ? extends Object> params) {
-        
-        String name = kind.contains("::") ?
-                kind.substring(kind.lastIndexOf("::" + 2), kind.length()) :
-                    kind;
-         return addSPLOperator(name, kind, params);
-    }
     public BOperatorInvocation addSPLOperator(String name, String kind,
             Map<String, ? extends Object> params) {
         final BOperatorInvocation op = new BOperatorInvocation(this, kind, params);      


### PR DESCRIPTION
Fixes #1215 - name was being incorrectly calculated (`+2`) was inside `lastIndexOf()` rather than adding two to the returned index. Only used in one place, so removed and have `addJobControlPlane` explicitly set the name.