### PR TITLE
Passing as tuple support

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter.xml
@@ -81,6 +81,15 @@
         <type>int32</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>pyStyle</name>
+        <description>Style stream tuples are passed into Python.</description>
+        <optional>true</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Constant</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -49,15 +49,8 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-  IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
+@include "../pyspltuple2value.cgt"
 
-<%
-print splpy_inputtuple2value($pystyle);
-%>
-
-<%if ($pystyle eq 'dict') {%>
-@include "../pyspltuple2dict.cgt"
-<%}%>
   if (streamsx::topology::Splpy::pyTupleFilter(funcop_->callable(), value)) {
       submit(tuple, 0);
   }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap.xml
@@ -81,6 +81,15 @@
         <type>int32</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>pyStyle</name>
+        <description>Style stream tuples are passed into Python.</description>
+        <optional>true</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Constant</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
@@ -90,19 +90,11 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-  IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
-
-<%
-print splpy_inputtuple2value($pystyle);
-%>
+@include "../pyspltuple2value.cgt"
   
   std::vector<OPort0Type> output_tuples; 
   
   {
-<%if ($pystyle eq 'dict') {%>
-@include "../pyspltuple2dict.cgt"
-<%}%>
-
     SplpyGIL lock;
 
     PyObject * pyIterator = streamsx::topology::pySplProcessTuple(funcop_->callable(), value);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach.xml
@@ -69,6 +69,15 @@
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>pyStyle</name>
+        <description>Style stream tuples are passed into Python.</description>
+        <optional>true</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Constant</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -57,6 +57,9 @@ print splpy_inputtuple2value($pystyle);
 <%if ($pystyle eq 'dict') {%>
 @include "../pyspltuple2dict.cgt"
 <%}%>
+<%if ($pystyle eq 'tuple') {%>
+@include "../pyspltuple2tuple.cgt"
+<%}%>
   streamsx::topology::Splpy::pyTupleForEach(funcop_->callable(), value);
 }
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -49,17 +49,8 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-  IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
+@include "../pyspltuple2value.cgt"
 
-<%
-print splpy_inputtuple2value($pystyle);
-%>
-<%if ($pystyle eq 'dict') {%>
-@include "../pyspltuple2dict.cgt"
-<%}%>
-<%if ($pystyle eq 'tuple') {%>
-@include "../pyspltuple2tuple.cgt"
-<%}%>
   streamsx::topology::Splpy::pyTupleForEach(funcop_->callable(), value);
 }
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder.xml
@@ -72,6 +72,15 @@
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>pyStyle</name>
+        <description>Style stream tuples are passed into Python.</description>
+        <optional>true</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Constant</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -49,26 +49,21 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-  IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
+@include "../pyspltuple2value.cgt"
 
-<%
-print splpy_inputtuple2value($pystyle);
-%>
-
-<%if ($pystyle eq 'dict') {%>
-@include "../pyspltuple2dict.cgt"
+<%if ($pystyle eq 'dict' || $pystyle eq 'tuple') {%>
 
   OPort0Type otuple;
   otuple.assignFrom(ip, false);
   otuple.set___spl_hash(streamsx::topology::Splpy::pyTupleHash(funcop_->callable(), value));
 
-<%}%>
+<%} else { %>
 
-<%if ($pystyle ne 'dict') {%>
-
+  // value is the first matching attribute and an SPL:: reference
   OPort0Type otuple(value,
        streamsx::topology::Splpy::pyTupleHash(funcop_->callable(), value));
 <%}%>
+
   // submit tuple
   submit(otuple, 0);
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map.xml
@@ -81,6 +81,15 @@
         <type>int32</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>pyStyle</name>
+        <description>Style stream tuples are passed into Python.</description>
+        <optional>true</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Constant</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -83,15 +83,7 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-  IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
-
-<%
-print splpy_inputtuple2value($pystyle);
-%>
-
-<%if ($pystyle eq 'dict') {%>
-@include "../pyspltuple2dict.cgt"
-<%}%>
+@include "../pyspltuple2value.cgt"
 
   OPort0Type otuple;
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
@@ -19,6 +19,11 @@
 
  # determine which input tuple style is being used
 
- my $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
+ my $pystyle = $model->getParameterByName("pyStyle");
+ if ($pystyle) {
+     $pystyle = substr $pystyle->getValueAt(0)->getSPLExpression(), 1, -1;
+ } else {
+     $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
+ }
 %>
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2tuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2tuple.cgt
@@ -1,0 +1,21 @@
+
+// process the attributes in the spl tuple
+// into a python tuple object
+<%
+# Fix up names for blobs script
+my $inputAttrs2Py = $pynumattrs;
+my @itypes = @pyatypes;
+%>
+@include "../opt/python/codegen/py_splTupleCheckForBlobs.cgt"
+
+  PyObject *value = 0;
+  {
+  SplpyGIL locktuple;
+  PyObject * pyTuple = PyTuple_New(<%=$pynumattrs%>);
+<%
+     for (my $i = 0; $i < $pynumattrs; ++$i) {
+         print convertAndAddToPythonTupleObject("ip", $i, $pyatypes[$i], $pyanames[$i]);
+     }
+%>
+  value = pyTuple;
+  }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2value.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2value.cgt
@@ -1,0 +1,12 @@
+  // Set up the variable value to represent the SPL tuple on port 0
+  // (see splpy_tuple.h for details)
+  IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
+
+<%
+print splpy_inputtuple2value($pystyle);
+if ($pystyle eq 'dict') {
+%>
+@include "pyspltuple2dict.cgt"
+<% } elsif ($pystyle eq 'tuple') { %>
+@include "pyspltuple2tuple.cgt"
+<% } %>

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -277,6 +277,30 @@ sub convertAndAddToPythonDictionaryObject {
   return $get . $getkey . $setdict . "}\n" ;
 }
 
+#
+# Convert attribute of an SPL tuple to Python
+# and add to a tuple object.
+#
+# ituple - C++ expression of the tuple
+# i  - Attribute index
+# type - spl type
+# name - attribute name
+# names - PyObject * pointing to Python tuple containing attribute names.
+
+sub convertAndAddToPythonTupleObject {
+  my $ituple = $_[0];
+  my $i = $_[1];
+  my $type = $_[2];
+  my $name = $_[3];
+
+  # starts a C++ blockand sets value
+  my $get = _attr2Value($ituple, $type, $name);
+
+  my $settuple =  "PyTuple_SET_ITEM(pyTuple, $i, value);\n";
+
+  return $get . $settuple . "}\n" ;
+}
+
 ## Execute pip to install packages in the
 ## applications output directory under
 ## /etc/streamsx.topology/python

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_tuple.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_tuple.h
@@ -47,6 +47,23 @@ namespace streamsx {
       return pyReturnVar;
     }
 
+
+  /**
+   *  An SPL tuple is passed to Python through pySplProcessTuple.
+   *  The generated code performs a first step in converting
+   *  the specific SPL tuple instance to a value (through
+   *  the cgt file pyspltuple2value.cgt) that is passed
+   *  as the second argument to pySplProcessTuple.
+   *  This first step convertds as follows:
+   *
+   *  CommonSchema.Python (pickle): SPL::blob & representing the single SPL attribute '__spl_po'
+   *  CommonSchema.String (string): SPL::rstring & representing the single SPL attribute 'string'
+   *  CommonSchema.Json (json): SPL::rstring & representing the single SPL attribute 'jsonString'
+   *  SPL Schema (dict):  PyObject * that is a dict object with all attributes of the SPL schema
+   *  SPL Schema (tuple):  PyObject * that is a tuple object with all attributes of the SPL schema in order
+   *
+   */
+
   /**
    * Convert the SPL tuple that represents a Python object
    * to a Python tuple that holds as its first argument:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -240,6 +240,11 @@ class _JSONInJSONOut(_FunctionalCallable):
 ##          they are mapped to the object versions, e.g.
 ##          string_in == dict_in == object_in
 ##
+## tuple - Object is an SPL schema passed as a regular Python tuple. The
+##         order of the Python tuple values matches the order of
+##         attributes in the schema. Upon return a tuple is expected
+##         like the dict style.
+##
 
 ## The wrapper functions also ensure the correct context is set up for streamsx.ec
 ## and the __enter__/__exit__ methods are called.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -349,6 +349,7 @@ class _JSONInObjectIter(_ObjectInObjectIter):
         return super(_JSONInObjectIter, self).__call__(json.loads(tuple))
 
 
+<<<<<<< HEAD
 # Variables used by SPL Python operators to create specific wrapper function.
 #
 # Source: source_style
@@ -402,3 +403,5 @@ dict_in__string_out = object_in__object_out
 dict_in__json_out = object_in__json_out
 dict_in__dict_out = object_in__dict_out
 dict_in = object_in
+
+tuple_in = object_in

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -408,4 +408,11 @@ dict_in__json_out = object_in__json_out
 dict_in__dict_out = object_in__dict_out
 dict_in = object_in
 
+tuple_in__object_out = object_in__object_out
+tuple_in__object_iter = object_in__object_iter
+tuple_in__pickle_out = object_in__pickle_out
+tuple_in__pickle_iter = object_in__pickle_iter
+tuple_in__string_out = object_in__object_out
+tuple_in__json_out = object_in__json_out
+tuple_in__dict_out = object_in__dict_out
 tuple_in = object_in

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -349,7 +349,6 @@ class _JSONInObjectIter(_ObjectInObjectIter):
         return super(_JSONInObjectIter, self).__call__(json.loads(tuple))
 
 
-<<<<<<< HEAD
 # Variables used by SPL Python operators to create specific wrapper function.
 #
 # Source: source_style

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -37,7 +37,7 @@ def is_common(schema):
         return True
     if isinstance(schema, str):
         return is_common(StreamSchema(schema))
-    raise TypeError()
+    return False
 
 # Parses a schema of the form 'tuple<...>'
 # _parse returns a list of the schema attributes,

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -368,7 +368,7 @@ class Topology(object):
             if _name is None:
                 _name = type(func).__name__
             func = streamsx.topology.functions._IterableInstance(func)
-        
+
         sl = _SourceLocation(_source_info(), "source")
         _name = self.graph._requested_name(_name, action='source', func=func)
         op = self.graph.addOperator(self.opnamespace+"::Source", func, name=_name, sl=sl)
@@ -503,6 +503,7 @@ class Stream(object):
         _name = self.topology.graph._requested_name(name, action='for_each', func=func)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::ForEach", func, name=_name, sl=sl)
         op.addInputPort(outputPort=self.oport, name=self.name)
+        StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')
         op._layout(kind='ForEach', name=_name, orig_name=name)
         return Sink(op)
 
@@ -627,7 +628,7 @@ class Stream(object):
             a structured stream.
         """
         if schema is None:
-             schema = CommonSchema.Python
+            schema = CommonSchema.Python
      
         ms = self._map(func, schema=schema, name=name)._layout('Map')
         ms.oport.operator.sl = _SourceLocation(_source_info(), 'map')
@@ -1202,7 +1203,7 @@ class PendingStream(object):
         def __init__(self, topology):
             self.topology = topology
             self._marker = topology.graph.addOperator(kind="$Pending$")
-            self._pending_schema = StreamSchema('<pending')
+            self._pending_schema = StreamSchema('<pending>')
 
             self.stream = Stream(topology, self._marker.addOutputPort(schema=self._pending_schema))
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -533,6 +533,7 @@ class Stream(object):
         _name = self.topology.graph._requested_name(name, action="filter", func=func)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::Filter", func, name=_name, sl=sl)
         op.addInputPort(outputPort=self.oport, name=self.name)
+        StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')
         op._layout(kind='Filter', name=_name, orig_name=name)
         oport = op.addOutputPort(schema=self.oport.schema, name=_name)
         return Stream(self.topology, oport)._make_placeable()
@@ -541,6 +542,7 @@ class Stream(object):
         _name = self.topology.graph._requested_name(name, action="map", func=func)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::Map", func, name=_name)
         op.addInputPort(outputPort=self.oport, name=self.name)
+        StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')
         oport = op.addOutputPort(schema=schema, name=_name)
         op._layout(name=_name, orig_name=name)
         return Stream(self.topology, oport)._make_placeable()
@@ -669,6 +671,7 @@ class Stream(object):
         _name = self.topology.graph._requested_name(name, action='flat_map', func=func)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::FlatMap", func, name=_name, sl=sl)
         op.addInputPort(outputPort=self.oport, name=self.name)
+        StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')
         oport = op.addOutputPort(name=_name)
         return Stream(self.topology, oport)._make_placeable()._layout('FlatMap', name=_name, orig_name=name)
     
@@ -785,6 +788,7 @@ class Stream(object):
                 hash_adder._layout(hidden=True)
                 hash_schema = self.oport.schema.extend(StreamSchema("tuple<int64 __spl_hash>"))
                 hash_adder.addInputPort(outputPort=self.oport, name=self.name)
+                StreamSchema._fnop_style(self.oport.schema, hash_adder, 'pyStyle')
                 parallel_input = hash_adder.addOutputPort(schema=hash_schema)
 
             parallel_op = self.topology.graph.addOperator("$Parallel$", name=_name)

--- a/test/python/topology/test2_schema_tuple.py
+++ b/test/python/topology/test2_schema_tuple.py
@@ -1,0 +1,42 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016
+import unittest
+import sys
+import itertools
+
+import test_vers
+
+from streamsx.topology.topology import *
+from streamsx.topology.schema import StreamSchema
+from streamsx.topology.tester import Tester
+
+"""
+Test that structured schemas can be passed into Python functions as tuples.
+"""
+
+def check_is_tuple(t):
+    if type(t) != tuple:
+        raise ValueError("Expected a tuple:" + str(t) + " >> type:" + str(type(t)))
+
+def check_is_tuple_for_each(t):
+    check_is_tuple(t)
+    if t[1] != str(t[0]*2) + "Hi!":
+        raise ValueError("Incorrect value:" + str(t))
+
+@unittest.skipIf(not test_vers.tester_supported() , "tester not supported")
+class TestSchemaTuple(unittest.TestCase):
+    """ Test invocations handling of SPL schemas in Python ops.
+    """
+    def setUp(self):
+        Tester.setup_standalone(self)
+
+    def test_as_tuple_for_each(self):
+        topo = Topology()
+        s = topo.source([1,2,3])
+        schema=StreamSchema('tuple<int32 x, rstring msg>').as_tuple()
+        st = s.map(lambda x : (x,str(x*2) + "Hi!"), schema=schema)
+        st.for_each(check_is_tuple_for_each)
+
+        tester = Tester(topo)
+        tester.tuple_count(st, 3)
+        tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/topology/test2_schema_tuple.py
+++ b/test/python/topology/test2_schema_tuple.py
@@ -23,6 +23,37 @@ def check_is_tuple_for_each(t):
     if t[1] != str(t[0]*2) + "Hi!":
         raise ValueError("Incorrect value:" + str(t))
 
+def check_is_tuple_filter(t):
+    check_is_tuple_for_each(t)
+    return t[0] != 2
+
+def check_is_tuple_hash(t):
+    print("ISHASH:", t, flush=True)
+    check_is_tuple_for_each(t)
+    print("ISHASH_RET:", t[0], flush=True)
+    return t[0]
+
+def check_is_tuple_map(t):
+    check_is_tuple(t)
+    return (t[0]*7, t[1] + "-Map")
+
+
+def check_is_tuple_map_to_string(t):
+    check_is_tuple(t)
+    return str(t[0]*11) + t[1] + "-MapString"
+
+def check_is_tuple_map_to_schema(t):
+    check_is_tuple(t)
+    return (t[0]*13, t[1] + "-MapSPL")
+
+def check_is_tuple_flat_map(t):
+    check_is_tuple(t)
+    return [(t[0]*9, t[1] + "-FlatMap")]
+
+def check_is_tuple_map_to_json(t):
+    check_is_tuple(t)
+    return {'a':t[0]*15, 'b':t[1] + "-MapJSON"}
+
 @unittest.skipIf(not test_vers.tester_supported() , "tester not supported")
 class TestSchemaTuple(unittest.TestCase):
     """ Test invocations handling of SPL schemas in Python ops.
@@ -30,13 +61,83 @@ class TestSchemaTuple(unittest.TestCase):
     def setUp(self):
         Tester.setup_standalone(self)
 
-    def test_as_tuple_for_each(self):
-        topo = Topology()
+    def _create_stream(self, topo):
         s = topo.source([1,2,3])
         schema=StreamSchema('tuple<int32 x, rstring msg>').as_tuple()
-        st = s.map(lambda x : (x,str(x*2) + "Hi!"), schema=schema)
+        return s.map(lambda x : (x,str(x*2) + "Hi!"), schema=schema)
+
+    def test_as_tuple_for_each(self):
+        topo = Topology()
+        st = self._create_stream(topo)
         st.for_each(check_is_tuple_for_each)
 
         tester = Tester(topo)
         tester.tuple_count(st, 3)
         tester.test(self.test_ctxtype, self.test_config)
+
+    def test_as_tuple_map(self):
+        topo = Topology()
+        s = self._create_stream(topo)
+        st = s.map(check_is_tuple_map)
+
+        tester = Tester(topo)
+        tester.contents(st, [(7,'2Hi!-Map'), (14,'4Hi!-Map'), (21,'6Hi!-Map')])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_as_tuple_filter(self):
+        topo = Topology()
+        s = self._create_stream(topo)
+        s = s.filter(check_is_tuple_filter)
+
+        tester = Tester(topo)
+        tester.tuple_count(s, 2)
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_as_tuple_flat_map(self):
+        topo = Topology()
+        s = self._create_stream(topo)
+        st = s.flat_map(check_is_tuple_flat_map)
+
+        tester = Tester(topo)
+        tester.contents(st, [(9,'2Hi!-FlatMap'), (18,'4Hi!-FlatMap'), (27,'6Hi!-FlatMap')])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_as_tuple_hash(self):
+        topo = Topology()
+        s = self._create_stream(topo)
+        s = s.parallel(width=2, routing=Routing.HASH_PARTITIONED, func=check_is_tuple_hash)
+        s = s.map(check_is_tuple_map)
+        s = s.end_parallel()
+
+        tester = Tester(topo)
+        tester.contents(s, [(7,'2Hi!-Map'), (14,'4Hi!-Map'), (21,'6Hi!-Map')], ordered=False)
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_as_tuple_map_to_string(self):
+        topo = Topology()
+        s = self._create_stream(topo)
+        st = s.map(check_is_tuple_map_to_string, schema=CommonSchema.String)
+
+        tester = Tester(topo)
+        tester.contents(st, ['112Hi!-MapString', '224Hi!-MapString', '336Hi!-MapString'])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_as_tuple_map_to_schema(self):
+        topo = Topology()
+        s = self._create_stream(topo)
+        st = s.map(check_is_tuple_map_to_schema, schema=StreamSchema('tuple<int32 y, rstring txt>'))
+
+        tester = Tester(topo)
+        tester.contents(st, [{'y':13, 'txt':'2Hi!-MapSPL'}, {'y':26, 'txt':'4Hi!-MapSPL'}, {'y':39, 'txt':'6Hi!-MapSPL'}])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_as_tuple_map_to_json(self):
+        topo = Topology()
+        s = self._create_stream(topo)
+        s = s.map(check_is_tuple_map_to_json, schema=CommonSchema.Json)
+        s = s.map(lambda x : str(x['a']) + x['b'])
+
+        tester = Tester(topo)
+        tester.contents(s, ['152Hi!-MapJSON', '304Hi!-MapJSON', '456Hi!-MapJSON'])
+        tester.test(self.test_ctxtype, self.test_config)
+

--- a/test/python/topology/test_schemas.py
+++ b/test/python/topology/test_schemas.py
@@ -134,6 +134,7 @@ class TestSchema(unittest.TestCase):
         s = _sch.StreamSchema('tuple<set<list<int32>[9]>[100] a>')
 
 
+    @unittest.skip
     def test_named_schema(self):
         s = _sch.StreamSchema('tuple<int32 a, boolean alert>')
 
@@ -146,6 +147,48 @@ class TestSchema(unittest.TestCase):
         self.assertFalse(t.alert)
         self.assertEqual(345, t[0])
         self.assertFalse(t[1])
+
+    def test_common_styles(self):
+        """ Test that common schemas cannot have their style changed"""
+        s = _sch.CommonSchema.Python
+        st = s.value.as_tuple()
+        self.assertIs(s.value, st)
+
+        s = _sch.CommonSchema.String
+        st = s.value.as_tuple()
+        self.assertIs(s.value, st)
+
+        s = _sch.CommonSchema.Json
+        st = s.value.as_tuple()
+        self.assertIs(s.value, st)
+
+        s = _sch.CommonSchema.Binary
+        st = s.value.as_tuple()
+        self.assertIs(s.value, st)
+
+        s = _sch.CommonSchema.XML
+        st = s.value.as_tuple()
+        self.assertIs(s.value, st)
+
+    def test_styles(self):
+        s = _sch.StreamSchema('tuple<int32 a, boolean alert>')
+        self.assertEqual(dict, s.style)
+        st = s.as_tuple()
+        self.assertIsNot(s, st)
+        self.assertEqual(tuple, st.style)
+
+        sd = s.as_dict()
+        self.assertIs(s, sd)
+        self.assertEqual(dict, sd.style)
+
+        sd2 = st.as_dict()
+        self.assertIsNot(st, sd2)
+        self.assertEqual(dict, sd2.style)
+
+        self.assertEqual(object, _sch.CommonSchema.Python.value.style)
+        self.assertEqual(str, _sch.CommonSchema.String.value.style)
+        self.assertEqual(dict, _sch.CommonSchema.Json.value.style)
+
 
 class TestKeepSchema(unittest.TestCase):
     """


### PR DESCRIPTION
**updated** Now supports `map`, `filter`, `for_each`, `parallel (hash)`, `flat_map`.

Allows a `StreamSchema` to be modified to indicate for a structured stream that its stream tuples are to be passed as instances of `tuple` instead of `dict`.

```
# Existing/default - values passed as dict objects with the attribute names being the keys. 
sd = StreamSchema('tuple<rstring id, float64 value>')

# s1 is a a stream with the schema 'tuple<rstring id, float64 value>' and
# any processing against the stream will have stream tuples passed as dict objects
# e.g. {'id': 'Sensor', 'value': 23.2}
s1 = s.map(fm, schema=sd)

# So fs will be called as fs( {'id': 'Sensor', 'value': 23.2} )
def fs(t):
    print("Sensor:" + t['id'] + '=' + str(t['value']))
s1.for_each(fs)
```

Now by calling `as_tuple()` against the `StreamSchema` object a stream can be created where its stream tuples will be processed as tuple objects.

```
# New - values passed as tuple objects with the values being in order of the schema
sd = StreamSchema('tuple<rstring id, float64 value>').as_tuple()

# s1 is a a stream with the schema 'tuple<rstring id, float64 value>' and
# any processing against the stream will have stream tuples passed as tuple objects
# e.g. ('Sensor', 23.2)
s1 = s.map(fm, schema=sd)

# So callable fs will be called as fs( ('Sensor', 'value': 23.2) )
def fs(t):
    print("Sensor:" + t[0] + '=' + str(t[1]))
s1.for_each(fs)
```

@wmarshall484 Review requested for the api changes mainly, `as_tuple`, `as_dict` and `style` methods on `StreamSchema`.

WIP for #1235 - only regular `tuple` support.