### PR TITLE
[WIP] Add StreamingAnalyticsService.getJobId()

### DIFF
--- a/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
@@ -278,6 +278,17 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
         return name;
     }
 
+    public String getJobId(JsonObject submission) {
+        if (submission.has(RemoteContext.SUBMISSION_RESULTS)) {
+            JsonObject results = submission.getAsJsonObject(RemoteContext.SUBMISSION_RESULTS);
+            String memberName = getJobSubmitId();
+            if (results.has(memberName)) {
+                return results.get(memberName).getAsString();
+            }
+        }
+        return null;
+    }
+
     public Instance getInstance() throws IOException {
         synchronized (this) {
             if (null == streamsConnection) {

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -140,6 +140,14 @@ public interface StreamingAnalyticsService {
     BigInteger buildAndSubmitJob(File archive, JsonObject submission) throws IOException;
 
     /**
+     * Get the job ID from a previous successful {@link #buildAndSubmitJob} or
+     * {@link #submitJob}.
+     * @param submission The JSON object provided at submit time.
+     * @return Job ID or null.
+     */
+    String getJobId(JsonObject submission);
+
+    /**
      * Gets the {@link Instance IBM Streams Instance} object for the Streaming
      * Analytics service.
      * @return an {@link Instance IBM Streams Instance} associated with this

--- a/java/src/com/ibm/streamsx/topology/internal/tester/rest/RESTTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/rest/RESTTesterRuntime.java
@@ -56,11 +56,8 @@ public class RESTTesterRuntime extends TesterRuntime {
         String serviceName = jstring(deployment, SERVICE_NAME);
         StreamingAnalyticsService sas = StreamingAnalyticsService.of(vcapServices, serviceName);
 
-        JsonObject submission = jobject(deployment, "submissionResults");
-        requireNonNull(submission);
-
-        // FIXME: This is not correct for SASv2, SAS needs a method to get this
-        String jobId = jstring(submission, "jobId");
+        String jobId = sas.getJobId(deployment);
+        requireNonNull(jobId);
 
         Job job = sas.getInstance().getJob(jobId);
 


### PR DESCRIPTION
The job submission result from V2 of the Streaming Analytics Service uses a member named just `id` instead of `jobId` that was in V1.

This pull request adds `StreamingAnalyticsService.getJobId()` which takes the submission result and returns the `String` job ID based on the service version.
