### PR TITLE
Have a consistent method for calling PyObject_Call

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
@@ -169,6 +169,25 @@ class SplpyGeneral {
     }
 
     /**
+     * Utility method to call PyObject_Call(callable_object, args, kw)
+     * 
+     * Does not check for PyObject_Call returning null,
+     * the return from PyObject_Call is directly returned.
+     *
+     * Steals the reference to args and kw
+     */
+    static PyObject *pyObject_Call(PyObject *callable_object, PyObject *args, PyObject *kw) {
+      PyObject *ret  = PyObject_Call(callable_object, args, kw);
+      Py_DECREF(args);
+      if (kw != NULL)
+          Py_DECREF(kw);
+     
+      return ret;
+    }
+
+    
+
+    /**
      * Class object for streamsx.spl.types.Timestamp.
      * First call is through setup to set the
      * static variable.

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
@@ -48,10 +48,8 @@
      // At this point callable is the callable class object
      // we call it to create an instance of the class
      // (which itself is callable)
-     PyObject *tmp_instance = PyObject_Call(callable, empty_tuple, param_dict);
+     PyObject *tmp_instance = SplpyGeneral::pyObject_Call(callable, empty_tuple, param_dict);
      Py_DECREF(callable);
-     Py_DECREF(empty_tuple);
-     Py_DECREF(param_dict);
      if (tmp_instance == NULL) {
          SPLAPPTRC(L_ERROR, "Fatal error: cannot create instance of class " << "<%=$functionName%>" << " in module " << "<%=$module%>", "python");
          throw SplpyGeneral::pythonException("<%=$module%>");

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
@@ -3,11 +3,7 @@
    // SPL Tuples and submits them.
    // Returns if the Python function returns None.
 
-    PyObject * pyReturnVar = PyObject_Call(pyop_->callable(), pyTuple, pyDict);
-
-    Py_DECREF(pyTuple);
-    if (pyDict != NULL)
-        Py_DECREF(pyDict);
+    PyObject * pyReturnVar = SplpyGeneral::pyObject_Call(pyop_->callable(), pyTuple, pyDict);
 
     if (pyReturnVar == NULL) {
         SPLAPPTRC(L_ERROR, "Fatal error: function failed: " << "<%=$functionName%>", "python");

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
@@ -105,8 +105,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 
  @include  "../../opt/.__splpy/common/py_splTupleToFunctionArgs.cgt"
 
-    PyObject * pyReturnVar = PyObject_Call(pyop_->callable(), pyTuple, pyDict);
-    Py_DECREF(pyTuple);
+    PyObject * pyReturnVar = SplpyGeneral::pyObject_Call(pyop_->callable(), pyTuple, pyDict);
 
     if (pyReturnVar == NULL) {
         SPLAPPTRC(L_ERROR, "Fatal error: function failed: " << "<%=$functionName%>", "python");

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
@@ -85,9 +85,8 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 
  @include  "../../opt/.__splpy/common/py_splTupleToFunctionArgs.cgt"
   
-    PyObject * pyReturnNone = PyObject_CallObject(pyop_->callable(), pyTuple);
+    PyObject * pyReturnNone = SplpyGeneral::pyObject_Call(pyop_->callable(), pyTuple, pyDict);
 
-    Py_DECREF(pyTuple);
     if (pyReturnNone == NULL) {
         SPLAPPTRC(L_ERROR, "Fatal error: function failed: " << "<%=$functionName%>", "python");
         throw SplpyGeneral::pythonException("<%=$functionName%>");

--- a/test/python/spl/tests/test_kwargs.py
+++ b/test/python/spl/tests/test_kwargs.py
@@ -1,0 +1,34 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+import os
+import unittest
+import sys
+import itertools
+
+from streamsx.topology.topology import *
+from streamsx.topology.tester import Tester
+from streamsx.topology import schema
+import streamsx.topology.context
+import streamsx.spl.op as op
+import streamsx.spl.toolkit
+
+class TestKWArgs(unittest.TestCase):
+    """ 
+    Test decorated operators with **kwargs
+    """
+    def setUp(self):
+        Tester.setup_standalone(self)
+
+    def test_filer_for_each(self):
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+        s = topo.source([(1,2,3), (1,2,201), (2,2,301), (3,4,401), (5,6,78), (8,6,501), (803, 9324, 901)])
+        sch = 'tuple<int32 a, int32 b, int32 c>'
+        s = s.map(lambda x : x, schema=sch)
+        bop = op.Map("com.ibm.streamsx.topology.pytest.pykwargs::KWFilter", s)
+
+        op.Sink("com.ibm.streamsx.topology.pytest.pykwargs::KWForEach", bop.stream)
+        
+        tester = Tester(topo)
+        tester.contents(bop.stream, [{'a':1, 'b':2, 'c':201}, {'a':3, 'b':4, 'c':401}, {'a':803, 'b':9324, 'c':901}])
+        tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/testtkpy/opt/python/streams/test_kwargs_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_kwargs_ops.py
@@ -1,0 +1,33 @@
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+
+# Import the SPL decorators
+from streamsx.spl import spl
+
+#------------------------------------------------------------------
+# Test Map functions
+#------------------------------------------------------------------
+
+# Defines the SPL namespace for any functions in this module
+# Multiple modules can map to the same namespace
+def splNamespace():
+    return "com.ibm.streamsx.topology.pytest.pykwargs"
+
+@spl.filter()
+def KWFilter(**t):
+    a = t['a']
+    b = t['b']
+    c = t['c']
+
+    return a < b and c > 100
+
+
+@spl.for_each()
+def KWForEach(**t):
+    a = t['a']
+    b = t['b']
+    c = t['c']
+    if a >= b:
+        raise ValueError("A>=B" + str(t))
+    if c <= 100:
+        raise ValueError("C<=100" + str(t))


### PR DESCRIPTION
Adds a utilit method to call `PyObject_Call` to ensure that the tuple and dict objects are correctly handled with reference counts.

Fixes #1262 
Fixes #1263