### PR TITLE
Add object mapping functions for Python functional operators.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -194,6 +194,12 @@ class _JSONInTupleOut(_FunctionalCallable):
         rv =  self._callable(json.loads(tuple))
         return _verify_tuple(rv)
 
+
+class _JSONInJSONOut(_FunctionalCallable):
+    def __call__(self, tuple):
+        rv = self._callable(json.loads(tuple))
+        return _json_object_out(rv)
+
 ##
 ## Set of functions that wrap the application's Python callable
 ## with a function that correctly handles the input and output
@@ -374,6 +380,7 @@ string_in__object_out = object_in__object_out
 string_in__object_iter = object_in__object_iter
 string_in__pickle_out = object_in__pickle_out
 string_in__pickle_iter = object_in__pickle_iter
+string_in__string_out = object_in__object_out
 string_in__json_out = object_in__json_out
 string_in__dict_out = object_in__dict_out
 string_in = object_in
@@ -383,6 +390,7 @@ json_in__object_iter = _JSONInObjectIter
 json_in__pickle_out = _JSONInPickleOut
 json_in__pickle_iter = _JSONInPickleIter
 json_in__string_out = _JSONInStringOut
+json_in__json_out = _JSONInJSONOut
 json_in__dict_out = _JSONInTupleOut
 json_in = _JSONInObjectOut
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -194,143 +194,60 @@ class _JSONInTupleOut(_FunctionalCallable):
         rv =  self._callable(json.loads(tuple))
         return _verify_tuple(rv)
 
-# Given a callable 'callable', return a function
-# that depickles the input and then calls 'callable'
-# returning the callable's return
-# The returned function must not maintain a reference
-# to the passed in value as it will be a memory view
-# object with memory that will become invalid after the call.
-def pickle_in(callable) :
-    return _PickleInObjectOut(callable)
-
-# Given a callable 'callable', return a function
-# that loads an object from the serialized JSON input
-# and then calls 'callable' returning the callable's return
-def json_in(callable) :
-    return _JSONInObjectOut(callable)
-
-def string_in(callable) :
-    return _FunctionalCallable(callable)
-
-# Given a callable 'callable', return a function
-# that calls 'callable' with a python dictionary object 
-# form of an spltuple returning the callable's return
-def dict_in(callable) :
-    return _FunctionalCallable(callable)
-
 ##
 ## Set of functions that wrap the application's Python callable
 ## with a function that correctly handles the input and output
 ## (return) value. The input is from the SPL operator, i.e.
-## a value obtained from a tuple attribute as a Python object.
+## a value obtained from a tuple (attribute) as a Python object.
 ## The output is the value (as a Python object) to be returned
-## to the SPL operator to be set as a tuple attribute.
+## to the SPL operator to be set as a tuple (attribute).
 ##
 ## The style is one of:
 ##
 ## pickle - Object is a Python byte string representing a picked object.
 ##          The object is depicked/pickled before being passed to/return from
-##          the application function.
+##          the application callable.
+##          he returned function must not maintain a reference
+##          to the passed in value as it will be a memory view
+##          object with memory that will become invalid after the call.
 ##
 ## json - Object is a Python unicode string representing a serialized
 ##          Json object. The object is deserialized/serialized before
-##          being passed to/return from the application function.
+##          being passed to/return from the application callable.
 ##
 ## string - Object is a Python unicode string representing a string
-##          to be passed directly to the Python application function.
+##          to be passed directly to the Python application callable.
 ##          For output the function return is converted to a unicode
 ##          string using str(value).
 ##
 ## dict - Object is a Python dictionary object
 ##          to be passed directly to the Python application function.
-##          For output the function return is converted to a unicode
-##          string using str(value).
+##          For output the function return is expecting a Python
+##          tuple with the values in the correct order for the
+##          the SPL schema. Missing values (not enough fields in
+##          the Python tuple or set to None are set the the SPL
+##          attribute type default.
 ##
-## object - Object is a Python object passed directly into the function
-##          Only used within this file 
-##
-
-###
-# Currently there are only these cases to handle for transform
-#
-#  {pickle,json,string} -> {pickle}
-#  {pickle} ->  {json,string}
-#
-#  Typically the use case is {pickle} -> {pickle}
-#  The other cases are only introduced with publish or subscribe.
-#
-###
-
-## 
-## {pickle,json,string} -> {pickle}
+## object - Object is a Python object passed directly into/ from the callable
+##          Used when passing by ref. In addition since from the Python
+##          point of view string and dict need no transformations
+##          they are mapped to the object versions, e.g.
+##          string_in == dict_in == object_in
 ##
 
-# The returned function must not maintain a reference
-# to the passed in value as it will be a memory view
-# object with memory that will become invalid after the call.
-def pickle_in__pickle_out(callable):
-    return _PickleInPickleOut(callable)
+## The wrapper functions also ensure the correct context is set up for streamsx.ec
+## and the __enter__/__exit__ methods are called.
 
-def json_in__pickle_out(callable):
-    return _JSONInPickleOut(callable)
+## The core functionality of the wrapper functions are implemented as classes
+## with the input_style__output_style (e.g. string_in__json_out) are fields
+## set to the correct class objcet. The class object is called with the application
+## callable and a function the SPL operator will call is returned.
 
-def json_in__string_out(callable):
-    return _JSONInStringOut(callable)
 
-def json_in__object_out(callable):
-    return _JSONInObjectOut(callable)
-
-def json_in__dict_out(callable):
-    return _JSONInTupleOut(callable)
-
-def string_in__pickle_out(callable):
-    return _ObjectInPickleOut(callable)
-
-def string_in__object_out(callable):
-    return _FunctionalCallable(callable)
-
-def string_in__json_out(callable):
-    return _ObjectInJSONOut(callable)
-
-def string_in__dict_out(callable):
-    return _ObjectInTupleOut(callable)
-
-def dict_in__pickle_out(callable):
-    return _ObjectInPickleOut(callable)
-
-def dict_in__object_out(callable):
-    return _FunctionalCallable(callable)
-
-def dict_in__json_out(callable):
-    return _ObjectInJSONOut(callable)
-
-def dict_in__string_out(callable):
-    return _ObjectInStringOut(callable)
-
-def dict_in__dict_out(callable):
-    return _ObjectInTupleOut(callable)
-
-##################################################
-
-##
-##  {pickle} ->  {json,string}
-##
-
-# The returned function must not maintain a reference
-# to the passed in value as it will be a memory view
-# object with memory that will become invalid after the call.
-def pickle_in__json_out(callable):
-    return _PickleInJSONOut(callable)
-
-def pickle_in__string_out(callable):
-    return _PickleInStringOut(callable)
-
-def pickle_in__object_out(callable):
-    return _PickleInObjectOut(callable)
-
-def pickle_in__dict_out(callable):
-    return _PickleInTupleOut(callable)
-
+# Given a callable that returns an iterable
+# return a function that can be called
+# repeatably by a source operator returning
+# the next tuple in its pickled form
 class _IterablePickleOut(_FunctionalCallable):
     def __init__(self, callable):
         super(_IterablePickleOut, self).__init__(callable)
@@ -358,18 +275,6 @@ class _IterableObjectOut(_FunctionalCallable):
                     return tuple
         except StopIteration:
             return None
-
-# Given a function that returns an iterable
-# return a function that can be called
-# repeatably by a source operator returning
-# the next tuple in its pickled form
-def source_pickle(callable) :
-    return _IterablePickleOut(callable)
-
-# Source iterator that returns objects
-# when passing by ref
-def source_object(callable) :
-    return _IterableObjectOut(callable)
 
 # Iterator that wraps another iterator
 # to discard any values that are None
@@ -437,30 +342,55 @@ class _JSONInObjectIter(_ObjectInObjectIter):
     def __call__(self, tuple):
         return super(_JSONInObjectIter, self).__call__(json.loads(tuple))
 
-# The returned function must not maintain a reference
-# to the passed in value as it will be a memory view
-# object with memory that will become invalid after the call.
-def pickle_in__pickle_iter(callable):
-    return _PickleInPickleIter(callable)
 
-def json_in__pickle_iter(callable):
-    return _JSONInPickleIter(callable)
+# Variables used by SPL Python operators to create specific wrapper function.
+#
+# Source: source_style
+# Filter: style_in__style_out (output style is same as input) - (any input style supported)
+# Map: style_in__style_out (any input/output style supported)
+# FlatMap: style_in__style_iter: (any input style supported, pickle/object on output)
+# ForEach: style_in (any style)
 
-def string_in__pickle_iter(callable):
-    return _ObjectInPickleIter(callable)
+source_object = _IterableObjectOut
+object_in__object_out = _FunctionalCallable
+object_in__object_iter = _ObjectInObjectIter
+object_in__pickle_out = _ObjectInPickleOut
+object_in__pickle_iter = _ObjectInPickleIter
+object_in__json_out = _ObjectInJSONOut
+object_in__dict_out = _ObjectInTupleOut
+object_in = _FunctionalCallable
 
-def dict_in__pickle_iter(callable):
-    return _ObjectInPickleIter(callable)
+source_pickle = _IterablePickleOut
+pickle_in__object_out = _PickleInObjectOut
+pickle_in__object_iter = _PickleInObjectIter
+pickle_in__pickle_out = _PickleInPickleOut
+pickle_in__pickle_iter = _PickleInPickleIter
+pickle_in__string_out = _PickleInStringOut
+pickle_in__json_out = _PickleInJSONOut
+pickle_in__dict_out = _PickleInTupleOut
+pickle_in = _PickleInObjectOut
 
-# By reference versions
-def pickle_in__object_iter(callable):
-    return _PickleInObjectIter(callable)
+string_in__object_out = object_in__object_out
+string_in__object_iter = object_in__object_iter
+string_in__pickle_out = object_in__pickle_out
+string_in__pickle_iter = object_in__pickle_iter
+string_in__json_out = object_in__json_out
+string_in__dict_out = object_in__dict_out
+string_in = object_in
 
-def json_in__object_iter(callable):
-    return _JSONInObjectIter(callable)
+json_in__object_out = _JSONInObjectOut
+json_in__object_iter = _JSONInObjectIter
+json_in__pickle_out = _JSONInPickleOut
+json_in__pickle_iter = _JSONInPickleIter
+json_in__string_out = _JSONInStringOut
+json_in__dict_out = _JSONInTupleOut
+json_in = _JSONInObjectOut
 
-def string_in__object_iter(callable):
-    return _ObjectInObjectIter(callable)
-
-def dict_in__object_iter(callable):
-    return _ObjectInObjectIter(callable)
+dict_in__object_out = object_in__object_out
+dict_in__object_iter = object_in__object_iter
+dict_in__pickle_out = object_in__pickle_out
+dict_in__pickle_iter = object_in__pickle_iter
+dict_in__string_out = object_in__object_out
+dict_in__json_out = object_in__json_out
+dict_in__dict_out = object_in__dict_out
+dict_in = object_in

--- a/test/python/topology/test2_python2spl.py
+++ b/test/python/topology/test2_python2spl.py
@@ -29,6 +29,24 @@ class TestPython2SPL(unittest.TestCase):
         tester.contents(st, [{'x':1}, {'x':2}, {'x':3}])
         tester.test(self.test_ctxtype, self.test_config)
 
+    def test_object_to_string(self):
+        topo = Topology()
+        s = topo.source([93,'hello',True])
+        st = s.map(lambda x : x, schema=CommonSchema.String)
+
+        tester = Tester(topo)
+        tester.contents(st, ['93','hello','True'])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_object_to_json(self):
+        topo = Topology()
+        s = topo.source([{'a': 7}, {'b': 8}, {'c': 9}])
+        st = s.map(lambda x: x, schema=CommonSchema.Json)
+
+        tester = Tester(topo)
+        tester.contents(st, [{'a': 7}, {'b': 8}, {'c': 9}])
+        tester.test(self.test_ctxtype, self.test_config)
+
     def test_string_to_schema(self):
         topo = Topology()
         s = topo.source(['a', 'b', 'c']).as_string()
@@ -36,6 +54,24 @@ class TestPython2SPL(unittest.TestCase):
 
         tester = Tester(topo)
         tester.contents(st, [{'y':'astruct!'}, {'y':'bstruct!'}, {'y':'cstruct!'}])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_string_to_string(self):
+        topo = Topology()
+        s = topo.source([False, 'b', 19]).as_string()
+        st = s.map(lambda x: x + '3', schema=CommonSchema.String)
+
+        tester = Tester(topo)
+        tester.contents(st, ['False3', 'b3', '193'])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_string_to_json(self):
+        topo = Topology()
+        s = topo.source(['a', 79, 'c']).as_string()
+        st = s.map(lambda x: x if x == 'c' else {'v': x + 'd'}, schema=CommonSchema.Json)
+
+        tester = Tester(topo)
+        tester.contents(st, [{'v': 'ad'}, {'v': '79d'}, 'c'])
         tester.test(self.test_ctxtype, self.test_config)
 
     def test_json_to_schema(self):
@@ -47,13 +83,51 @@ class TestPython2SPL(unittest.TestCase):
         tester.contents(st, [{'y':'a', 'x':7}, {'y':'b', 'x':8}, {'y':'c', 'x':9}])
         tester.test(self.test_ctxtype, self.test_config)
 
+    def test_json_to_string(self):
+        topo = Topology()
+        s = topo.source([{'a': True}, {'a': 8}, {'a': 'third'}]).as_json()
+        st = s.map(lambda x : x['a'], schema=CommonSchema.String)
+
+        tester = Tester(topo)
+        tester.contents(st, ['True', '8', 'third'])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_json_to_json(self):
+        topo = Topology()
+        s = topo.source([{'a': True}, {'a': 8}, {'a': 'third'}]).as_json()
+        st = s.map(lambda x : {'yy': x['a']}, schema=CommonSchema.Json)
+
+        tester = Tester(topo)
+        tester.contents(st, [{'yy': True}, {'yy': 8}, {'yy': 'third'}])
+        tester.test(self.test_ctxtype, self.test_config)
+
     def test_dict_to_schema(self):
         topo = Topology()
         s = topo.source([{'a':7}, {'b':8}, {'c':9}]).as_json()
         st = s.map(lambda x : (next(iter(x)), x[next(iter(x))]), schema='tuple<rstring y, int32 x>')
-
         st = st.map(lambda x : (x['y'], x['x']+3), schema='tuple<rstring id, int32 value>')
 
         tester = Tester(topo)
         tester.contents(st, [{'id':'a', 'value':10}, {'id':'b', 'value':11}, {'id':'c', 'value':12}])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_dict_to_string(self):
+        topo = Topology()
+        s = topo.source([{'a':7}, {'b':8}, {'c':9}]).as_json()
+        st = s.map(lambda x : (next(iter(x)), x[next(iter(x))]), schema='tuple<rstring y, int32 x>')
+
+        st = st.map(lambda x : (x['y'], x['x']+20), schema=CommonSchema.String)
+
+        tester = Tester(topo)
+        tester.contents(st, ["('a', 27)", "('b', 28)", "('c', 29)"])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_dict_to_json(self):
+        topo = Topology()
+        s = topo.source([{'a':7}, {'b':8}, {'c':9}]).as_json()
+        st = s.map(lambda x: (next(iter(x)), x[next(iter(x))]), schema='tuple<rstring y, int32 x>')
+        st = st.map(lambda x: x, schema=CommonSchema.Json)
+
+        tester = Tester(topo)
+        tester.contents(st, [{'y': 'a', 'x': 7}, {'y':'b', 'x': 8}, {'y':'c', 'x': 9}])
         tester.test(self.test_ctxtype, self.test_config)


### PR DESCRIPTION
- Adds object mapping like `object_in_object_out`
- Changes the _style_ functions to be variables that reference the required callable class either directly or through another variable
- Moves the _style_ variables to a single location which exposed #1230 and #1231
- Add additional tests to cover all the combinations where a schema can be changed.
- Fixes #1230 #1231