### PR TITLE
Have cgt scripts driven by  and not specific to port 0

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -117,15 +117,7 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-  IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
-
-<%
-print splpy_inputtuple2value($pystyle);
-%>
-
-<%if ($pystyle eq 'dict') {%>
-@include "../pyspltuple2dict.cgt"
-<%}%>
+@include "../pyspltuple2value.cgt"
 
   PyObject *python_value;
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -54,7 +54,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 <%if ($pystyle eq 'dict' || $pystyle eq 'tuple') {%>
 
   OPort0Type otuple;
-  otuple.assignFrom(ip, false);
+  otuple.assignFrom(<%=$iport->getCppTupleName()%>, false);
   otuple.set___spl_hash(streamsx::topology::Splpy::pyTupleHash(funcop_->callable(), value));
 
 <%} else { %>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
@@ -7,15 +7,10 @@
 
  require $pydir."/codegen/splpy.pm";
 
- # setup the variables used when processing spltuples
- my $pyport = $model->getInputPortAt(0);
- my $pytupleType = $pyport->getSPLTupleType();
- my @pyanames = SPL::CodeGen::Type::getAttributeNames($pytupleType);
- my @pyatypes = SPL::CodeGen::Type::getAttributeTypes($pytupleType);
-
- my $pynumattrs = $pyport->getNumberOfAttributes();
- 
- my $pytuple = $pyport->getCppTupleName();
+ # Currently function operators only have a single input port
+ # and take all the input attributes
+ my $iport = $model->getInputPortAt(0);
+ my $inputAttrs2Py = $iport->getNumberOfAttributes();
 
  # determine which input tuple style is being used
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2dict.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2dict.cgt
@@ -1,11 +1,13 @@
-
-// process the attributes in the spl tuple
-// into a python dictionary object
 <%
-# Fix up names for blobs script
-my $inputAttrs2Py = $pynumattrs;
-my @itypes = @pyatypes;
+# Takes the input SPL tuple and converts it to
+# as a dict to be passed to a Python functional operator
+#
+# Leaves the C++ variable value set to a PyObject * dict.
+
+# Variables that need to be set:
+# $iport - input port 
 %>
+
 @include "../opt/python/codegen/py_splTupleCheckForBlobs.cgt"
 
   PyObject *value = 0;
@@ -13,8 +15,9 @@ my @itypes = @pyatypes;
   SplpyGIL lockdict;
   PyObject * pyDict = PyDict_New();
 <%
-     for (my $i = 0; $i < $pynumattrs; ++$i) {
-         print convertAndAddToPythonDictionaryObject("ip", $i, $pyatypes[$i], $pyanames[$i], 'pyInNames_');
+     for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
+         my $la = $iport->getAttributeAt($i);
+         print convertAndAddToPythonDictionaryObject($iport->getCppTupleName(), $i, $la->getSPLType(), $la->getName(), 'pyInNames_');
      }
 %>
   value = pyDict;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2tuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2tuple.cgt
@@ -1,20 +1,22 @@
-
-// process the attributes in the spl tuple
-// into a python tuple object
 <%
-# Fix up names for blobs script
-my $inputAttrs2Py = $pynumattrs;
-my @itypes = @pyatypes;
+# Takes the input SPL tuple and converts it to
+# as a tuple to be passed to a Python functional operator
+#
+# Leaves the C++ variable value set to a PyObject * dict.
+
+# Variables that need to be set:
+# $iport - input port 
 %>
 @include "../opt/python/codegen/py_splTupleCheckForBlobs.cgt"
 
   PyObject *value = 0;
   {
   SplpyGIL locktuple;
-  PyObject * pyTuple = PyTuple_New(<%=$pynumattrs%>);
+  PyObject * pyTuple = PyTuple_New(<%=$inputAttrs2Py%>);
 <%
-     for (my $i = 0; $i < $pynumattrs; ++$i) {
-         print convertAndAddToPythonTupleObject("ip", $i, $pyatypes[$i], $pyanames[$i]);
+     for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
+         my $la = $iport->getAttributeAt($i);
+         print convertAndAddToPythonTupleObject($iport->getCppTupleName(), $i, $la->getSPLType(), $la->getName());
      }
 %>
   value = pyTuple;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2value.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2value.cgt
@@ -1,9 +1,19 @@
-  // Set up the variable value to represent the SPL tuple on port 0
-  // (see splpy_tuple.h for details)
-  IPort0Type const &ip = static_cast<IPort0Type const &>(tuple);
+<%
+# Takes the input SPL tuple and converts it to
+# the arguments needed to be passed to a Python
+# functional operator
+
+# Variables that need to be set:
+
+# $pyStyle - tuple or dictionary
+# $iport - input port 
+# $inputAttrs2Py - number of attributes to pass as tuple style
+%>
+
+    <%=$iport->getCppTupleType()%> const & <%=$iport->getCppTupleName()%> = static_cast< <%=$iport->getCppTupleType()%> const &>(tuple);
 
 <%
-print splpy_inputtuple2value($pystyle);
+print splpy_inputtuple2value($pystyle, $iport);
 if ($pystyle eq 'dict') {
 %>
 @include "pyspltuple2dict.cgt"

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_splTupleCheckForBlobs.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_splTupleCheckForBlobs.cgt
@@ -1,7 +1,14 @@
 <%
+# Perl Variables that need to be set:
+#
+# $iport - input port 
+#
+# $inputAttrs2Py - number of attributes to pass as tuple style
+#
+
    #Check if a blob exists in the input schema
    for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
-      if (typeHasBlobs($itypes[$i])) {
+      if (typeHasBlobs($iport->getAttributeAt($i)->getSPLType())) {
 %>
    PYSPL_MEMORY_VIEW_CLEANUP();
 <%

--- a/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
+++ b/com.ibm.streamsx.topology/opt/python/codegen/splpy.pm
@@ -202,17 +202,17 @@ sub splpy_tuplestyle{
 # represents the value to be passed into the Python function
 #
 sub splpy_inputtuple2value{
- my ($pystyle) = @_;
+ my ($pystyle, $iport) = @_;
  if ($pystyle eq 'pickle') {
-  return 'SPL::blob const & value = ip.get___spl_po();';
+  return 'SPL::blob const & value = ' . $iport->getCppTupleName() . '.get___spl_po();';
  }
 
  if ($pystyle eq 'string') {
-  return 'SPL::rstring const & value = ip.get_string();';
+  return 'SPL::rstring const & value = ' . $iport->getCppTupleName() . '.get_string();';
  }
  
  if ($pystyle eq 'json') {
-  return 'SPL::rstring const & value = ip.get_jsonString();';
+  return 'SPL::rstring const & value = ' . $iport->getCppTupleName() . '.get_jsonString();';
  }
 
  if ($pystyle eq 'dict') {

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_splTupleToFunctionArgs.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_splTupleToFunctionArgs.cgt
@@ -1,10 +1,21 @@
-//
-// Takes the input SPL tuple and converts it to
-// the arguments needed to be passed to a Python
-// function/callable decorated as a SPL operator.
-//
+<%
+{
+# Takes the input SPL tuple and converts it to
+# the arguments needed to be passed to a Python
+# function/callable decorated as a SPL operator.
 
-   IPort0Type const & <%=$ituple%> = static_cast<IPort0Type const &>(tuple);
+# Variables that need to be set:
+
+# $paramStyle - tuple or dictionary
+# $iport - input port 
+# $inputAttrs2Py - number of attributes to pass as tuple style
+
+my $ipt = $iport->getCppTupleType();
+my $ipv = $iport->getCppTupleName();
+
+%>
+
+   <%=$ipt%> const & <%=$ipv%> = static_cast< <%=$ipt%> const &>(tuple);
 
 <%
     if ($paramStyle eq 'tuple') {
@@ -18,7 +29,8 @@
     PyObject *pyValue;
 <%
      for (my $i = 0; $i < $inputAttrs2Py; ++$i) {
-         print convertToPythonValueAsTuple($ituple, $i, $itypes[$i], $inames[$i]);
+         my $la = $iport->getAttributeAt($i);
+         print convertToPythonValueAsTuple($ipv, $i, $la->getSPLType(), $la->getName());
      }
 %>
 // END-Processing passing SPL tuple as a Python tuple
@@ -39,11 +51,12 @@
 <%
      for (my $i = 0; $i < $iport->getNumberOfAttributes(); ++$i) {
          my $la = $iport->getAttributeAt($i);
-         print convertAndAddToPythonDictionaryObject($ituple, $i, $la->getSPLType(), $la->getName(), 'pyInNames_');
+         print convertAndAddToPythonDictionaryObject($ipv, $i, $la->getSPLType(), $la->getName(), 'pyInNames_');
      }
 %>
 // END-Processing passing SPL tuple as a Python dictionary
 <%
     }
+}
 %>
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
@@ -25,8 +25,6 @@ using namespace streamsx::topology;
  
  my $iport = $model->getInputPortAt(0);
  my $itupleType = $iport->getSPLTupleType();
- my @inames = SPL::CodeGen::Type::getAttributeNames($itupleType);
- my @itypes = SPL::CodeGen::Type::getAttributeTypes($itupleType);
 
  my $inputAttrs2Py = $iport->getNumberOfAttributes();
  if ($fixedParam != -1) {

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -24,9 +24,6 @@ using namespace streamsx::topology;
  spl_pip_packages($model, \@packages);
  
  my $iport = $model->getInputPortAt(0);
- my $itupleType = $iport->getSPLTupleType();
- my @inames = SPL::CodeGen::Type::getAttributeNames($itupleType);
- my @itypes = SPL::CodeGen::Type::getAttributeTypes($itupleType);
 
  my $inputAttrs2Py = $iport->getNumberOfAttributes();
  if ($fixedParam != -1) {
@@ -43,8 +40,6 @@ using namespace streamsx::topology;
   my @onames = SPL::CodeGen::Type::getAttributeNames($otupleType);
   my @otypes = SPL::CodeGen::Type::getAttributeTypes($otupleType);
  
-  my $ituple = $iport->getCppTupleName();
-  
 %>
 
 // Constructor

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
@@ -25,8 +25,6 @@ using namespace streamsx::topology;
  
  my $iport = $model->getInputPortAt(0);
  my $itupleType = $iport->getSPLTupleType();
- my @inames = SPL::CodeGen::Type::getAttributeNames($itupleType);
- my @itypes = SPL::CodeGen::Type::getAttributeTypes($itupleType);
 
  my $inputAttrs2Py = $iport->getNumberOfAttributes();
  if ($fixedParam != -1) {

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -22,10 +22,6 @@ using namespace streamsx::topology;
  spl_pip_packages($model, \@packages);
 
  my $iport;
- my $itupleType;
- my @inames;
- my @itypes;
- my $ituple;
  
   my $oport = $model->getOutputPortAt(0);
   my $otupleType = $oport->getSPLTupleType();


### PR DESCRIPTION
Drive scripts related to handling the input port (typically SPL tuple to python object related) by the perl `$iport` variable, to ensure no dependency on port 0.

Step towards #1241 