### PR TITLE
Change approach for mapping names to SPL identifiers

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/BuildServiceRemoteRESTWrapper.java
@@ -5,6 +5,7 @@
 package com.ibm.streamsx.topology.internal.context.remote;
 
 import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.copyJobConfigOverlays;
+import static com.ibm.streamsx.topology.internal.graph.GraphKeys.splAppName;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.array;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.object;
@@ -49,7 +50,10 @@ class BuildServiceRemoteRESTWrapper {
 	void remoteBuildAndSubmit(JsonObject submission, File archive) throws ClientProtocolException, IOException {
 	    JsonObject deploy = DeployKeys.deploy(submission);
 	    JsonObject graph = object(submission, "graph");
-	    String graphBuildName = jstring(graph, "name");
+	    // Use the SPL compatible form of the name to ensure
+	    // that any strange characters in the name provided by
+	    // the user are not rejected by the build service.
+	    String graphBuildName = splAppName(graph);
 	    
 		CloseableHttpClient httpclient = HttpClients.createDefault();
 		try {

--- a/java/src/com/ibm/streamsx/topology/internal/graph/GraphKeys.java
+++ b/java/src/com/ibm/streamsx/topology/internal/graph/GraphKeys.java
@@ -9,9 +9,11 @@ import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.object;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.objectCreate;
 
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 import com.google.gson.JsonObject;
+import com.ibm.streamsx.topology.generator.spl.SPLGenerator;
 
 /**
  * Keys in the JSON graph object for job submission.
@@ -101,12 +103,20 @@ public interface GraphKeys {
             if (ns != null) {
                 StringBuilder nsb = new StringBuilder();
                 StringTokenizer st = new StringTokenizer(ns, ".");
+                String lastElement = null;
                 while (st.hasMoreTokens()) {
                     if (nsb.length() != 0)
                         nsb.append(".");
-                    nsb.append(getSPLCompatibleName(st.nextToken()));
+                    lastElement = st.nextToken();
+                    nsb.append(getSPLCompatibleName(lastElement));
                 }
                 ns = nsb.toString();
+                // Account for the full app name being > 255 (with a margin)
+                // when including file suffixes and separators.
+                if (ns.length() + splAppName(graph).length() > 240) {
+                    ns = "__spl_ns._" + 
+                        SPLGenerator.md5Name(appNamespace(graph).getBytes(StandardCharsets.UTF_8));
+                }
                 graph.addProperty(SPL_NAMESPACE, ns);
             }
         }

--- a/java/src/com/ibm/streamsx/topology/internal/graph/GraphKeys.java
+++ b/java/src/com/ibm/streamsx/topology/internal/graph/GraphKeys.java
@@ -103,12 +103,10 @@ public interface GraphKeys {
             if (ns != null) {
                 StringBuilder nsb = new StringBuilder();
                 StringTokenizer st = new StringTokenizer(ns, ".");
-                String lastElement = null;
                 while (st.hasMoreTokens()) {
                     if (nsb.length() != 0)
                         nsb.append(".");
-                    lastElement = st.nextToken();
-                    nsb.append(getSPLCompatibleName(lastElement));
+                    nsb.append(getSPLCompatibleName(st.nextToken()));
                 }
                 ns = nsb.toString();
                 // Account for the full app name being > 255 (with a margin)

--- a/test/java/src/com/ibm/streamsx/topology/test/TestTopology.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/TestTopology.java
@@ -120,6 +120,9 @@ public class TestTopology {
      */
     protected static Topology newTopology(String name) {
         return new Topology(name + "_" + topoCounter.getAndIncrement() + "_" + baseName);
+    }  
+    protected static Topology newTopology(String ns, String name) {
+        return new Topology(ns, name + "_" + topoCounter.getAndIncrement() + "_" + baseName);
     }   
 
     /**

--- a/test/python/topology/test2_names.py
+++ b/test/python/topology/test2_names.py
@@ -42,6 +42,27 @@ class TestNames(unittest.TestCase):
      tester.contents(hw, ["Hello", "Tester"])
      tester.test(self.test_ctxtype, self.test_config)
 
+  def test_LongTopoNames(self):
+     """ Test long topo names
+     """
+     n = 'abcd8' # * 30
+     ns = 'def9' #* 100
+     topo = Topology(name=n, namespace=ns)
+
+     self.assertEqual(n, topo.name)
+     self.assertEqual(ns, topo.namespace)
+     hw = topo.source(["Hello", "Tester"], name='sourceabc')
+     hw = hw.filter(lambda x : True, name='a'*255)
+     hw = hw.filter(lambda x : True, name='你好'*100)
+     hw = hw.filter(lambda x : True, name='你好')
+     tester = Tester(topo)
+     tester.contents(hw, ["Hello", "Tester"])
+     tester.test(self.test_ctxtype, self.test_config)
+
+class TestCloudNames(TestNames):
+    def setUp(self):
+        Tester.setup_streaming_analytics(self, force_remote_build=True)
+
 class TestContextNames(unittest.TestCase):
     def test_expected_values(self):
         self.assertEqual('DISTRIBUTED', stc.ContextTypes.DISTRIBUTED)


### PR DESCRIPTION
Maps each name that is not a SPL identifier OR over 80 characters to a md5 hash based name from the bytes of the original name.

Fixes #1212 

Uses the SPL mapped identifier of the app name as the base for the build identifier to avoid any problematic names.
Fixes #1217 