### PR TITLE
Directly submit tuples from fromPythonToPortN function

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -85,7 +85,6 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
 @include "../pyspltuple2value.cgt"
 
-  OPort0Type otuple;
 
 <%if ($pyoutstyle eq 'dict') {%>
   {
@@ -93,17 +92,18 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
   PyObject * ret = streamsx::topology::Splpy::pyTupleMap(funcop_->callable(), value);
   if (ret == NULL)
      return;
-  fromPythonToPort0(ret, otuple);
+  fromPythonToPort0(ret);
   Py_DECREF(ret);
   }
   
 <% } else { %>
+  OPort0Type otuple;
 
   if (SPLPY_TUPLE_MAP(funcop_->callable(), value,
        otuple.get_<%=$model->getOutputPortAt(0)->getAttributeAt(0)->getName()%>(), occ_))
+     submit(otuple, 0);
 
 <%}%>
-     submit(otuple, 0);
 }
 
 <%

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
@@ -30,7 +30,7 @@ private:
 <%
 if ($pyoutstyle eq 'dict') {
 %>
-    void fromPythonToPort0(PyObject * pyTuple, <%=$oport->getCppTupleType()%> & otuple);
+    void fromPythonToPort0(PyObject * pyTuple);
 <%}%>
 
     // Members

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_pyTupleTosplTuple.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_pyTupleTosplTuple.cgt
@@ -12,7 +12,9 @@
   }
 %>
  
-void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=$oport->getCppTupleType()%> & otuple <%=$itypeparam%>) {
+void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple <%=$itypeparam%>) {
+
+  <%=$oport->getCppTupleType()%> otuple;
 
   Py_ssize_t frs = PyTuple_GET_SIZE(pyTuple); 
     
@@ -66,4 +68,8 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=
 <%
 }
  %>
+
+  Py_BEGIN_ALLOW_THREADS
+  submit(otuple, <%=$oport->getIndex()%>);
+  Py_END_ALLOW_THREADS
 }

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_functionReturnToTuples.cgt
@@ -26,10 +26,7 @@
 
 if (PyTuple_Check(pyReturnVar))
 {
-  OPort0Type otuple;    
-  fromPythonToPort<%=$oport->getIndex()%>(pyReturnVar, otuple <%=$ituplearg%>);
-  output_tuples.push_back(otuple);
-
+  fromPythonToPort<%=$oport->getIndex()%>(pyReturnVar <%=$ituplearg%>);
 }
 else if (PyList_Check(pyReturnVar))
 {
@@ -45,9 +42,7 @@ else if (PyList_Check(pyReturnVar))
              "Fatal error: function must return a Python Tuple or a Python List: <%=$functionName%>");
      }
      
-     OPort0Type otuple;
-     fromPythonToPort<%=$oport->getIndex()%>(ltuple, otuple <%=$ituplearg%>);
-     output_tuples.push_back(otuple);
+     fromPythonToPort<%=$oport->getIndex()%>(ltuple <%=$ituplearg%>);
    }
 }
 else {

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -103,18 +103,13 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
  @include  "../../opt/.__splpy/common/py_splTupleCheckForBlobs.cgt"
 
-   std::vector<OPort0Type> output_tuples;  
-   {
-    // Don't hold the lock across submission
-    SplpyGIL lock;
+ // GIL is released across submission
+ SplpyGIL lock;
 
  @include  "../../opt/.__splpy/common/py_splTupleToFunctionArgs.cgt"
 
  @include  "../../opt/.__splpy/common/py_functionReturnToTuples.cgt"
    
-    }
- for(int i = 0; i < output_tuples.size();i++)
-   submit(output_tuples[i], 0);   
 }
 
 // Create member function that converts Python tuple to SPL tuple

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
@@ -38,7 +38,7 @@ private:
     PyObject *pyInNames_;
     PyObject *pyOutNames_;
 
-    void fromPythonToPort0(PyObject * pyTuple, <%=$oport->getCppTupleType()%> & otuple, <%=$iport->getCppTupleType()%> const & ituple);
+    void fromPythonToPort0(PyObject * pyTuple, <%=$iport->getCppTupleType()%> const & ituple);
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -93,19 +93,13 @@ void MY_OPERATOR::process(uint32_t idx)
 {
   while(!getPE().getShutdownRequested()) {
 
-    std::vector<OPort0Type> output_tuples;  
-    {
-      // Don't hold the lock across submission
+      // GIL is released across submission
       SplpyGIL lock;
 
       PyObject *pyTuple = PyTuple_New(0);
       PyObject *pyDict = NULL;
 
 @include  "../../opt/.__splpy/common/py_functionReturnToTuples.cgt"
-    }
- 
-    for(int i = 0; i < output_tuples.size();i++)
-       submit(output_tuples[i], 0);   
   }
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
@@ -36,7 +36,7 @@ private:
     SplpyPyOp *pyop_;
     PyObject *pyOutNames_;
 
-    void fromPythonToPort0(PyObject * pyTuple, <%=$oport->getCppTupleType()%> & otuple);
+    void fromPythonToPort0(PyObject * pyTuple);
 
 }; 
 


### PR DESCRIPTION
`otuple` is created in the `fromPythonToPortN` function and the generated function now derives everything from the perl variable `$oport`. (there were some cases where port 0 was still assumed.