### PR TITLE
Switch to planned public interfaces / classes for REST APIs.

### DIFF
--- a/java/src/com/ibm/streamsx/rest/IStreamingAnalyticsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/IStreamingAnalyticsConnection.java
@@ -15,7 +15,7 @@ import java.io.IOException;
  * Concrete instances are created with the factory methods in
  * {@link StreamsRestFactory}
  */
-public interface IStreamingAnalyticsConnection extends IStreamsConnection {
+interface IStreamingAnalyticsConnection extends IStreamsConnection {
     /**
      * Gets the {@link Instance IBM Streams Instance} object for the Streaming
      * Analytics service.

--- a/java/src/com/ibm/streamsx/rest/IStreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/IStreamsConnection.java
@@ -12,7 +12,7 @@ import java.util.List;
  * Concrete instances are created with the factory methods in
  * {@link StreamsRestFactory}
  */
-public interface IStreamsConnection {
+interface IStreamsConnection {
 
     /**
      * Gets a list of {@link Instance instances} that are available to this IBM

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnection.java
@@ -10,17 +10,16 @@ import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.VCAP_
 import java.io.IOException;
 
 import com.google.gson.JsonObject;
-import com.ibm.streamsx.rest.StreamsConnection.InvalidStreamsConnection;
 
 /**
- * Connection to a Streaming Analytics Instance.
+ * Connection to a Streaming Analytics Service Instance.
  * <p>
- * This class exists for backward compatibility. Users should instead create
- * instances of {@link IStreamingAnalyticsConnection} using the factory
- * methods in {@link StreamsRestFactory}.
+ * This class exists for backward compatibility and direct use is strongly
+ * discouraged. The preferred method for interacting with the Streaming
+ * Analytics Service is to use instances of {@link StreamingAnalyticsConnection}
+ * which can be created using a factory method in it.
  */
 
-@Deprecated
 public class StreamingAnalyticsConnection extends StreamsConnection
         implements IStreamingAnalyticsConnection {
 

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -21,7 +21,49 @@ import com.google.gson.JsonObject;
  * @since 1.8
  */
 public interface StreamingAnalyticsService {
-    
+
+    /**
+     * Access to a Streaming Analytics service on IBM Cloud.
+     * 
+     * <BR>
+     *  When specified {@code vcapServices} may be one of:
+     * <UL>
+     * <LI>An string representing VCAP service definitions in JSON format.</LI>
+     * <LI>A string representing a file containing VCAP service definitions.</LI>
+     * </UL>
+     * If {@code vcapServices} is {@code null} then the environment
+     * variable {@code VCAP_SERVICES} must contain the valid service
+     * definitions and credentials.
+     * <BR>
+     * If {@code serviceName} is {@code null} then the environment
+     * variable {@code STREAMING_ANALYTICS_SERVICE_NAME} must contain the name of
+     * the required service.
+     * <BR>
+     * The service named by {@code serviceName} must exist in the
+     * defined VCAP services.
+     *
+     * @param vcapServices
+     *            JSON representation of VCAP service definitions, or path to
+     *            a file containing the VCAP service definitions.
+     * @param serviceName
+     *            Name of the Streaming Analytics service to access.
+     *
+     * @return {@code StreamingAnalyticsService} for {@code serviceName}.
+     * @throws IOException
+     */
+    static StreamingAnalyticsService of(String vcapServices,
+            String serviceName) throws IOException {
+
+        JsonObject config = new JsonObject();
+
+        if (serviceName != null)
+            config.addProperty(SERVICE_NAME, serviceName);
+        if (vcapServices != null)
+            config.addProperty(VCAP_SERVICES, vcapServices);
+
+        return AbstractStreamingAnalyticsService.of(config);
+    }
+
     /**
      * Access to a Streaming Analytics service on IBM Cloud.
      * 

--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -13,13 +13,8 @@ import org.apache.http.client.fluent.Executor;
 import com.ibm.streamsx.topology.internal.streams.InvokeCancel;
 
 /**
- * Connection to IBM Streams
- * <p>
- * This class exists for backward compatibility. Users should instead create
- * instances of {@link IStreamsConnection} using the factory methods
- * in {@link StreamsRestFactory}.
+ * Connection to IBM Streams.
  */
-@Deprecated
 public class StreamsConnection implements IStreamsConnection {
     protected IStreamsConnection delegate;
     protected boolean allowInsecure;
@@ -28,7 +23,10 @@ public class StreamsConnection implements IStreamsConnection {
     private String authToken;
     private String url;
 
-    // May be stale or expired. Invoke a member method to refresh.
+    /**
+     * Direct use by derived classes is strongly discouraged. May be stale or
+     * expired. Invoke a member method to refresh.
+     */
     protected String apiKey;
     protected Executor executor;
 

--- a/java/src/com/ibm/streamsx/rest/StreamsRestFactory.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsRestFactory.java
@@ -18,7 +18,7 @@ import com.ibm.streamsx.rest.StreamsRestUtils.StreamingAnalyticsServiceVersion;
 import com.ibm.streamsx.topology.context.AnalyticsServiceProperties;
 import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 
-public class StreamsRestFactory {
+class StreamsRestFactory {
 
     private StreamsRestFactory() {}
 

--- a/samples/java/functional/src/rest/StreamingAnalyticsConnectionSample.java
+++ b/samples/java/functional/src/rest/StreamingAnalyticsConnectionSample.java
@@ -12,8 +12,7 @@ import com.ibm.streamsx.rest.Job;
 import com.ibm.streamsx.rest.Metric;
 import com.ibm.streamsx.rest.Operator;
 import com.ibm.streamsx.rest.OutputPort;
-import com.ibm.streamsx.rest.IStreamingAnalyticsConnection;
-import com.ibm.streamsx.rest.StreamsRestFactory;
+import com.ibm.streamsx.rest.StreamingAnalyticsService;
 
 /**
  * Sample code to show how to access a Streaming Analytics Instance through the
@@ -39,22 +38,13 @@ public class StreamingAnalyticsConnectionSample {
     public static void main(String[] args) {
         String credentials = args[0];
         String serviceName = args[1];
-        boolean allowInsecure = false;
-
-        /*
-         * This option is only used to by-pass the certificate certification
-         */
-        if (args.length == 3 && "true".equals(args[2])) {
-            allowInsecure = true;
-        }
-
 
         System.out.println(credentials);
         System.out.println(serviceName);
 
         try {
-            IStreamingAnalyticsConnection sClient = StreamsRestFactory.createStreamingAnalyticsConnection(credentials,
-                    serviceName, allowInsecure);
+            StreamingAnalyticsService sClient = StreamingAnalyticsService.of(credentials,
+                    serviceName);
 
             Instance instance = sClient.getInstance();
             System.out.println("Instance:" + instance.toString());

--- a/samples/java/functional/src/rest/StreamsConnectionSample.java
+++ b/samples/java/functional/src/rest/StreamsConnectionSample.java
@@ -15,8 +15,7 @@ import com.ibm.streamsx.rest.Operator;
 import com.ibm.streamsx.rest.OutputPort;
 import com.ibm.streamsx.rest.ProcessingElement;
 import com.ibm.streamsx.rest.RESTException;
-import com.ibm.streamsx.rest.IStreamsConnection;
-import com.ibm.streamsx.rest.StreamsRestFactory;
+import com.ibm.streamsx.rest.StreamsConnection;
 
 /**
  * This is the main class to show how to use the StreamsConnectionInterface.
@@ -44,20 +43,18 @@ public class StreamsConnectionSample {
         String authToken = args[1];
         String url = args[2];
         String instanceName = args[3];
-        boolean allowInsecure = false;
-
-        /*
-         * This option is only used to by-pass the certificate certification
-         */
-        if (args.length == 5 && "true".equals(args[4])) {
-            allowInsecure = true;
-        }
 
         /*
          * Create the connection to the instance indicated
          */
-        IStreamsConnection sClient = StreamsRestFactory.createStreamsConnection(userName, authToken,
-                url, allowInsecure);
+        StreamsConnection sClient = StreamsConnection.createInstance(userName, authToken,
+                url);
+        /*
+         * This option is only used to by-pass the certificate certification
+         */
+        if (args.length == 5 && "true".equals(args[4])) {
+            sClient.allowInsecureHosts(true);
+        }
 
         try {
             System.out.println("Instance: ");


### PR DESCRIPTION
Remove `@Deprecated` tags on the classes from 1.7, but add some comments discouraging use of `StreamingAnanlyticsConnection` (recommend `StreamingAnalyticsService` instead) and `apiKey` protected member.

Make `IStreamsConnection`, `IStreamingAnalyticsConnection`, and `StreamsRestFactory` package access.

Add a convenience factory method to `StreamingAnalyticsService` (one sample, and IBM Streams Runner for Apache Beam start with a String reference to VCAP services).

Update existing uses of previously public interfaces / classes.