### PR TITLE
Revert to a single StreamingAnalytics.of

### DIFF
--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -27,54 +27,14 @@ public interface StreamingAnalyticsService {
      * <BR>
      *  When specified {@code vcapServices} may be one of:
      * <UL>
-     * <LI>An string representing VCAP service definitions in JSON format.</LI>
-     * <LI>A string representing a file containing VCAP service definitions.</LI>
-     * </UL>
-     * If {@code vcapServices} is {@code null} then the environment
-     * variable {@code VCAP_SERVICES} must contain the valid service
-     * definitions and credentials.
-     * <BR>
-     * If {@code serviceName} is {@code null} then the environment
-     * variable {@code STREAMING_ANALYTICS_SERVICE_NAME} must contain the name of
-     * the required service.
-     * <BR>
-     * The service named by {@code serviceName} must exist in the
-     * defined VCAP services.
-     *
-     * @param vcapServices
-     *            JSON representation of VCAP service definitions, or path to
-     *            a file containing the VCAP service definitions.
-     * @param serviceName
-     *            Name of the Streaming Analytics service to access.
-     *
-     * @return {@code StreamingAnalyticsService} for {@code serviceName}.
-     * @throws IOException
-     */
-    static StreamingAnalyticsService of(String vcapServices,
-            String serviceName) throws IOException {
-
-        JsonObject config = new JsonObject();
-
-        if (serviceName != null)
-            config.addProperty(SERVICE_NAME, serviceName);
-        if (vcapServices != null)
-            config.addProperty(VCAP_SERVICES, vcapServices);
-
-        return AbstractStreamingAnalyticsService.of(config);
-    }
-
-    /**
-     * Access to a Streaming Analytics service on IBM Cloud.
-     * 
-     * <BR>
-     *  When specified {@code vcapServices} may be one of:
-     * <UL>
      * <LI>An object representing VCAP service definitions.</LI>
+     * <LI>A string representing the serialized JSON VCAP service definitions.</LI>
      * <LI>A string representing a file containing VCAP service definitions.</LI>
      * </UL>
      * If {@code vcapServices} is {@code null} then the environment
-     * variable {@code VCAP_SERVICES} must contain the valid service
-     * definitions and credentials.
+     * variable {@code VCAP_SERVICES} must either contain the valid service
+     * definitions and credentials or point to a file containing the definitions
+     * and credentials.
      * <BR>
      * If {@code serviceName} is {@code null} then the environment
      * variable {@code STREAMING_ANALYTICS_SERVICE_NAME} must contain the name of
@@ -101,9 +61,6 @@ public interface StreamingAnalyticsService {
         if (vcapServices != null)
             config.add(VCAP_SERVICES, vcapServices);
         
-        System.err.println("SAS:" + config);
-
-
         return AbstractStreamingAnalyticsService.of(config);
     }
     

--- a/java/src/com/ibm/streamsx/topology/internal/context/streams/AnalyticsServiceStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streams/AnalyticsServiceStreamsContext.java
@@ -90,9 +90,6 @@ public class AnalyticsServiceStreamsContext extends
 
         JsonObject vcapServices = VcapServices.getVCAPServices(deploy.get(VCAP_SERVICES));
 
-        System.err.println("CONTEXT:" + vcapServices);
-        System.err.println("CONTEXT:NAME:" + jstring(deploy, SERVICE_NAME));
-
         final StreamingAnalyticsService sas = StreamingAnalyticsService.of(vcapServices,
                 jstring(deploy, SERVICE_NAME));
 

--- a/samples/java/functional/src/rest/StreamingAnalyticsConnectionSample.java
+++ b/samples/java/functional/src/rest/StreamingAnalyticsConnectionSample.java
@@ -6,6 +6,7 @@ package rest;
 
 import java.util.List;
 
+import com.google.gson.JsonPrimitive;
 import com.ibm.streamsx.rest.InputPort;
 import com.ibm.streamsx.rest.Instance;
 import com.ibm.streamsx.rest.Job;
@@ -43,7 +44,8 @@ public class StreamingAnalyticsConnectionSample {
         System.out.println(serviceName);
 
         try {
-            StreamingAnalyticsService sClient = StreamingAnalyticsService.of(credentials,
+            StreamingAnalyticsService sClient = StreamingAnalyticsService.of(
+                    new JsonPrimitive(credentials),
                     serviceName);
 
             Instance instance = sClient.getInstance();


### PR DESCRIPTION
The typical use case will be supplying VCAP_SERVICES through the environment variable or passing in a file name, having multiple `of` methods increase the "complexity" of the api for no real benefit.