### PR TITLE
Add StreamingAnalyticsService.getInstance()

### DIFF
--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -7,7 +7,6 @@ package com.ibm.streamsx.rest;
 
 import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.SERVICE_NAME;
 import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.VCAP_SERVICES;
-import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
 
 import java.io.File;
 import java.io.IOException;

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -97,4 +97,13 @@ public interface StreamingAnalyticsService {
      * @throws IOException
      */
     BigInteger buildAndSubmitJob(File archive, JsonObject submission) throws IOException;
+
+    /**
+     * Gets the {@link Instance IBM Streams Instance} object for the Streaming
+     * Analytics service.
+     * @return an {@link Instance IBM Streams Instance} associated with this
+     * service.
+     * @throws IOException
+     */
+    Instance getInstance() throws IOException;
 }

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
@@ -216,4 +216,24 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
         return jsonResponse;
     }
 
+    @Override
+    protected AbstractStreamsConnection createStreamsConnection() throws IOException {
+        String authorization = getAuthorization();
+        String sasResourcesUrl = StreamsRestUtils.getRequiredMember(credentials,
+                StreamsRestUtils.MEMBER_V2_REST_URL);
+        JsonObject sasResources = getServiceResources(authorization, sasResourcesUrl);
+        String instanceUrl = StreamsRestUtils.getRequiredMember(sasResources,
+                "streams_self");
+        // Find root URL. V2 starts at the instance, we want resources
+        String baseUrl = instanceUrl.substring(0, instanceUrl.lastIndexOf("/instances/"));
+        String streamsResourcesUrl = fixStreamsRestUrl(baseUrl);
+
+        StreamingAnalyticsConnectionV2 connection =
+                new StreamingAnalyticsConnectionV2(authorization,
+                        authExpiryTime, streamsResourcesUrl, credentials,
+                        false);
+        connection.init();
+        return connection;
+    }
+
 }


### PR DESCRIPTION
On first use, the StreamingAnalyticsServiceVx implementations will create an
instance of StreamingAnalyticsConnectionVx.

This lifted some code from StreamsRestFactory, the factory code will be
removed as part of later commits.

TODO:
- Make IStreamsConnection, IStreamingAnalyticsConnection package access
- Change hierarchy to remove IStreamingAnalyticsConnection
- Clean up unused factory methods.