### PR TITLE
Support by position with @spl.primitive_operator.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
@@ -344,39 +344,19 @@ class _Extractor(object):
     # Write information about the Python function parameters.
     #
     def _write_style_info(self, cfgfile, opobj):
-            is_class = inspect.isclass(opobj)
-            if is_class:
-                opfn = opobj.__call__
-            else:
-                opfn = opobj
-        
-            sig = _inspect.signature(opfn)
-            fixedCount = 0
-            if opobj._splpy_style == 'tuple':
-                pmds = sig.parameters
-                itpmds = iter(pmds)
-                # Skip 'self' for classes
-                if is_class:
-                    next(itpmds)
-                
-                for pn in itpmds:
-                     param = pmds[pn]
-                     if param.kind == _inspect.Parameter.POSITIONAL_OR_KEYWORD:
-                         fixedCount += 1
-                     if param.kind == _inspect.Parameter.VAR_POSITIONAL:
-                         fixedCount = -1
-                         break
-                     if param.kind == _inspect.Parameter.VAR_KEYWORD:
-                         break
 
             if isinstance(opobj._splpy_style, list):
                 pm_style = '(' + ','.join(["'{0}'".format(_) for _ in opobj._splpy_style]) + ')'
             else:
                 pm_style = "'" + opobj._splpy_style + "'"
-             
-
-            cfgfile.write('sub splpy_FixedParam { \''+ str(fixedCount)   + "\'}\n")
             cfgfile.write('sub splpy_ParamStyle {'+ pm_style + '}\n')
+             
+            if isinstance(opobj._splpy_fixed_count, list):
+                pm_fixed = '(' + ','.join(["'{0}'".format(_) for _ in opobj._splpy_fixed_count]) + ')'
+            else:
+                pm_fixed = "'" + str(opobj._splpy_fixed_count) + "'"
+
+            cfgfile.write('sub splpy_FixedParam { '+ pm_fixed + "}\n")
  
 
     # Write out the configuration for the operator

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -615,6 +615,7 @@ def _wrapforsplop(optype, wrapped, style, docpy):
         _op_class._splpy_callable = 'class'
         if hasattr(wrapped, '__call__'):
             _op_class._splpy_style = _define_style(wrapped, wrapped.__call__, style)
+            _op_class._splpy_fixed_count = _define_fixed(_op_class)
         _op_class._splpy_file = inspect.getsourcefile(wrapped)
         _op_class._splpy_docpy = docpy
         return _op_class
@@ -638,6 +639,7 @@ def _wrapforsplop(optype, wrapped, style, docpy):
     _op_fn._splpy_optype = optype
     _op_fn._splpy_callable = 'function'
     _op_fn._splpy_style = _define_style(_op_fn, _op_fn, style)
+    _op_fn._splpy_fixed_count = _define_fixed(_op_fn)
     _op_fn._splpy_file = inspect.getsourcefile(wrapped)
     _op_fn._splpy_docpy = docpy
     return _op_fn
@@ -713,6 +715,33 @@ def _define_style(wrapped, fn, style):
     if style == 'name':
          raise TypeError("Not yet implemented!")
     return style
+
+def _define_fixed(callable_):
+    """For the callable see how many positional parameters are required"""
+    is_class = inspect.isclass(callable_)
+    style = callable_._splpy_style
+    if is_class:
+        callable_ = callable_.__call__
+
+    fixed_count = 0
+    if style == 'tuple':
+        sig = _inspect.signature(callable_)
+        pmds = sig.parameters
+        itpmds = iter(pmds)
+        # Skip 'self' for classes
+        if is_class:
+            next(itpmds)
+
+        for pn in itpmds:
+            param = pmds[pn]
+            if param.kind == _inspect.Parameter.POSITIONAL_OR_KEYWORD:
+                fixed_count += 1
+            if param.kind == _inspect.Parameter.VAR_POSITIONAL: # *args
+                fixed_count = -1
+                break
+            if param.kind == _inspect.Parameter.VAR_KEYWORD:
+                break
+    return fixed_count
 
 class source:
     """
@@ -940,13 +969,16 @@ class primitive_operator(object):
 
         cls._splpy_input_ports = []
         cls._splpy_style = []
+        cls._splpy_fixed_count = []
         for seq in sorted(inputs.keys()):
             fn = inputs[seq]
             fn._splpy_input_port_id = len(cls._splpy_input_ports)
             fn._splpy_style = _define_style(wrapped, fn, fn._splpy_style)
+            fn._splpy_fixed_count = _define_fixed(fn)
 
             cls._splpy_input_ports.append(fn)
             cls._splpy_style.append(fn._splpy_style)
+            cls._splpy_fixed_count.append(fn._splpy_fixed_count)
 
         cls._splpy_output_ports = dict()
         if self._output_ports:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -615,7 +615,7 @@ def _wrapforsplop(optype, wrapped, style, docpy):
         _op_class._splpy_callable = 'class'
         if hasattr(wrapped, '__call__'):
             _op_class._splpy_style = _define_style(wrapped, wrapped.__call__, style)
-            _op_class._splpy_fixed_count = _define_fixed(_op_class)
+            _op_class._splpy_fixed_count = _define_fixed(_op_class, _op_class.__call__)
         _op_class._splpy_file = inspect.getsourcefile(wrapped)
         _op_class._splpy_docpy = docpy
         return _op_class
@@ -639,7 +639,7 @@ def _wrapforsplop(optype, wrapped, style, docpy):
     _op_fn._splpy_optype = optype
     _op_fn._splpy_callable = 'function'
     _op_fn._splpy_style = _define_style(_op_fn, _op_fn, style)
-    _op_fn._splpy_fixed_count = _define_fixed(_op_fn)
+    _op_fn._splpy_fixed_count = _define_fixed(_op_fn, _op_fn)
     _op_fn._splpy_file = inspect.getsourcefile(wrapped)
     _op_fn._splpy_docpy = docpy
     return _op_fn
@@ -716,12 +716,10 @@ def _define_style(wrapped, fn, style):
          raise TypeError("Not yet implemented!")
     return style
 
-def _define_fixed(callable_):
+def _define_fixed(wrapped, callable_):
     """For the callable see how many positional parameters are required"""
-    is_class = inspect.isclass(callable_)
-    style = callable_._splpy_style
-    if is_class:
-        callable_ = callable_.__call__
+    is_class = inspect.isclass(wrapped)
+    style = callable_._splpy_style if hasattr(callable_, '_splpy_style') else wrapped._splpy_style
 
     fixed_count = 0
     if style == 'tuple':
@@ -974,7 +972,7 @@ class primitive_operator(object):
             fn = inputs[seq]
             fn._splpy_input_port_id = len(cls._splpy_input_ports)
             fn._splpy_style = _define_style(wrapped, fn, fn._splpy_style)
-            fn._splpy_fixed_count = _define_fixed(fn)
+            fn._splpy_fixed_count = _define_fixed(cls, fn)
 
             cls._splpy_input_ports.append(fn)
             cls._splpy_style.append(fn._splpy_style)

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -43,10 +43,21 @@ MY_OPERATOR::MY_OPERATOR() :
 <%
 
 my @portParamStyles = splpy_ParamStyle();
+my @portFixedParam = splpy_FixedParam();
 
 for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
 
+my $iport = $model->getInputPortAt($p);
+
 my $paramStyle = @portParamStyles[$p];
+my $fixedParam = @portFixedParam[$p];
+
+if ($fixedParam != -1) {
+    if ($fixedParam > $iport->getNumberOfAttributes()) {
+       SPL::CodeGen::exitln('%s requires at least %i attributes in input port %i but schema is %s',
+           $model->getContext()->getKind(), $fixedParam, $iport->getIndex(), $iport->getSPLTupleType());
+ }
+}
 
 my $ppn = "";
 if ($p >= 1) {
@@ -111,12 +122,17 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 <%
 if ($model->getNumberOfInputPorts() != 0) {
 my @portParamStyles = splpy_ParamStyle();
+my @portFixedParam = splpy_FixedParam();
 
 for (my $p = 0; $p < $model->getNumberOfInputPorts(); $p++) {
 
   my $iport = $model->getInputPortAt($p);
-  my $inputAttrs2Py = $iport->getNumberOfAttributes();
   my $paramStyle = @portParamStyles[$p];
+  my $fixedParam = @portFixedParam[$p];
+  my $inputAttrs2Py = $iport->getNumberOfAttributes();
+  if ($fixedParam != -1) {
+    $inputAttrs2Py = $fixedParam;
+  }
 
   if ($model->getNumberOfInputPorts() > 1) {
 %>

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -193,3 +193,20 @@ class TestPrimitivesOutputs(unittest.TestCase):
         self.tester.contents(r[0], [{'d':9237, 'e':(9237*2), 'f':9237+4}, {'d':-24, 'e':(-24*2), 'f':-24+4}])
         self.tester.contents(r[1], [{'d':9237+7, 'f':(9237*2)+777, 'e':9237+4+77}, {'d':9237, 'e':(9237*2), 'f':9237+4}, {'d':-24+7, 'f':(-24*2)+777, 'e':-24+4+77}, {'d':-24, 'e':(-24*2), 'f':-24+4}])
         self.tester.test(self.test_ctxtype, self.test_config)
+
+    def test_input_by_position(self):
+        """Operator with input by position"""
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+
+        s = topo.source([3642, -393])
+        s = s.map(lambda x : (x,x*2,x+4), schema='tuple<int64 d, int64 e, int64 f>')
+
+        bop = op.Map("com.ibm.streamsx.topology.pytest.pyprimitives::InputByPosition", s)
+
+        r = bop.stream
+    
+        self.tester = Tester(topo)
+        self.tester.tuple_count(r, 2)
+        self.tester.contents(r, [{'d':3642, 'e':(3642*2)+89, 'f':-92}, {'d':-393, 'e':(-393*2)+89, 'f':-92}])
+        self.tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
@@ -98,3 +98,13 @@ class DictOutputPorts(spl.PrimitiveOperator):
     def port0(self, **tuple_):
         self.submit('A', tuple_)
         self.submit('B', [{'d':tuple_['d'] + 7, 'e':tuple_['f'] + 77, 'f':tuple_['e'] + 777}, tuple_],)
+
+
+@spl.primitive_operator(output_ports=['A'])
+class InputByPosition(spl.PrimitiveOperator):
+    def __init__(self):
+        pass
+
+    @spl.input_port(style='position')
+    def port0(self, a, b):
+        self.submit('A', (a,b+89,-92))


### PR DESCRIPTION
Supports an input port with a signature of:

```
@spl.input_port(style='position')
def process(self, a, b, c):
    """Passed first three attributes of the tuple"""
    pass
```