### PR TITLE
Support for submission of tuples with @spl.primitive_operator

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy_ec.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_ec.h
@@ -44,7 +44,7 @@ class SplpyPrimitiveOp
 {
     public:
         virtual ~SplpyPrimitiveOp() {} 
-        virtual void convertAndSubmit(uint32_t port, PyObject *data) = 0;
+        virtual void convertAndSubmit(uint32_t port, PyObject *tuple_) = 0;
 };
 
 }}
@@ -312,7 +312,7 @@ static PyObject * __splpy_ec_metric_set(PyObject *self, PyObject *args){
 static PyObject * __splpy_ec_submit(PyObject *self, PyObject *args) {
    PyObject *opc = PyTuple_GET_ITEM(args, 0);
    PyObject *pyport = PyTuple_GET_ITEM(args, 1);
-   PyObject *pydata = PyTuple_GET_ITEM(args, 2);
+   PyObject *pytuple = PyTuple_GET_ITEM(args, 2);
 
    void * opptr = PyLong_AsVoidPtr(opc);
    SPL::Operator *op = reinterpret_cast<SPL::Operator*>(opptr);
@@ -320,7 +320,7 @@ static PyObject * __splpy_ec_submit(PyObject *self, PyObject *args) {
 
    uint32_t port = (uint32_t) PyLong_AsLong(pyport);
 
-   op2->convertAndSubmit(port, pydata);
+   op2->convertAndSubmit(port, pytuple);
 
    // Any return is going to be ignored
    // so return an existing object with its reference bumped

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_ec.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_ec.h
@@ -31,6 +31,24 @@
 #include <SPL/Runtime/Common/Metric.h>
 #include <SPL/Runtime/Function/UtilFunctions.h>
 
+namespace streamsx {
+  namespace topology {
+
+/**
+ * An "interface" for a SPL python primtive operator
+ * that can submit tuples from Python code. This allows
+ * the python code through __splpy_ec_submit to submit
+ * a tuple to an output port directly.
+ */
+class SplpyPrimitiveOp
+{
+    public:
+        virtual ~SplpyPrimitiveOp() {} 
+        virtual void convertAndSubmit(uint32_t port, PyObject *data) = 0;
+};
+
+}}
+
 extern "C" {
 
 /**
@@ -290,6 +308,26 @@ static PyObject * __splpy_ec_metric_set(PyObject *self, PyObject *args){
    return pyvalue;
 }
 
+// Submit a tuple to the output ports of a primitive operator.
+static PyObject * __splpy_ec_submit(PyObject *self, PyObject *args) {
+   PyObject *opc = PyTuple_GET_ITEM(args, 0);
+   PyObject *pyport = PyTuple_GET_ITEM(args, 1);
+   PyObject *pydata = PyTuple_GET_ITEM(args, 2);
+
+   void * opptr = PyLong_AsVoidPtr(opc);
+   SPL::Operator *op = reinterpret_cast<SPL::Operator*>(opptr);
+   streamsx::topology::SplpyPrimitiveOp *op2 = dynamic_cast<streamsx::topology::SplpyPrimitiveOp*>(op);
+
+   uint32_t port = (uint32_t) PyLong_AsLong(pyport);
+
+   op2->convertAndSubmit(port, pydata);
+
+   // Any return is going to be ignored
+   // so return an existing object with its reference bumped
+   Py_INCREF(pyport);
+   return pyport;
+}
+
 static PyMethodDef __splpy_ec_methods[] = {
     {"domain_id", __splpy_ec_domain_id, METH_NOARGS,
          "Return the domain identifier."},
@@ -327,6 +365,8 @@ static PyMethodDef __splpy_ec_methods[] = {
          "Increment metric value."},
     {"metric_set", __splpy_ec_metric_set, METH_O,
          "Set metric value."},
+    {"_submit", __splpy_ec_submit, METH_O,
+         "Submit tuple."},
     {"get_application_directory", __splpy_ec_get_application_directory, METH_NOARGS,
          "Get the application directory."},
     {NULL, NULL, 0, NULL}

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
@@ -17,10 +17,7 @@
 #ifndef __SPL__SPLPY_FUNCOP_H
 #define __SPL__SPLPY_FUNCOP_H
 
-#include "splpy_general.h"
-#include "splpy_setup.h"
 #include "splpy_op.h"
-#include "splpy_ec_api.h"
 
 #include <SPL/Runtime/Operator/ParameterValue.h>
 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
@@ -17,8 +17,9 @@
 #ifndef __SPL__SPLPY_OP_H
 #define __SPL__SPLPY_OP_H
 
-#include "splpy_general.h"
 #include "splpy_ec_api.h"
+#include "splpy_general.h"
+#include "splpy_setup.h"
 
 namespace streamsx {
   namespace topology {

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_pyop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_pyop.h
@@ -17,8 +17,6 @@
 #ifndef __SPL__SPLPY_PYOP_H
 #define __SPL__SPLPY_PYOP_H
 
-#include "splpy_general.h"
-#include "splpy_setup.h"
 #include "splpy_op.h"
 
 namespace streamsx {

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -457,9 +457,9 @@ def _callable_exit_clean(callable):
     if hasattr(callable, '__enter__') and hasattr(callable, '__exit__'):
         callable.__exit__(None, None, None)
 
-def _submit(primitive, port_index, data):
+def _submit(primitive, port_index, tuple_):
     """Internal method to submit a tuple"""
-    args = (_get_opc(primitive), port_index, data)
+    args = (_get_opc(primitive), port_index, tuple_)
     _ec._submit(args)
 
 #

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -457,6 +457,11 @@ def _callable_exit_clean(callable):
     if hasattr(callable, '__enter__') and hasattr(callable, '__exit__'):
         callable.__exit__(None, None, None)
 
+def _submit(primitive, port_index, data):
+    """Internal method to submit a tuple"""
+    args = (_get_opc(primitive), port_index, data)
+    _ec._submit(args)
+
 #
 # Application Trace & Log
 #

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
@@ -108,17 +108,35 @@ _OP_PARAM_TEMPLATE ="""
  </parameter>"""
 
 _OP_INPUT_PORT_SET_TEMPLATE ="""
-      <inputPortSet>
-        <description>
-__SPLPY__INPORT_DESCRIPTION__SPLPY__
-        </description>
-        <tupleMutationAllowed>false</tupleMutationAllowed>
-        <windowingMode>NonWindowed</windowingMode>
-        <windowPunctuationInputMode>Oblivious</windowPunctuationInputMode>
-        <cardinality>1</cardinality>
-        <optional>false</optional>
-      </inputPortSet>
+<inputPortSet>
+  <description>
+                                    __SPLPY__INPORT_DESCRIPTION__SPLPY__
+  </description>
+  <tupleMutationAllowed>false</tupleMutationAllowed>
+  <windowingMode>NonWindowed</windowingMode>
+  <windowPunctuationInputMode>Oblivious</windowPunctuationInputMode>
+  <cardinality>1</cardinality>
+  <optional>false</optional>
+</inputPortSet>
 """
+
+_OP_OUTPUT_PORT_SET_TEMPLATE ="""
+<outputPortSet>
+  <description>
+    __SPLPY__OUTPORT_DESCRIPTION__SPLPY__
+  </description>
+  <expressionMode>Nonexistent</expressionMode>
+  <autoAssignment>false</autoAssignment>
+  <completeAssignment>false</completeAssignment>
+  <rewriteAllowed>true</rewriteAllowed>
+  <windowPunctuationOutputMode>Preserving</windowPunctuationOutputMode>
+  <windowPunctuationInputPort>0</windowPunctuationInputPort>
+  <tupleMutationAllowed>false</tupleMutationAllowed>
+  <cardinality>1</cardinality>
+  <optional>false</optional>
+</outputPortSet>
+"""
+
 
 
 
@@ -311,8 +329,17 @@ class _Extractor(object):
                 ipd += tip
         else:
             ipd = "<!-- no input ports -->"
-
         replaceTokenInFile(opmodel_xml, "__SPLPY__INPORTS__SPLPY__", ipd);
+
+        # output ports
+        if cls._splpy_output_ports:
+            opd = ''
+            for portfn in cls._splpy_input_ports:
+                top = _OP_OUTPUT_PORT_SET_TEMPLATE
+                opd += top
+        else:
+            opd = "<!-- no output ports -->"
+        replaceTokenInFile(opmodel_xml, "__SPLPY__OUTPORTS__SPLPY__", opd);
    
     # Write information about the Python function parameters.
     #

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
@@ -334,7 +334,7 @@ class _Extractor(object):
         # output ports
         if cls._splpy_output_ports:
             opd = ''
-            for portfn in cls._splpy_input_ports:
+            for portfn in cls._splpy_output_ports:
                 top = _OP_OUTPUT_PORT_SET_TEMPLATE
                 opd += top
         else:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -872,11 +872,11 @@ class PrimitiveOperator(object):
 
     .. versionadded:: 1.8
     """
-    def submit(self, port_id, t):
+    def submit(self, port_id, tuple_):
         """Submit a tuple to the output port.
         """
         port_index = self._splpy_output_ports[port_id]
-        ec._submit(self, port_index, data)
+        ec._submit(self, port_index, tuple_)
 
 
 class input_port(object):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -863,6 +863,21 @@ class for_each:
     def __call__(self, wrapped):
         return _wrapforsplop(_OperatorType.Sink, wrapped, self.style, self.docpy)
 
+class PrimitiveOperator(object):
+    """Primitive operator super class.
+    Classes decorated with `@spl.primitive_operator` must extend
+    this class if they have one or more output ports. This class
+    provides the `submit` method to submit tuples to specified
+    otuput port.
+
+    .. versionadded:: 1.8
+    """
+    def submit(self, port_id, t):
+        """Submit a tuple to the output port.
+        """
+        port_index = self._splpy_output_ports[port_id]
+        ec._submit(self, port_index, data)
+
 
 class input_port(object):
     _count = 0
@@ -891,8 +906,9 @@ class input_port(object):
 
 
 class primitive_operator(object):
-    def __init__(self, docpy=True):
+    def __init__(self, output_ports=None,docpy=True):
         self._docpy = docpy
+        self._output_ports = output_ports
         """
         Decorator that creates an SPL primitive operator from a class.
 
@@ -903,7 +919,7 @@ class primitive_operator(object):
         output ports (TODO: output port handling).
 
         Args:
-           style: How an SPL tuple is passed into Python function, see  :ref:`spl-tuple-to-python`.
+           output_ports: List of identifiers for output ports.
            docpy: Copy Python docstrings into SPL operator model for SPLDOC.
 
         .. versionadded:: 1.8
@@ -931,6 +947,11 @@ class primitive_operator(object):
 
             cls._splpy_input_ports.append(fn)
             cls._splpy_style.append(fn._splpy_style)
+
+        cls._splpy_output_ports = dict()
+        if self._output_ports:
+            for i in range(len(self._output_ports)):
+                cls._splpy_output_ports[self._output_ports[i]] = i
 
         return cls
 

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
@@ -2,6 +2,13 @@
    // converts the returned value into
    // SPL Tuples and submits them.
    // Returns if the Python function returns None.
+<%
+{
+  my $ituplearg = "";
+  if (defined $iport) {
+     $ituplearg = ", " . $iport->getCppTupleName();
+  }
+%>
 
     PyObject * pyReturnVar = SplpyGeneral::pyObject_Call(pyop_->callable(), pyTuple, pyDict);
 
@@ -17,37 +24,6 @@
          return;
     }
 
-<%
-  my $ituplearg = "";
-  if (defined $iport) {
-     $ituplearg = ", " . $iport->getCppTupleName();
-  }
-%>
+    pySubmitTuplesPort<%=$oport->getIndex()%>(pyReturnVar <%=$ituplearg%>);
 
-if (PyTuple_Check(pyReturnVar))
-{
-  fromPythonToPort<%=$oport->getIndex()%>(pyReturnVar <%=$ituplearg%>);
-}
-else if (PyList_Check(pyReturnVar))
-{
-
-   /* Logic for if a list of tuples is returned */
-   Py_ssize_t tc = PyList_GET_SIZE(pyReturnVar);
-   for (Py_ssize_t k = 0; k < tc; k++){    
-     PyObject *ltuple = PyList_GET_ITEM(pyReturnVar, k);
-     if (SplpyGeneral::isNone(ltuple))
-         continue;
-     if(!PyTuple_Check(ltuple)){    
-        throw SplpyGeneral::generalException("<%=$functionName%>",
-             "Fatal error: function must return a Python Tuple or a Python List: <%=$functionName%>");
-     }
-     
-     fromPythonToPort<%=$oport->getIndex()%>(ltuple <%=$ituplearg%>);
-   }
-}
-else {
-  throw SplpyGeneral::generalException("<%=$functionName%>",
-     "Fatal error: function must return a Python Tuple or a Python List: <%=$functionName%>");
-}
-
-Py_DECREF(pyReturnVar);
+<%}%>

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
@@ -26,4 +26,5 @@
 
     pySubmitTuplesPort<%=$oport->getIndex()%>(pyReturnVar <%=$ituplearg%>);
 
+    Py_DECREF(pyReturnVar);
 <%}%>

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_valueToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_valueToTuples.cgt
@@ -44,7 +44,5 @@ void MY_OPERATOR::pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject *value <%=$
      throw SplpyGeneral::generalException("submit",
         "Fatal error: Value submitted must be a Python tuple or a Python list of tuples: Port <%=$oport->getIndex()%>");
   }
-
-  Py_DECREF(value);
 }
 <%}%>

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_valueToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_valueToTuples.cgt
@@ -1,0 +1,50 @@
+<%
+#
+# Creates a function pySubmitTuplesN that takes a Python value
+# and submits tuples to the output port. The value
+# must be a Python tuple or a list[tuple].
+# Calls the generated function fromPythonToPort0
+#
+# $oport - output port to submit to
+# $iport - optional - input port to copy attributes from.
+#
+{
+  my $itypeparam = "";
+  my $ituplearg = "";
+  if (defined $iport) {
+     $itypeparam = ", " . $iport->getCppTupleType() . " const & ituple";
+     $ituplearg = ", ituple";
+  }
+%>
+
+void MY_OPERATOR::pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject *value <%=$itypeparam%>) {
+
+  if (PyTuple_Check(value))
+  {
+    fromPythonToPort<%=$oport->getIndex()%>(value <%=$ituplearg%>);
+  }
+  else if (PyList_Check(value))
+  {
+
+     /* Logic for if a list of tuples is returned */
+     Py_ssize_t tc = PyList_GET_SIZE(value);
+     for (Py_ssize_t k = 0; k < tc; k++) {    
+       PyObject *ltuple = PyList_GET_ITEM(value, k);
+       if (SplpyGeneral::isNone(ltuple))
+           continue;
+       if (!PyTuple_Check(ltuple)) {    
+          throw SplpyGeneral::generalException("submit",
+             "Fatal error: Value submitted must be a Python tuple or a Python list of tuples: Port <%=$oport->getIndex()%>");
+       }
+     
+      fromPythonToPort<%=$oport->getIndex()%>(ltuple <%=$ituplearg%>);
+     }
+  }
+  else {
+     throw SplpyGeneral::generalException("submit",
+        "Fatal error: Value submitted must be a Python tuple or a Python list of tuples: Port <%=$oport->getIndex()%>");
+  }
+
+  Py_DECREF(value);
+}
+<%}%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -113,6 +113,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 }
 
 // Create member function that converts Python tuple to SPL tuple
+@include  "../../opt/.__splpy/common/py_valueToTuples.cgt"
 @include  "../../opt/.__splpy/common/py_pyTupleTosplTuple.cgt"
 
 // Punctuation processing

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
@@ -38,6 +38,7 @@ private:
     PyObject *pyInNames_;
     PyObject *pyOutNames_;
 
+    void pySubmitTuplesPort0(PyObject * value, <%=$iport->getCppTupleType()%> const & ituple);
     void fromPythonToPort0(PyObject * pyTuple, <%=$iport->getCppTupleType()%> const & ituple);
 }; 
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -104,6 +104,7 @@ void MY_OPERATOR::process(uint32_t idx)
 }
 
 // Create member function that converts Python tuple to SPL tuple
+@include  "../../opt/.__splpy/common/py_valueToTuples.cgt"
 @include  "../../opt/.__splpy/common/py_pyTupleTosplTuple.cgt"
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
@@ -36,6 +36,7 @@ private:
     SplpyPyOp *pyop_;
     PyObject *pyOutNames_;
 
+    void pySubmitTuplesPort0(PyObject * value);
     void fromPythonToPort0(PyObject * pyTuple);
 
 }; 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive.xml
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive.xml
@@ -38,6 +38,7 @@ __SPLPY__DESCRIPTION__SPLPY__
 __SPLPY__INPORTS__SPLPY__
     </inputPorts>
     <outputPorts>
+__SPLPY__OUTPORTS__SPLPY__
     </outputPorts>
   </cppOperatorModel>
 </operatorModel>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -135,7 +135,7 @@ for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
 <%}}%>
 }
 
-void MY_OPERATOR::convertAndSubmit(uint32_t port, PyObject *data) {
+void MY_OPERATOR::convertAndSubmit(uint32_t port, PyObject *tuple_) {
    fprintf(stderr, "Submit to %d from operator\n", port);
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -135,6 +135,16 @@ for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
 <%}}%>
 }
 
+// Create member functions that convert Python tuple to SPL tuple
+// for each port.
+<%
+for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) {
+    my $oport = $model->getOutputPortAt($p);
+    my $iport = undef;
+%>
+@include  "../../opt/.__splpy/common/py_pyTupleTosplTuple.cgt"
+<% } %>
+
 void MY_OPERATOR::convertAndSubmit(uint32_t port, PyObject *tuple_) {
    fprintf(stderr, "Submit to %d from operator\n", port);
 }

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -1,6 +1,6 @@
 /*
  * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2015,2016
+ * # Copyright IBM Corp. 2017
  */
 
 #include "splpy.h"
@@ -142,11 +142,15 @@ for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) {
     my $oport = $model->getOutputPortAt($p);
     my $iport = undef;
 %>
+@include  "../../opt/.__splpy/common/py_valueToTuples.cgt"
 @include  "../../opt/.__splpy/common/py_pyTupleTosplTuple.cgt"
 <% } %>
 
 void MY_OPERATOR::convertAndSubmit(uint32_t port, PyObject *tuple_) {
-   fprintf(stderr, "Submit to %d from operator\n", port);
+<% for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) { %>
+     if (port == <%=$p%>)
+         pySubmitTuplesPort<%=$p%>(tuple_);
+<%}%>
 }
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -4,7 +4,6 @@
  */
 
 #include "splpy.h"
-#include "splpy_pyop.h"
 
 using namespace streamsx::topology;
 
@@ -134,6 +133,10 @@ for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
  }
 
 <%}}%>
+}
+
+void MY_OPERATOR::convertAndSubmit(uint32_t port, PyObject *data) {
+   fprintf(stderr, "Submit to %d from operator\n", port);
 }
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -26,9 +26,16 @@ public:
 
   void convertAndSubmit(uint32_t port, PyObject *tuple_);
 
+
 private:
   // Members
     SplpyPyOp *pyop_;
+
+<% for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) {
+    my $oport = $model->getOutputPortAt($p);
+%>
+  void fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=$oport->getCppTupleType()%> & otuple);
+<%}%>
 
 
 <%if ($model->getNumberOfInputPorts() != 0) {%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -24,7 +24,7 @@ public:
   // Tuple processing for non-mutating ports
   void process(Tuple const & tuple, uint32_t port);
 
-  void convertAndSubmit(uint32_t port, PyObject *data);
+  void convertAndSubmit(uint32_t port, PyObject *tuple_);
 
 private:
   // Members

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -9,7 +9,7 @@ using namespace streamsx::topology;
 
 <%SPL::CodeGen::headerPrologue($model);%>
 
-class MY_OPERATOR : public MY_BASE_OPERATOR 
+class MY_OPERATOR : public MY_BASE_OPERATOR, public SplpyPrimitiveOp
 {
 public:
   // Constructor
@@ -23,6 +23,8 @@ public:
 
   // Tuple processing for non-mutating ports
   void process(Tuple const & tuple, uint32_t port);
+
+  void convertAndSubmit(uint32_t port, PyObject *data);
 
 private:
   // Members

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -1,6 +1,6 @@
 /*
  * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2015  
+ * # Copyright IBM Corp. 2017
  */
 
 #include "splpy_pyop.h"
@@ -34,7 +34,8 @@ private:
 <% for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) {
     my $oport = $model->getOutputPortAt($p);
 %>
-  void fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=$oport->getCppTupleType()%> & otuple);
+  void pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject * value);
+  void fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple);
 <%}%>
 
 

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -155,3 +155,22 @@ class TestPrimitivesOutputs(unittest.TestCase):
         self.tester.tuple_count(s, 2)
         self.tester.contents(s, [{'v':9237}, {'v':-24}])
         self.tester.test(self.test_ctxtype, self.test_config)
+
+    def test_multi_output_ports(self):
+        """Operator with multiple output port."""
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+
+        s = topo.source([9237, -24])
+        s = s.map(lambda x : (x,), schema='tuple<int64 v>')
+
+        bop = op.Invoke(topo, "com.ibm.streamsx.topology.pytest.pyprimitives::MultiOutputPorts", s, schemas=['tuple<int64 v1>', 'tuple<int32 v2>', 'tuple<int16 v3>'])
+
+        r = bop.outputs
+    
+        self.tester = Tester(topo)
+        self.tester.tuple_count(s, 2)
+        self.tester.contents(r[0], [{'v1':9237}, {'v1':-24}])
+        self.tester.contents(r[1], [{'v2':9237+921}, {'v2':-24+921}])
+        self.tester.contents(r[2], [{'v3':9237-407}, {'v3':-24-407}])
+        self.tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -132,3 +132,25 @@ class TestPrimitives(unittest.TestCase):
         self.tester = Tester(topo)
         self.tester.local_check = self._multi_input_port_check
         self.tester.test(self.test_ctxtype, self.test_config)
+
+class TestPrimitives2(unittest.TestCase):
+    def setUp(self):
+        Tester.setup_standalone(self)
+
+    @unittest.expectedFailure
+    def test_single_output_port(self):
+        """Operator with single output port."""
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+
+        s = topo.source([9237, -24])
+        s = s.map(lambda x : (x,), schema='tuple<uint64 v>')
+
+        bop = op.Map("com.ibm.streamsx.topology.pytest.pyprimitives::SingleOutputPort", s)
+
+        r = bop.stream
+    
+        self.tester = Tester(topo)
+        self.tester.tuple_count(s, 2)
+        self.tester.contents(s, [{'v':9237}, {'v',-24}])
+        self.tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -133,18 +133,19 @@ class TestPrimitives(unittest.TestCase):
         self.tester.local_check = self._multi_input_port_check
         self.tester.test(self.test_ctxtype, self.test_config)
 
-class TestPrimitives2(unittest.TestCase):
+# With output ports it's easier to test thus can use standalone.
+#
+class TestPrimitivesOutputs(unittest.TestCase):
     def setUp(self):
         Tester.setup_standalone(self)
 
-    @unittest.expectedFailure
     def test_single_output_port(self):
         """Operator with single output port."""
         topo = Topology()
         streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
 
         s = topo.source([9237, -24])
-        s = s.map(lambda x : (x,), schema='tuple<uint64 v>')
+        s = s.map(lambda x : (x,), schema='tuple<int64 v>')
 
         bop = op.Map("com.ibm.streamsx.topology.pytest.pyprimitives::SingleOutputPort", s)
 
@@ -152,5 +153,5 @@ class TestPrimitives2(unittest.TestCase):
     
         self.tester = Tester(topo)
         self.tester.tuple_count(s, 2)
-        self.tester.contents(s, [{'v':9237}, {'v',-24}])
+        self.tester.contents(s, [{'v':9237}, {'v':-24}])
         self.tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
@@ -41,6 +41,8 @@ class SingleInputPort(object):
 
     @spl.input_port()
     def my_only_port(self, *t):
+        import streamsx.ec as ec
+        ec._submit(self, 92, 'fref')
         self.cm.value = t[0] + 17
 
 @spl.primitive_operator()
@@ -68,3 +70,12 @@ class MultiInputPort(object):
     @spl.input_port()
     def port2(self, *t):
         self.cm2.value = t[0] + 51
+
+@spl.primitive_operator(output_ports=['A'])
+class SingleOutputPort(spl.PrimitiveOperator):
+    def __init__(self):
+        pass
+
+    @spl.input_port()
+    def port0(self, *t):
+        self.submit('A', t)

--- a/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
@@ -79,3 +79,14 @@ class SingleOutputPort(spl.PrimitiveOperator):
     @spl.input_port()
     def port0(self, *t):
         self.submit('A', t)
+
+@spl.primitive_operator(output_ports=[1,2,3])
+class MultiOutputPorts(spl.PrimitiveOperator):
+    def __init__(self):
+        pass
+
+    @spl.input_port()
+    def port0(self, *t):
+        self.submit(1, t)
+        self.submit(2, (t[0] + 921,))
+        self.submit(3, (t[0] - 407,))


### PR DESCRIPTION
Allows definition of output ports with `@spl.primitive` and correctly passes the Python tuple from a `submit` call through to the generated C++ operator.

Tuples can be submitted, the class has to extend `spl.PrimitiveOperator`.

Here's an example:
```
@spl.primitive_operator(output_ports=[1,2,3])
 class MultiOutputPorts(spl.PrimitiveOperator):
    def __init__(self):
        pass

    @spl.input_port()
    def port0(self, *t):
        self.submit(1, t)
        self.submit(2, (t[0] + 921,))
        self.submit(3, (t[0] - 407,))
```

Note tuples are submitted by port _identfier_, not index. In the example above the identifiers are `1,2,3` but could be strings `A,B,C` or enums. The identifiers are set in the `output_ports` parameter to `@spl.primitive_operator`.

This PR only supports the tuple being submitted being a Python `tuple` or `list[tuple]`. Dictionary support will be added later.

Also there is no `all_ports_ready` function yet so operators with output ports but no input ports are not yet fully supported.