### PR TITLE
Add @spl.primitive_operator

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -544,11 +544,12 @@ else:
   raise ValueError("Python version not supported.")
 ############################################
 
-_OperatorType = Enum('_OperatorType', 'Ignore Source Sink Pipe Filter')
+_OperatorType = Enum('_OperatorType', 'Ignore Source Sink Pipe Filter Primitive')
 _OperatorType.Source.spl_template = 'PythonFunctionSource'
 _OperatorType.Pipe.spl_template = 'PythonFunctionPipe'
 _OperatorType.Sink.spl_template = 'PythonFunctionSink'
 _OperatorType.Filter.spl_template = 'PythonFunctionFilter'
+_OperatorType.Primitive.spl_template = 'PythonPrimitive'
 
 _SPL_KEYWORDS = {'graph', 'stream', 'public', 'composite', 'input', 'output', 'type', 'config', 'logic',
                  'window', 'param', 'onTuple', 'onPunct', 'onProcess', 'state', 'stateful', 'mutable',
@@ -860,3 +861,33 @@ class for_each:
 
     def __call__(self, wrapped):
         return _wrapforsplop(_OperatorType.Sink, wrapped, self.style, self.docpy)
+
+
+class primitive_operator(object):
+    """
+    Decorator that creates an SPL operator from a class.
+
+    WIP: Initial state is just the creation of an operator
+    with no inputs or outputs.
+
+    An SPL operator with an arbitrary number of input and
+    output ports (TODO: port handling).
+
+    Args:
+       style: How an SPL tuple is passed into Python function, see  :ref:`spl-tuple-to-python`.
+       docpy: Copy Python docstrings into SPL operator model for SPLDOC.
+
+    """
+    def __init__(self, style=None, docpy=True):
+        self.style = style
+        self.docpy = docpy
+    def __call__(self, wrapped):
+        if not inspect.isclass(wrapped):
+            raise TypeError('A class is required:' + str(wrapped))
+
+        _valid_identifier(wrapped.__name__)
+
+        cls = _wrapforsplop(_OperatorType.Primitive, wrapped, self.style, self.docpy)
+
+        return cls
+

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive.xml
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     # Licensed Materials - Property of IBM
+     # Copyright IBM Corp. 2017
+-->
+<operatorModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ibm.com/xmlns/prod/streams/spl/operator" xmlns:cmn="http://www.ibm.com/xmlns/prod/streams/spl/common" xsi:schemaLocation="http://www.ibm.com/xmlns/prod/streams/spl/operator operatorModel.xsd">
+  <cppOperatorModel>
+    <context>
+      <description>
+__SPLPY__DESCRIPTION__SPLPY__
+      </description>
+      <iconUri size="16">../../opt/.__splpy/icons/python-powered16.gif</iconUri>
+      <iconUri size="32">../../opt/.__splpy/icons/python-powered32.gif</iconUri>
+      <metrics>
+      </metrics>
+      <libraryDependencies>
+        <library>
+          <cmn:description>SPLPY header</cmn:description>
+          <cmn:managedLibrary>
+            <cmn:includePath>../../opt/.__splpy/include</cmn:includePath>
+          </cmn:managedLibrary>
+        </library>
+        <library>
+          <cmn:description>Python libraries.</cmn:description>
+          <cmn:managedLibrary>
+            <cmn:command>../../opt/.__splpy/common/pyversion__SPLPY__MAJOR_VERSION__SPLPY__.sh</cmn:command>
+          </cmn:managedLibrary>
+        </library>
+      </libraryDependencies>
+      <providesSingleThreadedContext>Always</providesSingleThreadedContext>
+      <allowCustomLogic>false</allowCustomLogic>
+    </context>
+    <parameters>
+      <allowAny>false</allowAny>
+      __SPLPY__PARAMETERS__SPLPY__
+    </parameters>
+    <inputPorts>
+<!-- __SPLPY__INPORTS__SPLPY__ -->
+    </inputPorts>
+    <outputPorts>
+    </outputPorts>
+  </cppOperatorModel>
+</operatorModel>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -1,0 +1,53 @@
+/*
+ * # Licensed Materials - Property of IBM
+ * # Copyright IBM Corp. 2015,2016
+ */
+
+#include "splpy.h"
+#include "splpy_pyop.h"
+
+using namespace streamsx::topology;
+
+<%SPL::CodeGen::implementationPrologue($model);%>
+
+<%
+ my $cmnDir = $model->getContext()->getToolkitDirectory()."/opt/.__splpy/common/";
+
+ require "splpy_operator.pm";
+ require $cmnDir."/splpy.pm";
+
+ my $module = splpy_Module();
+ my $functionName = splpy_FunctionName();
+ my @packages = splpy_Packages();
+ spl_pip_packages($model, \@packages);
+%>
+
+// Constructor
+MY_OPERATOR::MY_OPERATOR() :
+    pyop_(NULL)
+{
+   PyObject * callable;
+@include  "../../opt/.__splpy/common/py_constructor.cgt"
+
+   pyop_->setCallable(callable);
+}
+
+// Destructor
+MY_OPERATOR::~MY_OPERATOR() 
+{
+   SplpyGIL lock;
+   delete pyop_;
+}
+
+// Notify pending shutdown
+void MY_OPERATOR::prepareToShutdown() 
+{
+    pyop_->prepareToShutdown();
+}
+
+// Tuple processing for non-mutating ports
+void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
+{
+}
+
+<%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -1,0 +1,33 @@
+/*
+ * # Licensed Materials - Property of IBM
+ * # Copyright IBM Corp. 2015  
+ */
+
+#include "splpy_pyop.h"
+
+using namespace streamsx::topology;
+
+<%SPL::CodeGen::headerPrologue($model);%>
+
+class MY_OPERATOR : public MY_BASE_OPERATOR 
+{
+public:
+  // Constructor
+  MY_OPERATOR();
+
+  // Destructor
+  virtual ~MY_OPERATOR(); 
+
+  // Notify pending shutdown
+  void prepareToShutdown(); 
+
+  // Tuple processing for non-mutating ports
+  void process(Tuple const & tuple, uint32_t port);
+
+private:
+  // Members
+    SplpyPyOp *pyop_;
+}; 
+
+<%SPL::CodeGen::headerEpilogue($model);%>
+

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -1,0 +1,42 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016
+import os
+import unittest
+import sys
+import itertools
+
+from streamsx.topology.topology import *
+from streamsx.topology.tester import Tester
+from streamsx.topology import schema
+import streamsx.topology.context
+import streamsx.spl.op as op
+import streamsx.spl.toolkit
+
+class TestPrimitives(unittest.TestCase):
+    """ 
+    Test @spl.primitive_operator decorated operators
+    """
+    def setUp(self):
+        Tester.setup_distributed(self)
+
+    def _noports_check(self):
+        job = self.tester.submission_result.job
+        import time
+        ops = job.get_operators()
+        print(ops, flush=True)
+        self.assertEqual(1, len(ops))
+        ms = ops[0].get_metrics(name='NP_mymetric')
+        self.assertEqual(1, len(ms))
+        m = ms[0]
+        self.assertEqual('NP_mymetric', m.name)
+        self.assertEqual(89, m.value)
+
+    def test_noports(self):
+        """Operator with no inputs or outputs"""
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+        bop = op.Invoke(topo, "com.ibm.streamsx.topology.pytest.pyprimitives::NoPorts", params = {'mn': 'mymetric', 'iv':89})
+
+        self.tester = Tester(topo)
+        self.tester.local_check = self._noports_check
+        self.tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
@@ -1,0 +1,29 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+
+# Import the SPL decorators
+from streamsx.spl import spl
+
+#------------------------------------------------------------------
+# Test passing in SPL types functions
+#------------------------------------------------------------------
+
+# Defines the SPL namespace for any functions in this module
+# Multiple modules can map to the same namespace
+def spl_namespace():
+    return "com.ibm.streamsx.topology.pytest.pyprimitives"
+
+@spl.primitive_operator()
+class NoPorts(object):
+    def __init__(self, mn, iv):
+        self.mn = mn
+        self.iv = iv
+
+    def __enter__(self):
+        import streamsx.ec as ec
+        self.cm = ec.CustomMetric(self, 'NP_' + self.mn)
+        self.cm.value = self.iv
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+   


### PR DESCRIPTION
Intial code for #1241.

Adds a decorator `@spl.primitive_operator` to define a primitive operator.

With this PR no ports are supported, it's an initial step towards supporting input and output ports.