### PR TITLE
Fix get_application_logs pythondoc

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -411,13 +411,15 @@ class Job(_ResourceElement):
         If logs are retrieved with the same path and name as previously retrieved logs, the prior logs will be
         overwritten.
 
-        Attributes:
+        Args:
             path (str): a valid directory in which to save the application log output. Defaults to current dir.
             prefix (str): the prefix of the filename of the created tar file. Defaults to a prefix based on the job name.
 
-         Returns:
+        Returns:
             str: the path to the application logs tar file.
-         """
+
+        .. versionadded:: 1.8
+        """
         logger.debug("Retrieving application logs from: " + self.applicationLogTrace)
         logs = self.rest_client.make_raw_streaming_request(self.applicationLogTrace)
         


### PR DESCRIPTION
- Fix the parameters to be documented as arguments and not attributes
- Fix indentation of the Returns clause (caused it not to show up)
- add a `versionadded` tag.