### PR TITLE
Fix StreamsConnectionTest.

### DIFF
--- a/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
@@ -356,7 +356,11 @@ public class StreamsConnectionTest {
 
         List<Metric> inputPortMetrics = ip.getMetrics();
         for (Metric m : inputPortMetrics) {
-            assertTrue((m.getMetricKind().equals("counter")) || (m.getMetricKind().equals("gauge")));
+            assertTrue("Unexpected metric kind for metric " + m.getName() + ": "
+                    + m.getMetricKind(),
+                    (m.getMetricKind().equals("counter")) ||
+                            (m.getMetricKind().equals("gauge")) ||
+                            (m.getMetricKind().equals("time")));
             assertEquals("system", m.getMetricType());
             assertEquals("metric", m.getResourceType());
             assertNotNull(m.getName());


### PR DESCRIPTION
The V2 service now includes an input port metric of kind `time` named `recentMaxItemsQueuedInterval` which the test was not expecting.