### PR TITLE
Add all_ports_ready for @spl.primitive_operator

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
@@ -156,11 +156,12 @@ class SplpyGeneral {
      * Utility method to call an object
      * passing in a tuple of arguments.
      * 
-     * Steals the reference the the tuple.
+     * Steals the reference the the args (which may be NULL).
      */
-    static PyObject *pyCallObject(PyObject *pyclass, PyObject *args) {
-      PyObject *ret  = PyObject_CallObject(pyclass, args);
-      Py_DECREF(args);
+    static PyObject *pyCallObject(PyObject *callable_object, PyObject *args) {
+      PyObject *ret  = PyObject_CallObject(callable_object, args);
+      if (args != NULL)
+          Py_DECREF(args);
       if (ret == NULL) {
          throw SplpyGeneral::pythonException("pyCallObject");
       }

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
@@ -129,8 +129,7 @@ _OP_OUTPUT_PORT_SET_TEMPLATE ="""
   <autoAssignment>false</autoAssignment>
   <completeAssignment>false</completeAssignment>
   <rewriteAllowed>true</rewriteAllowed>
-  <windowPunctuationOutputMode>Preserving</windowPunctuationOutputMode>
-  <windowPunctuationInputPort>0</windowPunctuationInputPort>
+  <windowPunctuationOutputMode>Free</windowPunctuationOutputMode>
   <tupleMutationAllowed>false</tupleMutationAllowed>
   <cardinality>1</cardinality>
   <optional>false</optional>

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
@@ -101,3 +101,8 @@ def _splpy_primitive_output_attrs(callable_, port_attributes):
     callable_._splpy_conv_fns = conv_fns
 
 
+def _splpy_all_ports_ready(callable_):
+    """Call all_ports_ready for a primitive operator."""
+    if hasattr(type(callable_), 'all_ports_ready'):
+        return callable_.all_ports_ready()
+    return None

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -94,6 +94,58 @@ if ($paramStyle eq 'dictionary') { %>
 <%}%>
 }
 
+void MY_OPERATOR::allPortsReady()
+{
+    createThreads(1);
+}
+
+/**
+  Call the Python class's all_ports_ready method
+  if it exists and use the return to block for
+  completion of outstanding work. If this
+  operator has no output ports then it will
+  complete when this function (thread) returns.
+*/
+void MY_OPERATOR::process(uint32_t idx)
+{
+   if (getPE().getShutdownRequested())
+       return;
+
+   PyObject *blocker = NULL;
+
+   {
+     SplpyGIL lock;
+
+     Py_INCREF(pyop_->callable());
+     blocker = SplpyGeneral::callFunction(
+             "streamsx.spl.runtime", "_splpy_all_ports_ready",
+             pyop_->callable(), NULL);
+
+     bool callable = (bool) PyCallable_Check(blocker);
+     if (!callable) {
+         int has_background_work = PyObject_IsTrue(blocker);
+         Py_DECREF(blocker);
+         blocker = NULL;
+         
+         if (has_background_work == 0)
+             return;
+     }
+   }
+
+   if (blocker == NULL) {
+       getPE().blockUntilShutdownRequest();
+   } else {
+       if (getPE().getShutdownRequested())
+           return;
+
+       SplpyGIL lock;
+
+       PyObject *rv = SplpyGeneral::pyCallObject(blocker, NULL);
+       Py_DECREF(rv);
+       Py_DECREF(blocker);
+   }
+}
+
 // Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -12,23 +12,20 @@ using namespace streamsx::topology;
 class MY_OPERATOR : public MY_BASE_OPERATOR, public SplpyPrimitiveOp
 {
 public:
-  // Constructor
   MY_OPERATOR();
 
-  // Destructor
   virtual ~MY_OPERATOR(); 
 
-  // Notify pending shutdown
+  void allPortsReady();
+  void process(uint32_t idx);
+
   void prepareToShutdown(); 
 
-  // Tuple processing for non-mutating ports
   void process(Tuple const & tuple, uint32_t port);
 
   void convertAndSubmit(uint32_t port, PyObject *tuple_);
 
-
 private:
-  // Members
     SplpyPyOp *pyop_;
 
 <% for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) {

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -210,3 +210,18 @@ class TestPrimitivesOutputs(unittest.TestCase):
         self.tester.tuple_count(r, 2)
         self.tester.contents(r, [{'d':3642, 'e':(3642*2)+89, 'f':-92}, {'d':-393, 'e':(-393*2)+89, 'f':-92}])
         self.tester.test(self.test_ctxtype, self.test_config)
+
+    def test_only_output_port(self):
+        """Operator with single output port and no inputs."""
+        count = 106
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+
+        bop = op.Source(topo, "com.ibm.streamsx.topology.pytest.pyprimitives::OutputOnly", schema='tuple<int64 c>', params={'count':count})
+
+        r = bop.stream
+    
+        self.tester = Tester(topo)
+        self.tester.tuple_count(r, count)
+        self.tester.contents(r, list({'c':i+501} for i in range(count)))
+        self.tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_primitives_ops.py
@@ -108,3 +108,18 @@ class InputByPosition(spl.PrimitiveOperator):
     @spl.input_port(style='position')
     def port0(self, a, b):
         self.submit('A', (a,b+89,-92))
+
+import threading
+@spl.primitive_operator(output_ports=['A'])
+class OutputOnly(spl.PrimitiveOperator):
+    def __init__(self, count):
+        self.count = count
+
+    def all_ports_ready(self):
+        self.submitter = threading.Thread(target=self.submit_some)
+        self.submitter.start()
+        return self.submitter.join
+
+    def submit_some(self):
+        for i in range(self.count):
+            self.submit('A', (i+501,))


### PR DESCRIPTION
See pythondoc for `streamsx.spl.spl.all_ports_ready` on exactly how background processing is handled.