### PR TITLE
Support **kwargs for primitive operator input port

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
@@ -51,9 +51,6 @@ def _optype(opobj):
 def _opfile(opobj):
     return opobj._splpy_file
 
-def _opstyle(opobj):
-    return opobj._splpy_style
-
 def _opcallable(opobj):
     return opobj._splpy_callable
 
@@ -288,11 +285,11 @@ class _Extractor(object):
          replaceTokenInFile(opmodel_xml, "__SPLPY__DESCRIPTION__SPLPY__", opdoc);
 
     def _create_ip_spldoc(self, opmodel_xml, name, opobj):
-         if _opstyle(opobj) == 'dictionary':
+         if opobj._splpy_style == 'dictionary':
            _p0doc = """
            Tuple attribute values are passed by name to the Python callable using `\*\*kwargs`.
                  """
-         elif _opstyle(opobj) == 'tuple':
+         elif opobj._splpy_style == 'tuple':
            _p0doc = """
            Tuple attribute values are passed by position to the Python callable.
                  """
@@ -328,7 +325,7 @@ class _Extractor(object):
         
             sig = _inspect.signature(opfn)
             fixedCount = 0
-            if _opstyle(opobj) == 'tuple':
+            if opobj._splpy_style == 'tuple':
                 pmds = sig.parameters
                 itpmds = iter(pmds)
                 # Skip 'self' for classes
@@ -345,8 +342,14 @@ class _Extractor(object):
                      if param.kind == _inspect.Parameter.VAR_KEYWORD:
                          break
 
+            if isinstance(opobj._splpy_style, list):
+                pm_style = '(' + ','.join(["'{0}'".format(_) for _ in opobj._splpy_style]) + ')'
+            else:
+                pm_style = "'" + opobj._splpy_style + "'"
+             
+
             cfgfile.write('sub splpy_FixedParam { \''+ str(fixedCount)   + "\'}\n")
-            cfgfile.write('sub splpy_ParamStyle { \''+ str(_opstyle(opobj))   + "\'}\n")
+            cfgfile.write('sub splpy_ParamStyle {'+ pm_style + '}\n')
  
 
     # Write out the configuration for the operator

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -923,12 +923,14 @@ class primitive_operator(object):
                 inputs[fn._splpy_input_port_seq] = fn
 
         cls._splpy_input_ports = []
+        cls._splpy_style = []
         for seq in sorted(inputs.keys()):
             fn = inputs[seq]
             fn._splpy_input_port_id = len(cls._splpy_input_ports)
             fn._splpy_style = _define_style(wrapped, fn, fn._splpy_style)
 
             cls._splpy_input_ports.append(fn)
+            cls._splpy_style.append(fn._splpy_style)
 
         return cls
 

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_splTupleToFunctionArgs.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_splTupleToFunctionArgs.cgt
@@ -49,9 +49,14 @@ my $ipv = $iport->getCppTupleName();
     PyObject * pyTuple = PyTuple_New(0);
     PyObject * pyDict = PyDict_New();
 <%
+     my $ppn = '';
+     if ($iport->getIndex() >= 1) {
+         $ppn = $iport->getIndex();
+     }
+
      for (my $i = 0; $i < $iport->getNumberOfAttributes(); ++$i) {
          my $la = $iport->getAttributeAt($i);
-         print convertAndAddToPythonDictionaryObject($ipv, $i, $la->getSPLType(), $la->getName(), 'pyInNames_');
+         print convertAndAddToPythonDictionaryObject($ipv, $i, $la->getSPLType(), $la->getName(), 'pyInNames_' . $ppn);
      }
 %>
 // END-Processing passing SPL tuple as a Python dictionary

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -21,15 +21,17 @@ using namespace streamsx::topology;
 
  my $module = splpy_Module();
  my $functionName = splpy_FunctionName();
-
- my $paramStyle = splpy_ParamStyle();
- $paramStyle = 'tuple';
 %>
 
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
-    pyop_(NULL),
-    pyinputfns_(NULL)
+    pyop_(NULL)
+<%if ($model->getNumberOfInputPorts() != 0) {%>
+    ,pyinputfns_(NULL),
+    pyInNames_(NULL)
+<%  for (my $p = 1; $p < $model->getNumberOfInputPorts(); $p++) { %>
+    , pyInNames_<%=$p%>(NULL)
+<%}}%>
 {
    PyObject * callable;
 @include  "../../opt/.__splpy/common/py_constructor.cgt"
@@ -39,6 +41,25 @@ MY_OPERATOR::MY_OPERATOR() :
 <% if ($model->getNumberOfInputPorts() != 0) { %>
 
    SplpyGIL lock;
+
+<%
+
+my @portParamStyles = splpy_ParamStyle();
+
+for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
+
+my $paramStyle = @portParamStyles[$p];
+
+my $ppn = "";
+if ($p >= 1) {
+   $ppn = $p;
+}
+
+if ($paramStyle eq 'dictionary') { %>
+      pyInNames_<%=$ppn%> = streamsx::topology::Splpy::pyAttributeNames(
+               getInputPortAt(<%=$p%>));
+<%}}%>
+
    // callFunction takes a reference.
    Py_INCREF(callable);
    pyinputfns_ = SplpyGeneral::callFunction(
@@ -55,8 +76,16 @@ MY_OPERATOR::~MY_OPERATOR()
 {
    SplpyGIL lock;
    delete pyop_;
+
+<%if ($model->getNumberOfInputPorts() != 0) {%>
    if (pyinputfns_ != NULL)
        Py_DECREF(pyinputfns_);
+   if (pyInNames_ != NULL)
+       Py_DECREF(pyInNames_);
+<%  for (my $p = 1; $p < $model->getNumberOfInputPorts(); $p++) { %>
+   if (pyInNames_<%=$p%> != NULL)
+       Py_DECREF(pyInNames_<%=$p%>);
+<%}}%>
 }
 
 // Notify pending shutdown
@@ -65,14 +94,17 @@ void MY_OPERATOR::prepareToShutdown()
     pyop_->prepareToShutdown();
 }
 
-// Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
 <%
+if ($model->getNumberOfInputPorts() != 0) {
+my @portParamStyles = splpy_ParamStyle();
+
 for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
 
   my $iport = $model->getInputPortAt($p);
   my $inputAttrs2Py = $iport->getNumberOfAttributes();
+  my $paramStyle = @portParamStyles[$p];
 
   if ($model->getNumberOfInputPorts() > 1) {
 %>
@@ -101,7 +133,7 @@ for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
     return;
  }
 
-<%}%>
+<%}}%>
 }
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -28,7 +28,13 @@ private:
   // Members
     SplpyPyOp *pyop_;
 
+
+<%if ($model->getNumberOfInputPorts() != 0) {%>
     PyObject *pyinputfns_;
+    PyObject *pyInNames_; // port 0
+<%  for (my $p = 1; $p < $model->getNumberOfInputPorts(); $p++) { %>
+    PyObject *pyInNames_<%=$p%>;
+<%}}%>
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
@@ -62,8 +62,8 @@ class MultiInputPort(object):
         self.cm0.value = t[0] + 17
 
     @spl.input_port()
-    def port1(self, *t):
-        self.cm1.value = t[0] + 34
+    def port1(self, **t):
+        self.cm1.value = t['v'] + 34
 
     @spl.input_port()
     def port2(self, *t):


### PR DESCRIPTION
Now supports `@spl.input_port` with function signatures of `*t` and `**t`.

Still need to support by position with a subset of args e.g. `port1(a, b, c)`