### PR TITLE
Don't wrap identity function to perform tuple conversion in aggregate.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -33,6 +33,7 @@ using namespace streamsx::topology;
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
    pyInNames_(NULL),
+   loads(NULL),
    occ_(-1),
    window_(<%=$windowCppInitializer%>)
 {
@@ -85,9 +86,15 @@ MY_OPERATOR::MY_OPERATOR() :
 MY_OPERATOR::~MY_OPERATOR() 
 {
   delete funcop_;
+
+  <% if (($pystyle eq 'json') || ($pystyle eq 'pickle')) {%>
   {
       SplpyGIL lock;
+      if (loads != NULL){
+      	 Py_DECREF(loads);
+      }
   }
+  <% } %>
 }
 
 // Notify pending shutdown

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -19,7 +19,7 @@ using namespace streamsx::topology;
  # Select the Python wrapper function
  my $pyoutstyle = splpy_tuplestyle($model->getOutputPortAt(0));
 
- if (($pystyle eq 'dict') || ($pyoutstyle eq 'dict') || ($pystyle eq 'tuple') || ($pyoutstyle eq 'tuple')) {
+ if (($pystyle eq 'dict') || ($pyoutstyle eq 'dict') || ($pystyle eq 'tuple')) {
     SPL::CodeGen::exitln("Dictionary input and output not supported.");
  }
  

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -9,7 +9,6 @@ using namespace streamsx::topology;
 
 @include "../pyspltuple.cgt"
 
-
 <%
 
 # Configure Windowing
@@ -17,15 +16,13 @@ using namespace streamsx::topology;
  my $window = $inputPort->getWindow();
  my $windowCppInitializer = SPL::CodeGen::getWindowCppInitializer($window,"PyObject *");
 
-
  # Select the Python wrapper function
  my $pyoutstyle = splpy_tuplestyle($model->getOutputPortAt(0));
 
- if (($pystyle eq 'dict') || ($pyoutstyle eq 'dict')) {
+ if (($pystyle eq 'dict') || ($pyoutstyle eq 'dict') || ($pystyle eq 'tuple') || ($pyoutstyle eq 'tuple')) {
     SPL::CodeGen::exitln("Dictionary input and output not supported.");
  }
  
- my $in_pywrapfunc =  $pystyle . '_in__object_out';
  my $out_pywrapfunc=  'object_in__' . $pyoutstyle . '_out';
 %>
 
@@ -42,11 +39,7 @@ MY_OPERATOR::MY_OPERATOR() :
     window_.registerOnWindowTriggerHandler(this);
     window_.registerAfterTupleEvictionHandler(this);
 
-    const char * in_wrapfn = "<%=$in_pywrapfunc%>";
     const char * out_wrapfn = "<%=$out_pywrapfunc%>";
-    const char * functions_module = "streamsx.topology.functions";
-    const char * identity_function = "identity";
-
 <%
 # If occ parameter is positive then pass-by-ref is possible
 # Generate code to allow pass by ref but only use when
@@ -75,14 +68,17 @@ MY_OPERATOR::MY_OPERATOR() :
 %>
 
     funcop_ = new SplpyFuncOp(this, out_wrapfn);
-
-    // spl_in_object_out points to the wrapped identity function used to convert incoming tuples to 
-    // Python objects.
+    
+    // Obtain the function that loads the tuple's value in process()
     {
-        SplpyGIL lock;
-        spl_in_object_out = SplpyGeneral::loadFunction(functions_module, identity_function);
-        spl_in_object_out = SplpyGeneral::callFunction("streamsx.topology.runtime", in_wrapfn, spl_in_object_out, NULL);
+    SplpyGIL lock;
+    <%if ($pystyle eq 'pickle'){%>
+    loads = SplpyGeneral::loadFunction("pickle", "loads");
+    <% } elsif ($pystyle eq 'json'){ %>
+    loads = SplpyGeneral::loadFunction("json", "loads");
+    <% } %>
     }
+
 }
 
 // Destructor
@@ -91,7 +87,6 @@ MY_OPERATOR::~MY_OPERATOR()
   delete funcop_;
   {
       SplpyGIL lock;
-      Py_DECREF(spl_in_object_out);
   }
 }
 
@@ -108,7 +103,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 
   PyObject *python_value;
 
-// If the input style is pickle,
+  // If the input style is pickle,
 
   // None of the streamsx::topology methods in this scope grab the lock
   // so we need to do it here.
@@ -128,25 +123,31 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 	      SplpyGIL lock; 
               python_value = pySplValueToPyObject(value);
 
-	      // Create a tuple to pass to the depickling wrapper function.	  
-	      PyObject * pyTuple;
-              pyTuple = PyTuple_New(2);
-              PyTuple_SET_ITEM(pyTuple, 0, python_value);
-              Py_INCREF(python_value);
-              PyTuple_SET_ITEM(pyTuple, 1, python_value);
-
 	      // Depickle the tuple.
-	      python_value = streamsx::topology::SplpyGeneral::pyCallObject(spl_in_object_out, pyTuple);
+	      PyObject *tup = PyTuple_New(1);
+	      PyTuple_SET_ITEM(tup, 0, python_value);
+   	      python_value = SplpyGeneral::pyCallObject(loads, tup);
+
 	  } // End SplpyGIL lock
       }
-  <%} else {%>
-      	{
-	    // If the tuple is not a pickled object, or a reference, convert it to a PyObject
-	    // using pySplProcessTuple
-	    SplpyGIL lock;
-            python_value = streamsx::topology::pySplProcessTuple(spl_in_object_out, value);
-	} // End SplpyGIL lock
-  <%}%>
+  <% } elsif ($pystyle eq 'string'){%>
+      {
+	  SplpyGIL lock;
+          python_value = pySplValueToPyObject(value);
+      }
+  <% } elsif ($pystyle eq 'json'){%>
+      {
+      	  SplpyGIL lock;
+          python_value = pySplValueToPyObject(value);
+	  PyObject *tup = PyTuple_New(1);
+	  PyTuple_SET_ITEM(tup, 0, python_value);
+	  python_value = SplpyGeneral::pyCallObject(loads, tup);
+      }
+  
+ <% } else{
+	  SPL::CodeGen::exitln($pystyle . " is an unsupported input type.");      
+    }
+ %>
 
 
   window_.insert(python_value);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -51,6 +51,10 @@ if ($pyoutstyle eq 'dict') {
     // Names of input attributes
     PyObject *pyInNames_;
 
+    <% if (($pystyle eq 'pickle') || ($pystyle eq 'json')) { %>
+    PyObject *loads;
+    <% } %>
+
     // Number of output connections when passing by ref
     // -1 when cannot pass by ref
     int32_t occ_;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -51,9 +51,7 @@ if ($pyoutstyle eq 'dict') {
     // Names of input attributes
     PyObject *pyInNames_;
 
-    <% if (($pystyle eq 'pickle') || ($pystyle eq 'json')) { %>
     PyObject *loads;
-    <% } %>
 
     // Number of output connections when passing by ref
     // -1 when cannot pass by ref

--- a/test/python/topology/test2_python_window.py
+++ b/test/python/topology/test2_python_window.py
@@ -130,6 +130,7 @@ class TestPythonWindowing(unittest.TestCase):
                              [[{'a'},1], [{'c','b'}, 5]],
                              [[{'a'},1], [{'c','b'}, 5], [{'d','e'}, 9]]
                            ])
+
         tester.test(self.test_ctxtype, self.test_config)
 
     def test_StringInputCountCountWindow(self):


### PR DESCRIPTION
Uses SplpyGeneral::pyCallObject instead of SplpyGenerall::callFunction.