### PR TITLE
Add Domain and clean-up cancel jobs methods.

### DIFF
--- a/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
@@ -44,9 +44,9 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
      * domainInstance will only be called for distributed where we cancel using
      * streamtool and not the context provided by the REST connection object.
      * 
+     * @param instance - instance job is running in.
      * @param jobId Job identifier.
-     * @param domainInstance - How to get the domain and instance identifiers if needed.
-     * @return
+     * @return True if job was canceled.
      * @throws IOException
      */
     abstract boolean cancelJob(Instance instance, String jobId) throws IOException;

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
@@ -39,7 +39,17 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
     protected String authorization;
     protected String instancesUrl;
 
-    abstract boolean cancelJob(String instanceId, String jobId) throws IOException;
+    /**
+     * Cancel a job.
+     * domainInstance will only be called for distributed where we cancel using
+     * streamtool and not the context provided by the REST connection object.
+     * 
+     * @param jobId Job identifier.
+     * @param domainInstance - How to get the domain and instance identifiers if needed.
+     * @return
+     * @throws IOException
+     */
+    abstract boolean cancelJob(Instance instance, String jobId) throws IOException;
 
     abstract String getAuthorization();
 

--- a/java/src/com/ibm/streamsx/rest/Domain.java
+++ b/java/src/com/ibm/streamsx/rest/Domain.java
@@ -1,0 +1,88 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+ */
+package com.ibm.streamsx.rest;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * 
+ * An object describing an IBM Streams Domain
+ * 
+ * @since 1.8
+ */
+public class Domain extends Element {
+    
+    @Expose
+    private String id;
+    @Expose
+    private String status;
+    @Expose
+    private long creationTime;
+    @Expose
+    private String creationUser;
+    @Expose
+    private String zooKeeperConnectionString;
+
+    static final Domain create(final AbstractStreamsConnection sc, String gsonInstance) {
+        Domain domain = gson.fromJson(gsonInstance, Domain.class);
+        domain.setConnection(sc);
+        return domain;
+    }
+
+    /**
+     * Gets the time in milliseconds when this domain was created.
+     * 
+     * @return the epoch time in milliseconds when the domain was created.
+     */
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Gets the user ID that created this instance.
+     * 
+     * @return the creation user ID
+     */
+    public String getCreationUser() {
+        return creationUser;
+    }
+
+    /**
+     * Gets the IBM Streams unique identifier for this domain.
+     * 
+     * @return the IBM Streams unique identifier.
+     */
+    public String getId() {
+        return id;
+    }
+
+
+    /**
+     * Gets the status of the domain.
+     *
+     * @return the instance status that contains one of the following values:
+     *         <ul>
+     *         <li>running</li>
+     *         <li>stopping</li>
+     *         <li>stopped</li>
+     *         <li>starting</li>
+     *         <li>removing</li>
+     *         <li>unknown</li>
+     *         </ul>
+     * 
+     */
+    public String getStatus() {
+        return status;
+    }
+    
+
+    /**
+     * Gets the ZooKeeper connection string for this domain.
+     * @return ZooKeeper connection string for this domain.
+     */
+    public String getZooKeeperConnectionString() {
+        return zooKeeperConnectionString;
+    }
+}

--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -229,6 +229,24 @@ public class Instance extends Element {
     public String getStatus() {
         return status;
     }
+    
+    private Domain _domain;
+    /**
+     * Get the Streams domain for this instance.
+     * 
+     * @return Domain for this instance.
+     * 
+     * @throws IOException Error communicating with REST api.
+     * 
+     * @since 1.8
+     */
+    public Domain getDomain() throws IOException {
+        if (_domain == null) {
+            String sReturn = connection().getResponseString(domain);
+            _domain = Domain.create(connection(), sReturn);
+        }
+        return _domain;
+    }
 
     /**
      * internal usae to get list of instances

--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -105,7 +105,7 @@ public class Instance extends Element {
     public List<Job> getJobs() throws IOException {
         String sReturn = connection().getResponseString(jobs);
 
-        List<Job> lJobs = Job.getJobList(connection(), sReturn);
+        List<Job> lJobs = Job.getJobList(this, sReturn);
         return lJobs;
     }
 
@@ -123,7 +123,7 @@ public class Instance extends Element {
         String sGetJobURI = jobs + "/" + jobId;
 
         String sReturn = connection().getResponseString(sGetJobURI);
-        Job job = Job.create(connection(), sReturn);
+        Job job = Job.create(this, sReturn);
         return job;
     }
 

--- a/java/src/com/ibm/streamsx/rest/Job.java
+++ b/java/src/com/ibm/streamsx/rest/Job.java
@@ -76,14 +76,17 @@ public class Job extends Element {
     private long submitTime;
     @Expose
     private String views;
+    
+    private Instance _instance;
 
-    static final Job create(AbstractStreamsConnection sc, String gsonJobString) {
+    static final Job create(Instance instance, String gsonJobString) {
         Job job = gson.fromJson(gsonJobString, Job.class);
-        job.setConnection(sc);
+        job.setConnection(instance.connection());
+        job._instance = instance;
         return job;
     }
 
-    static final List<Job> getJobList(AbstractStreamsConnection sc, String gsonJobList) {
+    static final List<Job> getJobList(Instance instance, String gsonJobList) {
         List<Job> jList;
         JobArray jobsArray;
         try {
@@ -92,7 +95,8 @@ public class Job extends Element {
 
             jList = jobsArray.jobs;
             for (Job job : jList) {
-                job.setConnection(sc);
+                job.setConnection(instance.connection());
+                job._instance = instance;
             }
         } catch (JsonSyntaxException e) {
             jList = Collections.<Job> emptyList();
@@ -114,7 +118,7 @@ public class Job extends Element {
     }
 
     /**
-     * Cancels this job
+     * Cancels this job.
      * 
      * @return the result of the cancel method
      *         <ul>
@@ -125,11 +129,8 @@ public class Job extends Element {
      * @throws Exception
      */
     public boolean cancel() throws Exception, IOException {
-        // Get the instance ID
-        String sReturn = connection().getResponseString(instance);
-        String instanceId = Instance.create(connection(), sReturn).getId();
-        return connection().cancelJob(instanceId, id);
-    }
+        return connection().cancelJob(this._instance, id);
+    }          
 
     /**
      * Gets the name of the streams processing application that this job is

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV1.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV1.java
@@ -43,8 +43,6 @@ class StreamingAnalyticsConnectionV1 extends AbstractStreamingAnalyticsConnectio
     /**
      * Cancels a job that has been submitted to IBM Streaming Analytics service
      *
-     * @param instanceId
-     *            string indicating the instance id of the job
      * @param jobId
      *            string indicating the job id to be canceled
      * @return boolean indicating
@@ -54,12 +52,8 @@ class StreamingAnalyticsConnectionV1 extends AbstractStreamingAnalyticsConnectio
      *         </ul>
      * @throws IOException
      */
-    boolean cancelJob(String instanceId, String jobId) throws IOException {
-        Instance instance = getInstance();
-        if (!instance.getId().equals(instanceId)) {
-            // Sanity check, should not happen
-            throw new RESTException("Unable to cancel job in instance " + instanceId);
-        }
+    @Override
+    boolean cancelJob(Instance instance, String jobId) throws IOException {
         String restUrl = StreamsRestUtils.getRequiredMember(credentials, "rest_url");
         String jobsUrl = restUrl + StreamsRestUtils.getRequiredMember(credentials, "jobs_path");
         return delete(jobsUrl + "?job_id=" + jobId);

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV2.java
@@ -67,7 +67,8 @@ class StreamingAnalyticsConnectionV2 extends AbstractStreamingAnalyticsConnectio
      *         </ul>
      * @throws IOException
      */
-    boolean cancelJob(String instanceId, String jobId) throws IOException {
+    @Override
+    boolean cancelJob(Instance instance, String jobId) throws IOException {
         if (null == jobsUrl) {
             String restUrl = jstring(credentials, "v2_rest_url");
             JsonObject response = StreamsRestUtils.getGsonResponse(executor,
@@ -78,11 +79,6 @@ class StreamingAnalyticsConnectionV2 extends AbstractStreamingAnalyticsConnectio
             } else {
                 throw new RESTException("Unable to get jobs URL");
             }
-        }
-        Instance instance = getInstance();
-        if (!instance.getId().equals(instanceId)) {
-            // Sanity check, should not happen
-            throw new RESTException("Unable to cancel job in instance " + instanceId);
         }
 
         return delete(jobsUrl + "/" + jobId);

--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -108,7 +108,14 @@ public class StreamsConnection {
     }
 
     /**
-     * Cancels a job at this streams connection identified by the jobId
+     * Cancels a job identified by the jobId.
+     * <BR>
+     * <B>WARNING:</B> This cancels the job in the domain
+     * and instance identified by the environment variables
+     * {@code STREAMS_DOMAIN_ID} and {@code STREAMS_INSTANCE_ID}
+     * which may not be the intended job.
+     * <BR>
+     * Use {@link Job#cancel()} to cancel a job.
      * 
      * @param jobId
      *            string identifying the job to be cancelled
@@ -118,7 +125,10 @@ public class StreamsConnection {
      *         <li>false if the jobId did not get cancelled</li>
      *         </ul>
      * @throws Exception
+     * @deprecated Not recommend for use as an instance is not uniquely defined
+     * by a {@code StreamsConnection}. Use {@link Job#cancel()}.
      */
+    @Deprecated
     public boolean cancelJob(String jobId) throws Exception {
         refreshState();
         InvokeCancel cancelJob = new InvokeCancel(new BigInteger(jobId), userName);

--- a/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
@@ -23,8 +23,9 @@ class StreamsConnectionImpl extends AbstractStreamsConnection {
     @Override
     boolean cancelJob(Instance instance, String jobId) throws IOException {
 
-        // TODO - correct domain id
-        InvokeCancel cancelJob = new InvokeCancel(null, instance.getId(), new BigInteger(jobId), userName);
+        InvokeCancel cancelJob = new InvokeCancel(
+                instance.getDomain().getId(), instance.getId(),
+                new BigInteger(jobId), userName);
         try {
             return cancelJob.invoke(false) == 0;
         } catch (Exception e) {

--- a/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 
 import com.ibm.streamsx.topology.internal.streams.InvokeCancel;
-import com.ibm.streamsx.topology.internal.streams.Util;
 
 class StreamsConnectionImpl extends AbstractStreamsConnection {
 
@@ -22,17 +21,15 @@ class StreamsConnectionImpl extends AbstractStreamsConnection {
     }
 
     @Override
-    boolean cancelJob(String instanceId, String jobId) throws IOException {
-        // Sanity check instance since InvokeCancel uses default instance
-        if (!Util.getDefaultInstanceId().equals(instanceId)) {
-            throw new RESTException("Unable to cancel job in instance " + instanceId);
-        }
-        InvokeCancel cancelJob = new InvokeCancel(new BigInteger(jobId), userName);
+    boolean cancelJob(Instance instance, String jobId) throws IOException {
+
+        // TODO - correct domain id
+        InvokeCancel cancelJob = new InvokeCancel(null, instance.getId(), new BigInteger(jobId), userName);
         try {
             return cancelJob.invoke(false) == 0;
         } catch (Exception e) {
             throw new RESTException("Unable to cancel job " + jobId
-                    + " in instance " + instanceId, e);
+                    + " in instance " + instance.getId(), e);
         }
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/streams/InvokeCancel.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/InvokeCancel.java
@@ -16,35 +16,53 @@ public class InvokeCancel {
 
     static final Logger trace = Util.STREAMS_LOGGER;
 
+    private final String domainId;
+    private final String instanceId;
     private final BigInteger jobId;
     private final String userName;
 
-    public InvokeCancel(BigInteger jobId, String userName) {
+    public InvokeCancel(String domainId, String instanceId, BigInteger jobId, String userName) {
         super();
+        this.domainId = domainId;
+        this.instanceId = instanceId;
         this.jobId = jobId;
         this.userName = userName;
+
+    }
+    public InvokeCancel(BigInteger jobId, String userName) {
+        this(null, null, jobId, userName);
     }
     public InvokeCancel(BigInteger jobId) {
-        super();
-        this.jobId = jobId;
-        this.userName = null;
+        this(jobId, null);
     }
 
     public int invoke(boolean throwOnError) throws Exception, InterruptedException {
         String si = Util.getStreamsInstall();
         File sj = new File(si, "bin/streamtool");
         
-        Util.checkInvokeStreamtoolPreconditions();
+        if (domainId == null)
+             Util.checkInvokeStreamtoolPreconditions();
 
         List<String> commands = new ArrayList<>();
 
         commands.add(sj.getAbsolutePath());
         commands.add("canceljob");
-        if ( null != userName )
+        if (domainId != null)
+        {
+          commands.add("--domain-id");
+          commands.add(domainId);
+        }
+        if (instanceId != null)
+        {
+          commands.add("--instance-id");
+          commands.add(instanceId);
+        }
+        if (null != userName)
         {
           commands.add("-U");
           commands.add(userName);
         }
+
         commands.add(jobId.toString());
 
         trace.info("Invoking streamtool canceljob " + jobId);

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsConnectionTest.java
@@ -23,6 +23,7 @@ import com.ibm.streamsx.rest.Instance;
 import com.ibm.streamsx.rest.RESTException;
 import com.ibm.streamsx.rest.StreamingAnalyticsConnection;
 
+@SuppressWarnings("deprecation")
 public class StreamingAnalyticsConnectionTest extends StreamsConnectionTest {
 
     @Override
@@ -64,6 +65,8 @@ public class StreamingAnalyticsConnectionTest extends StreamsConnectionTest {
         String instanceName = instances.get(0).getId();
         Instance i2 = connection.getInstance(instanceName);
         assertEquals(instanceName, i2.getId());
+        
+        checkDomainFromInstance(instances.get(0));
 
         try {
             // try a fake instance name

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
@@ -292,7 +292,7 @@ public class StreamsConnectionTest {
         try {
             // get a non-existant job
             @SuppressWarnings("unused")
-            Job nonExistantJob = instance.getJob("999999");
+            Job nonExistantJob = instance.getJob("9999999");
             fail("this job number should not exist");
         } catch (RESTException r) {
             assertEquals(r.toString(), 404, r.getStatusCode());
@@ -302,7 +302,7 @@ public class StreamsConnectionTest {
         // cancel a non-existant jobid
         // API does not specify if this fails or throws, accept both
         try {
-            boolean failCancel = connection.cancelJob("99999");
+            boolean failCancel = connection.cancelJob("9999999");
             assertTrue(failCancel == false);
         } catch (RESTException ok) {}
     }

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
@@ -20,6 +20,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.ibm.streamsx.rest.Domain;
 import com.ibm.streamsx.rest.InputPort;
 import com.ibm.streamsx.rest.Instance;
 import com.ibm.streamsx.rest.Job;
@@ -175,6 +176,17 @@ public class StreamsConnectionTest {
 
         i2.refresh();
         assertEquals(instanceName, i2.getId());
+        
+        for (Instance instance : instances) {
+            instance.refresh();
+            
+            Domain domain = instance.getDomain();
+            assertNotNull(domain);
+            assertNotNull(domain.getId());
+            assertNotNull(domain.getZooKeeperConnectionString());
+            assertNotNull(domain.getCreationUser());
+            assertTrue(domain.getCreationTime() <= instance.getCreationTime());
+        }
 
         try {
             // try a fake instance name

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
@@ -177,16 +177,8 @@ public class StreamsConnectionTest {
         i2.refresh();
         assertEquals(instanceName, i2.getId());
         
-        for (Instance instance : instances) {
-            instance.refresh();
-            
-            Domain domain = instance.getDomain();
-            assertNotNull(domain);
-            assertNotNull(domain.getId());
-            assertNotNull(domain.getZooKeeperConnectionString());
-            assertNotNull(domain.getCreationUser());
-            assertTrue(domain.getCreationTime() <= instance.getCreationTime());
-        }
+        for (Instance instance : instances)
+            checkDomainFromInstance(instance);
 
         try {
             // try a fake instance name
@@ -196,6 +188,19 @@ public class StreamsConnectionTest {
             // not a failure, this is the expected result
             assertEquals(r.toString(), 404, r.getStatusCode());
         }
+    }
+    
+    static void checkDomainFromInstance(Instance instance)  throws Exception {
+        instance.refresh();
+        
+        System.err.println("DDDDD" + " GET DOMAIN");
+        Domain domain = instance.getDomain();
+        System.err.println("DDDDD" + " GOT DOMAIN:" + domain.getId());
+        assertNotNull(domain);
+        assertNotNull(domain.getId());
+        assertNotNull(domain.getZooKeeperConnectionString());
+        assertNotNull(domain.getCreationUser());
+        assertTrue(domain.getCreationTime() <= instance.getCreationTime());
     }
 
     @Before
@@ -287,6 +292,7 @@ public class StreamsConnectionTest {
         assertEquals(2, pes.size());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCancelSpecificJob() throws Exception {
         if (jobId != null) {
@@ -299,6 +305,7 @@ public class StreamsConnectionTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testNonExistantJob() throws Exception {
         try {


### PR DESCRIPTION
The existing cancel job required an instance identifier and checked it but in reality the instance identifier always comes from the context of an `Instance` or `Job`.

The one place the instance identifier was (really) checked was  when the cancel was executed for a distributed instance using `streamtool` which uses the defaults from the environment variables (`STREAMS_DOMAIN_ID` and `STREAMS_INSTANCE_ID`). In this case while the instance id was checked, the domain id wasn't , so it was still possible to cancel the wrong job. [By being connected to one domain and cancelling through streamtool using a different default domain).

This fixes this by using passing the domain and instance identifiers to `streamtool` which required creation of a `Domain` object.

This also deprecates `StreamsConnection.canceljob` as it cancels by job identifier with no context about the instance the job is running in, since a `StreamsConnection` can be connected to a domain with many instances.