### PR TITLE
Add support for @spl.input_port decorator.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
@@ -78,3 +78,15 @@ def _splpy_release_memoryviews(*args):
         elif isinstance(o, dict):
             for e in o.values():
                 _splpy_release_memoryviews(e)
+
+def _splpy_primitive_input_fns(obj):
+    """Convert the list of class input functions to be
+        instance functions against obj.
+        Used by @spl.primitive_operator SPL cpp template.
+    """
+    ofns = list()
+    for fn in obj._splpy_input_ports:
+        ofns.append(getattr(obj, fn.__name__))
+    return ofns
+    
+

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -866,9 +866,22 @@ class for_each:
 
 class input_port(object):
     _count = 0
-    def __init__(self, style=None, docpy=True):
+    def __init__(self, style=None):
+        """Declare an instance method as a the tuple processor
+        for an input port.
+
+        Instance methods within a class decorated using
+        `spl.primitive_operator` declare input ports by
+        decorating methods with this decorator.
+
+        The order of the methods within the class define
+        the order of the ports, so the first port is
+        the first method decorated with `input_port`.
+
+        .. versionadded:: 1.8
+        """
         self._style = style
-        self._docpy = docpy
+
     def __call__(self, wrapped):
         wrapped._splpy_input_port_seq = input_port._count
         wrapped._splpy_input_port_config = self
@@ -878,22 +891,24 @@ class input_port(object):
 
 
 class primitive_operator(object):
-    """
-    Decorator that creates an SPL operator from a class.
-
-    WIP: Initial state is just the creation of an operator
-    with no inputs or outputs.
-
-    An SPL operator with an arbitrary number of input and
-    output ports (TODO: port handling).
-
-    Args:
-       style: How an SPL tuple is passed into Python function, see  :ref:`spl-tuple-to-python`.
-       docpy: Copy Python docstrings into SPL operator model for SPLDOC.
-
-    """
     def __init__(self, docpy=True):
         self._docpy = docpy
+        """
+        Decorator that creates an SPL primitive operator from a class.
+
+        WIP: Initial state is just the creation of an operator
+        with inputs but no outputs.
+
+        An SPL operator with an arbitrary number of input and
+        output ports (TODO: output port handling).
+
+        Args:
+           style: How an SPL tuple is passed into Python function, see  :ref:`spl-tuple-to-python`.
+           docpy: Copy Python docstrings into SPL operator model for SPLDOC.
+
+        .. versionadded:: 1.8
+        """
+
     def __call__(self, wrapped):
         if not inspect.isclass(wrapped):
             raise TypeError('A class is required:' + str(wrapped))

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -611,11 +611,12 @@ def _wrapforsplop(optype, wrapped, style, docpy):
 
         _op_class.__wrapped__ = wrapped
         # _op_class.__doc__ = wrapped.__doc__
-        _op_class.__splpy_optype = optype
-        _op_class.__splpy_callable = 'class'
-        _op_class.__splpy_style = _define_style(wrapped, wrapped.__call__, style)
-        _op_class.__splpy_file = inspect.getsourcefile(wrapped)
-        _op_class.__splpy_docpy = docpy
+        _op_class._splpy_optype = optype
+        _op_class._splpy_callable = 'class'
+        if hasattr(wrapped, '__call__'):
+            _op_class._splpy_style = _define_style(wrapped, wrapped.__call__, style)
+        _op_class._splpy_file = inspect.getsourcefile(wrapped)
+        _op_class._splpy_docpy = docpy
         return _op_class
     if not inspect.isfunction(wrapped):
         raise TypeError('A function or callable class is required')
@@ -634,11 +635,11 @@ def _wrapforsplop(optype, wrapped, style, docpy):
     #       return wrapped(*args, **kwargs)
     _op_fn = wrapped
 
-    _op_fn.__splpy_optype = optype
-    _op_fn.__splpy_callable = 'function'
-    _op_fn.__splpy_style = _define_style(_op_fn, _op_fn, style)
-    _op_fn.__splpy_file = inspect.getsourcefile(wrapped)
-    _op_fn.__splpy_docpy = docpy
+    _op_fn._splpy_optype = optype
+    _op_fn._splpy_callable = 'function'
+    _op_fn._splpy_style = _define_style(_op_fn, _op_fn, style)
+    _op_fn._splpy_file = inspect.getsourcefile(wrapped)
+    _op_fn._splpy_docpy = docpy
     return _op_fn
 
 # define the SPL tuple passing style based
@@ -831,8 +832,8 @@ def ignore(wrapped):
     @functools.wraps(wrapped)
     def _ignore(*args, **kwargs):
         return wrapped(*args, **kwargs)
-    _ignore.__splpy_optype = _OperatorType.Ignore
-    _ignore.__splpy_file = inspect.getsourcefile(wrapped)
+    _ignore._splpy_optype = _OperatorType.Ignore
+    _ignore._splpy_file = inspect.getsourcefile(wrapped)
     return _ignore
 
 # Defines a function as a sink operator
@@ -863,6 +864,19 @@ class for_each:
         return _wrapforsplop(_OperatorType.Sink, wrapped, self.style, self.docpy)
 
 
+class input_port(object):
+    _count = 0
+    def __init__(self, style=None, docpy=True):
+        self._style = style
+        self._docpy = docpy
+    def __call__(self, wrapped):
+        wrapped._splpy_input_port_seq = input_port._count
+        wrapped._splpy_input_port_config = self
+        wrapped._splpy_style = self._style
+        input_port._count += 1
+        return wrapped
+
+
 class primitive_operator(object):
     """
     Decorator that creates an SPL operator from a class.
@@ -878,16 +892,28 @@ class primitive_operator(object):
        docpy: Copy Python docstrings into SPL operator model for SPLDOC.
 
     """
-    def __init__(self, style=None, docpy=True):
-        self.style = style
-        self.docpy = docpy
+    def __init__(self, docpy=True):
+        self._docpy = docpy
     def __call__(self, wrapped):
         if not inspect.isclass(wrapped):
             raise TypeError('A class is required:' + str(wrapped))
 
         _valid_identifier(wrapped.__name__)
 
-        cls = _wrapforsplop(_OperatorType.Primitive, wrapped, self.style, self.docpy)
+        cls = _wrapforsplop(_OperatorType.Primitive, wrapped, None, self._docpy)
+
+        inputs = dict()
+        for fname, fn in inspect.getmembers(wrapped, inspect.isfunction):
+            if hasattr(fn, '_splpy_input_port_seq'):
+                inputs[fn._splpy_input_port_seq] = fn
+
+        cls._splpy_input_ports = []
+        for seq in sorted(inputs.keys()):
+            fn = inputs[seq]
+            fn._splpy_input_port_id = len(cls._splpy_input_ports)
+            fn._splpy_style = _define_style(wrapped, fn, fn._splpy_style)
+
+            cls._splpy_input_ports.append(fn)
 
         return cls
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive.xml
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive.xml
@@ -35,7 +35,7 @@ __SPLPY__DESCRIPTION__SPLPY__
       __SPLPY__PARAMETERS__SPLPY__
     </parameters>
     <inputPorts>
-<!-- __SPLPY__INPORTS__SPLPY__ -->
+__SPLPY__INPORTS__SPLPY__
     </inputPorts>
     <outputPorts>
     </outputPorts>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -39,12 +39,11 @@ MY_OPERATOR::MY_OPERATOR() :
 <% if ($model->getNumberOfInputPorts() != 0) { %>
 
    SplpyGIL lock;
+   // callFunction takes a reference.
+   Py_INCREF(callable);
    pyinputfns_ = SplpyGeneral::callFunction(
              "streamsx.spl.runtime", "_splpy_primitive_input_fns",
              callable, NULL);   
-/*
-   pyinputfns_ = PyObject_GetAttrString(callable, "_splpy_input_ports");
-*/
    if (pyinputfns_ == NULL)
        throw SplpyGeneral::pythonException("<%=$functionName%>");
 
@@ -69,20 +68,28 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-<% if ($model->getNumberOfInputPorts() != 0) {
+<%
+for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
 
-my $iport = $model->getInputPortAt(0);
-my $inputAttrs2Py = $iport->getNumberOfAttributes();
+  my $iport = $model->getInputPortAt($p);
+  my $inputAttrs2Py = $iport->getNumberOfAttributes();
+
+  if ($model->getNumberOfInputPorts() > 1) {
+%>
+      if (port == <%=$p%>)
+<%
+  }
 
 %>
-
+ {
+ // Code block for a single port
  @include  "../../opt/.__splpy/common/py_splTupleCheckForBlobs.cgt"
 
     SplpyGIL lock;
 
  @include  "../../opt/.__splpy/common/py_splTupleToFunctionArgs.cgt"
 
-    PyObject *fn = PyList_GET_ITEM(pyinputfns_, (Py_ssize_t) port);
+    PyObject *fn = PyList_GET_ITEM(pyinputfns_, (Py_ssize_t) <%=$p%>);
     PyObject * pyReturnVar = SplpyGeneral::pyObject_Call(fn, pyTuple, pyDict);
 
     if (pyReturnVar == NULL) {
@@ -90,6 +97,10 @@ my $inputAttrs2Py = $iport->getNumberOfAttributes();
         throw SplpyGeneral::pythonException("<%=$functionName%>");
     }
     Py_DECREF(pyReturnVar);
+
+    return;
+ }
+
 <%}%>
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -16,20 +16,39 @@ using namespace streamsx::topology;
  require "splpy_operator.pm";
  require $cmnDir."/splpy.pm";
 
- my $module = splpy_Module();
- my $functionName = splpy_FunctionName();
  my @packages = splpy_Packages();
  spl_pip_packages($model, \@packages);
+
+ my $module = splpy_Module();
+ my $functionName = splpy_FunctionName();
+
+ my $paramStyle = splpy_ParamStyle();
+ $paramStyle = 'tuple';
 %>
 
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
-    pyop_(NULL)
+    pyop_(NULL),
+    pyinputfns_(NULL)
 {
    PyObject * callable;
 @include  "../../opt/.__splpy/common/py_constructor.cgt"
 
    pyop_->setCallable(callable);
+
+<% if ($model->getNumberOfInputPorts() != 0) { %>
+
+   SplpyGIL lock;
+   pyinputfns_ = SplpyGeneral::callFunction(
+             "streamsx.spl.runtime", "_splpy_primitive_input_fns",
+             callable, NULL);   
+/*
+   pyinputfns_ = PyObject_GetAttrString(callable, "_splpy_input_ports");
+*/
+   if (pyinputfns_ == NULL)
+       throw SplpyGeneral::pythonException("<%=$functionName%>");
+
+<% } %>
 }
 
 // Destructor
@@ -37,6 +56,8 @@ MY_OPERATOR::~MY_OPERATOR()
 {
    SplpyGIL lock;
    delete pyop_;
+   if (pyinputfns_ != NULL)
+       Py_DECREF(pyinputfns_);
 }
 
 // Notify pending shutdown
@@ -48,6 +69,28 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
+<% if ($model->getNumberOfInputPorts() != 0) {
+
+my $iport = $model->getInputPortAt(0);
+my $inputAttrs2Py = $iport->getNumberOfAttributes();
+
+%>
+
+ @include  "../../opt/.__splpy/common/py_splTupleCheckForBlobs.cgt"
+
+    SplpyGIL lock;
+
+ @include  "../../opt/.__splpy/common/py_splTupleToFunctionArgs.cgt"
+
+    PyObject *fn = PyList_GET_ITEM(pyinputfns_, (Py_ssize_t) port);
+    PyObject * pyReturnVar = SplpyGeneral::pyObject_Call(fn, pyTuple, pyDict);
+
+    if (pyReturnVar == NULL) {
+        SPLAPPTRC(L_ERROR, "Fatal error: function failed: " << "<%=$functionName%>", "python");
+        throw SplpyGeneral::pythonException("<%=$functionName%>");
+    }
+    Py_DECREF(pyReturnVar);
+<%}%>
 }
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -27,6 +27,8 @@ public:
 private:
   // Members
     SplpyPyOp *pyop_;
+
+    PyObject *pyinputfns_;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -19,11 +19,19 @@ class TestPrimitives(unittest.TestCase):
     def setUp(self):
         Tester.setup_distributed(self)
 
+    def _get_metric(self, name):
+        job = self.tester.submission_result.job
+        ops = job.get_operators()
+        self.assertEqual(1, len(ops))
+        ms = ops[0].get_metrics(name=name)
+        self.assertEqual(1, len(ms))
+        m = ms[0]
+        self.assertEqual(name, m.name)
+        return m 
+
     def _noports_check(self):
         job = self.tester.submission_result.job
-        import time
         ops = job.get_operators()
-        print(ops, flush=True)
         self.assertEqual(1, len(ops))
         ms = ops[0].get_metrics(name='NP_mymetric')
         self.assertEqual(1, len(ms))
@@ -39,4 +47,40 @@ class TestPrimitives(unittest.TestCase):
 
         self.tester = Tester(topo)
         self.tester.local_check = self._noports_check
+        self.tester.test(self.test_ctxtype, self.test_config)
+
+    def _single_input_port_check(self):
+        job = self.tester.submission_result.job
+        top = None
+        for op in job.get_operators():
+            if op.name == 'SIP_OP':
+                top = op
+                break
+        self.assertIsNot(None, top)
+
+        ms = top.get_metrics(name='SIP_METRIC')
+        self.assertEqual(1, len(ms))
+        m = ms[0]
+        self.assertEqual('SIP_METRIC', m.name)
+
+        import time
+        for i in range(10):
+            print(i, "Metric value", m.value, flush=True)
+            if m.value == 1043:
+                break
+            time.sleep(1.0)
+            print("About to refresh", flush=True)
+            m = top.get_metrics(name='SIP_METRIC')[0]
+        self.assertEqual(1043, m.value)
+
+    def test_single_input_ports(self):
+        """Operator with one input port"""
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+        s = topo.source([1043])
+        s = s.map(lambda x : (x,), schema='tuple<uint64 v>')
+        bop = op.Sink("com.ibm.streamsx.topology.pytest.pyprimitives::SingleInputPort", s, name="SIP_OP")
+
+        self.tester = Tester(topo)
+        self.tester.local_check = self._single_input_port_check
         self.tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -65,13 +65,11 @@ class TestPrimitives(unittest.TestCase):
 
         import time
         for i in range(10):
-            print(i, "Metric value", m.value, flush=True)
-            if m.value == 1043:
+            if m.value == 1060:
                 break
             time.sleep(1.0)
-            print("About to refresh", flush=True)
             m = top.get_metrics(name='SIP_METRIC')[0]
-        self.assertEqual(1043, m.value)
+        self.assertEqual(1060, m.value)
 
     def test_single_input_ports(self):
         """Operator with one input port"""
@@ -83,4 +81,54 @@ class TestPrimitives(unittest.TestCase):
 
         self.tester = Tester(topo)
         self.tester.local_check = self._single_input_port_check
+        self.tester.test(self.test_ctxtype, self.test_config)
+
+    def _multi_input_port_check(self):
+        job = self.tester.submission_result.job
+        top = None
+        for op in job.get_operators():
+            if op.name == 'MIP_OP':
+                top = op
+                break
+        self.assertIsNot(None, top)
+
+        ms = top.get_metrics(name='MIP_METRIC_0')
+        self.assertEqual(1, len(ms))
+        m0 = ms[0]
+        self.assertEqual('MIP_METRIC_0', m0.name)
+
+        ms = top.get_metrics(name='MIP_METRIC_1')
+        self.assertEqual(1, len(ms))
+        m1 = ms[0]
+        self.assertEqual('MIP_METRIC_1', m1.name)
+
+        ms = top.get_metrics(name='MIP_METRIC_2')
+        self.assertEqual(1, len(ms))
+        m2 = ms[0]
+        self.assertEqual('MIP_METRIC_2', m2.name)
+
+        import time
+        for i in range(10):
+            if m0.value == 9081 and m1.value == 379 and m2.value == -899:
+                break
+            time.sleep(1.0)
+            m0 = top.get_metrics(name='MIP_METRIC_0')[0]
+            m1 = top.get_metrics(name='MIP_METRIC_1')[0]
+            m2 = top.get_metrics(name='MIP_METRIC_2')[0]
+
+        self.assertEqual(9054 + 17, m0.value)
+        self.assertEqual(345 + 34, m1.value)
+        self.assertEqual(-953 + 51, m2.value)
+
+    def test_multi_input_ports(self):
+        """Operator with three input ports"""
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+        s0 = topo.source([9054]).map(lambda x : (x,), schema='tuple<uint64 v>')
+        s1 = topo.source([345]).map(lambda x : (x,), schema='tuple<int64 v>')
+        s2 = topo.source([-953]).map(lambda x : (x,), schema='tuple<int32 v>')
+        bop = op.Invoke(topo, "com.ibm.streamsx.topology.pytest.pyprimitives::MultiInputPort", [s0,s1,s2], name="MIP_OP")
+
+        self.tester = Tester(topo)
+        self.tester.local_check = self._multi_input_port_check
         self.tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
@@ -41,6 +41,30 @@ class SingleInputPort(object):
 
     @spl.input_port()
     def my_only_port(self, *t):
-        print("SELF", self, flush=True)
-        print("tuple", t, flush=True)
-        self.cm.value = t[0]
+        self.cm.value = t[0] + 17
+
+@spl.primitive_operator()
+class MultiInputPort(object):
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        import streamsx.ec as ec
+        self.cm0 = ec.CustomMetric(self, 'MIP_METRIC_0')
+        self.cm1 = ec.CustomMetric(self, 'MIP_METRIC_1')
+        self.cm2 = ec.CustomMetric(self, 'MIP_METRIC_2')
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    @spl.input_port()
+    def port0(self, *t):
+        self.cm0.value = t[0] + 17
+
+    @spl.input_port()
+    def port1(self, *t):
+        self.cm1.value = t[0] + 34
+
+    @spl.input_port()
+    def port2(self, *t):
+        self.cm2.value = t[0] + 51

--- a/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
@@ -27,3 +27,20 @@ class NoPorts(object):
     def __exit__(self, exc_type, exc_value, traceback):
         pass
    
+@spl.primitive_operator()
+class SingleInputPort(object):
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        import streamsx.ec as ec
+        self.cm = ec.CustomMetric(self, 'SIP_METRIC')
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    @spl.input_port()
+    def my_only_port(self, *t):
+        print("SELF", self, flush=True)
+        print("tuple", t, flush=True)
+        self.cm.value = t[0]


### PR DESCRIPTION
Defines a port and the method to process it in an class decorated with `@spl.primitve_operator`.

Only `tuple` passing style is currently implemented. style will be driven by the method signature (the one annotated by `@spl.input_port`) or its `style` parameter.

E.g.
```
@spl.primitive_operator()
class NoPorts(object):
    def __init__(self, mn, iv):
        self.mn = mn
        self.iv = iv

    def __enter__(self):
        import streamsx.ec as ec
        self.cm = ec.CustomMetric(self, 'NP_' + self.mn)
        self.cm.value = self.iv

    def __exit__(self, exc_type, exc_value, traceback):
        pass
   
@spl.primitive_operator()
class SingleInputPort(object):
    def __init__(self):
        pass

    def __enter__(self):
        import streamsx.ec as ec
        self.cm = ec.CustomMetric(self, 'SIP_METRIC')

    def __exit__(self, exc_type, exc_value, traceback):
        pass

    @spl.input_port()
    def my_only_port(self, *t):
        self.cm.value = t[0] + 17

@spl.primitive_operator()
class MultiInputPort(object):
    def __init__(self):
        pass

    def __enter__(self):
        import streamsx.ec as ec
        self.cm0 = ec.CustomMetric(self, 'MIP_METRIC_0')
        self.cm1 = ec.CustomMetric(self, 'MIP_METRIC_1')
        self.cm2 = ec.CustomMetric(self, 'MIP_METRIC_2')

    def __exit__(self, exc_type, exc_value, traceback):
        pass

    @spl.input_port()
    def port0(self, *t):
        self.cm0.value = t[0] + 17

    @spl.input_port()
    def port1(self, *t):
        self.cm1.value = t[0] + 34

    @spl.input_port()
    def port2(self, *t):
        self.cm2.value = t[0] + 51
```