### PR TITLE
Use decorated class & function directly

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -442,8 +442,8 @@ def _get_opc(obj):
         raise AssertionError("InternalError")
 
 def _shutdown_op(callable):
-    if hasattr(callable, '_shutdown'):
-        callable._shutdown()
+    if hasattr(callable, '_splpy_shutdown'):
+        callable._splpy_shutdown()
 
 def _callable_enter(callable):
     """Called at initialization time.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
@@ -62,10 +62,10 @@ def _splpy_to_tuples(fn, attributes):
              lt.append(ev)
          return lt
       return value
-   if hasattr(fn, '_shutdown'):
-       def _shutdown():
-           fn._shutdown()
-       _to_tuples._shutdown = _shutdown
+   if hasattr(fn, '_splpy_shutdown'):
+       def _splpy_shutdown():
+           fn._splpy_shutdown()
+       _to_tuples._splpy_shutdown = _splpy_shutdown
    return _to_tuples
 
 def _splpy_release_memoryviews(*args):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -594,28 +594,19 @@ def _wrapforsplop(optype, wrapped, style, docpy):
 
         _valid_identifier(wrapped.__name__)
 
-        class _op_class(object):
+        class _op_class(wrapped):
 
             __doc__ = wrapped.__doc__
+
             @functools.wraps(wrapped.__init__)
             def __init__(self,*args,**kwargs):
-                self.__splpy_instance = wrapped(*args,**kwargs)
+                super(_op_class, self).__init__(*args,**kwargs)
                 if ec._is_supported():
-                    ec._save_opc(self.__splpy_instance)
-                ec._callable_enter(self.__splpy_instance)
+                    ec._save_opc(self)
+                ec._callable_enter(self)
 
-            if hasattr(wrapped, "__call__"):
-                @functools.wraps(wrapped.__call__)
-                def __call__(self, *args,**kwargs):
-                    return self.__splpy_instance.__call__(*args, **kwargs)
-
-            if hasattr(wrapped, "__iter__"):
-                @functools.wraps(wrapped.__iter__)
-                def __iter__(self):
-                    return self.__splpy_instance.__iter__()
-
-            def _shutdown(self):
-                ec._callable_exit_clean(self.__splpy_instance)
+            def _splpy_shutdown(self):
+                ec._callable_exit_clean(self)
 
         _op_class.__wrapped__ = wrapped
         # _op_class.__doc__ = wrapped.__doc__
@@ -630,12 +621,21 @@ def _wrapforsplop(optype, wrapped, style, docpy):
 
     _valid_identifier(wrapped.__name__)
 
-    @functools.wraps(wrapped)
-    def _op_fn(*args, **kwargs):
-        return wrapped(*args, **kwargs)
+    #fnstyle =
+
+    #if fnstyle == 'tuple':
+    #    @functools.wraps(wrapped)
+    #    def _op_fn(*args):
+    #        return wrapped(args)
+    #else:
+    #    @functools.wraps(wrapped)
+    #    def _op_fn(*args, **kwargs):
+    #       return wrapped(*args, **kwargs)
+    _op_fn = wrapped
+
     _op_fn.__splpy_optype = optype
     _op_fn.__splpy_callable = 'function'
-    _op_fn.__splpy_style = _define_style(wrapped, wrapped, style)
+    _op_fn.__splpy_style = _define_style(_op_fn, _op_fn, style)
     _op_fn.__splpy_file = inspect.getsourcefile(wrapped)
     _op_fn.__splpy_docpy = docpy
     return _op_fn

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -105,7 +105,7 @@ class _FunctionalCallable(object):
         """
         return self._callable(tuple)
 
-    def _shutdown(self):
+    def _splpy_shutdown(self):
         if self._cls:
             ec._callable_exit_clean(self._callable)
 


### PR DESCRIPTION
Improves performance. Meta data required for extract is added to the decorated object.