### PR TITLE
Change StreamingAnalyticsService build / submit methods to take JCO, return Job

### DIFF
--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -10,7 +10,6 @@ import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.VCAP_
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -110,34 +109,23 @@ public interface StreamingAnalyticsService {
     
     /**
      * Submit a Streams bundle to run on the Streaming Analytics Service.
-     * <p>The JSON object may contain an optional {@code deploy} member that
-     * includes deployment information.
      * @param bundle A streams application bundle
-     * @param submission Deployment info to be submitted.
-     * @return The job id, or -1. Results from the submit will be added to the
-     * submission parameter object as a member named @{code submissionResults}.
+     * @param jco Job configuration overlay in JSON format.
+     * @return The Job, or null.
      * @throws IOException
      */
-    BigInteger submitJob(File bundle, JsonObject submission) throws IOException;
+    Job submitJob(File bundle, JsonObject jco) throws IOException;
 
     /**
      * Submit an archive to build on the Streaming Analytics Service, and submit
      * the job if the build is successful.
-     * <p>
-     * The JSON object contains two keys:
-     * <UL>
-     * <LI>{@code deploy} - Optional - Deployment information.</LI>
-     * <LI>{@code graph} - Required - JSON representation of the topology graph.</LI>
-     * </UL>
-     * <p>
-     * Results are added to the submission parameters object.
      * @param archive The application archive to build.
-     * @param submission Topology and deployment info to be submitted.
-     * @return The job id, or -1. Results from the submit will be added to the
-     * submission parameter object as a member named @{code submissionResults}.
+     * @param jco Job configuration overlay in JSON format.
+     * @param buildName A name for the build, or null.
+     * @return The Job, or null.
      * @throws IOException
      */
-    BigInteger buildAndSubmitJob(File archive, JsonObject submission) throws IOException;
+    Job buildAndSubmitJob(File archive, JsonObject jco, String buildName) throws IOException;
 
     /**
      * Gets the {@link Instance IBM Streams Instance} object for the Streaming

--- a/java/src/com/ibm/streamsx/topology/internal/context/service/RemoteStreamingAnalyticsServiceStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/service/RemoteStreamingAnalyticsServiceStreamsContext.java
@@ -15,6 +15,7 @@ import com.ibm.streamsx.topology.context.StreamsContext;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import com.ibm.streamsx.topology.internal.context.JSONStreamsContext;
 import com.ibm.streamsx.topology.internal.context.remote.RemoteBuildAndSubmitRemoteContext;
+import com.ibm.streamsx.topology.internal.context.remote.SubmissionResultsKeys;
 import com.ibm.streamsx.topology.internal.process.CompletedFuture;
 
 /**
@@ -42,10 +43,7 @@ public class RemoteStreamingAnalyticsServiceStreamsContext extends JSONStreamsCo
 
         JsonObject results = object(entity.submission, RemoteContext.SUBMISSION_RESULTS);
         if (results != null) {
-            // V2 uses id, V1 uses jobId
-            String jobId = jstring(results, "id");
-            if (jobId == null)
-                jobId = jstring(results, "jobId");
+            String jobId = jstring(results, SubmissionResultsKeys.JOB_ID);
             if (jobId != null)
                 return new CompletedFuture<>(new BigInteger(jobId));
         }

--- a/java/src/com/ibm/streamsx/topology/internal/tester/rest/RESTTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/rest/RESTTesterRuntime.java
@@ -25,6 +25,7 @@ import com.ibm.streamsx.topology.TSink;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.context.StreamsContext;
 import com.ibm.streamsx.topology.function.Consumer;
+import com.ibm.streamsx.topology.internal.context.remote.SubmissionResultsKeys;
 import com.ibm.streamsx.topology.internal.tester.ConditionTesterImpl;
 import com.ibm.streamsx.topology.internal.tester.TesterRuntime;
 import com.ibm.streamsx.topology.internal.tester.conditions.ContentsUserCondition;
@@ -59,8 +60,8 @@ public class RESTTesterRuntime extends TesterRuntime {
         JsonObject submission = jobject(deployment, "submissionResults");
         requireNonNull(submission);
 
-        // FIXME: This is not correct for SASv2, SAS needs a method to get this
-        String jobId = jstring(submission, "jobId");
+        String jobId = jstring(submission, SubmissionResultsKeys.JOB_ID);
+        requireNonNull(jobId);
 
         Job job = sas.getInstance().getJob(jobId);
 


### PR DESCRIPTION
Current internal users were updated. Since they expected results JSON to be added to the submission JSON, they now do that directly _only_ with the returned job ID. No other results are saved.