### PR TITLE
Java: Allow use of service credentials directly

### DIFF
--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -5,6 +5,7 @@
 
 package com.ibm.streamsx.rest;
 
+import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.SERVICE_DEFINITION;
 import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.SERVICE_NAME;
 import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.VCAP_SERVICES;
 
@@ -13,6 +14,7 @@ import java.io.IOException;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.ibm.streamsx.topology.context.AnalyticsServiceProperties;
 import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 
 /**
@@ -84,13 +86,9 @@ public interface StreamingAnalyticsService {
      * @since 1.8
      */
     static StreamingAnalyticsService of(JsonObject serviceDefinition) throws IOException {
-        
-        // Create a VCAP services that contains our single service
-        JsonObject singleVcap = VcapServices.vcapFromServiceDefinition(serviceDefinition);
-        
+                
         JsonObject config = new JsonObject();
-        config.add(VCAP_SERVICES, singleVcap);
-        config.addProperty(SERVICE_NAME, VcapServices.nameFromServiceDefinition(serviceDefinition));
+        config.add(SERVICE_DEFINITION, serviceDefinition);
         
         return AbstractStreamingAnalyticsService.of(config);
     }

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.ibm.streamsx.topology.context.AnalyticsServiceProperties;
-import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 
 /**
  * Access to a Streaming Analytics service on IBM Cloud.

--- a/java/src/com/ibm/streamsx/topology/context/AnalyticsServiceProperties.java
+++ b/java/src/com/ibm/streamsx/topology/context/AnalyticsServiceProperties.java
@@ -4,23 +4,64 @@
  */
 package com.ibm.streamsx.topology.context;
 
+/**
+ * Configuration properties for the Streaming Analytics service
+ * on IBM Cloud.
+ * 
+ * When submitting to a Streaming Analytics service <B>one</B>
+ * of these two sets of information must be provided:
+ * <UL>
+ * <LI>
+ * {@linkplain #SERVICE_DEFINITION Service definition}.
+ * </LI>
+ * <LI>
+ * IBM Cloud {@linkplain VCAP_SERVICES service definitions} and
+ * a {@linkplain #SERVICE_NAME service name}. The named service must exist in
+ * service definitions and must be of type {@code streaming-analytics}.
+ * </LI>
+ * </UL>
+ * A {@code SERVICE_DEFINITION} takes precedence over {@code VCAP_SERVICES} and
+ * {@code SERVICE_NAME}.
+ *
+ * @see StreamsContext.Type#STREAMING_ANALYTICS_SERVICE
+*/
 public interface AnalyticsServiceProperties {
     /**
      * Name of the service to use as a {@code String}.
      * The information for the service will be extracted
-     * from the VCAP using this name. This property must be
+     * from the VCAP service definitions using this name. This property must be
      * set when submitting to {@link StreamsContext.Type#STREAMING_ANALYTICS_SERVICE}.
      */
     String SERVICE_NAME = "topology.service.name";
     
     /**
-     * Definition of IBM Bluemix services. The value
-     * may be:
+     * IBM Cloud service definitions.
+     * 
+     * The value may be:
      * <UL>
      * <LI>{@code java.io.File} - File containing the VCAP services JSON.</LI>
      * <LI>{@code String} - String containing the VCAP services serialized JSON.</LI>
      * <LI>{@code com.ibm.json.java.JSONObject} - JSON object containing the VCAP services.</LI>
      * </UL>
+     * If not set then the environment variable {@code VCAP_SERVICES} is assumed
+     * to contain service definitions directly or a file name containing the definitions.
      */
     String VCAP_SERVICES = "topology.service.vcap";
+    
+    /**
+     * Definition of a Streaming Analytics service. A service definition is a JSON
+     * object describing a Streaming Analytics service.
+     * <UL>
+     * <LI>The <em>service credentials</em> copied from the <em>Service credentials</em>
+     * page of the service console (not the Streams console).
+     * Credentials are provided in JSON format. They contain such as
+     * the API key and secret, as well as connection information for the service.
+     * <LI>A JSON object of the form:
+     * <code>{ "type": "streaming-analytics", "name": "</code><em>service-name</em><code>", "credentials": {...} }</code>
+     * with the <em>service credentials</em> as the value of the {@code credentials} key</LI>
+     * </UL>
+     * 
+     * @since 1.8
+     */
+    String SERVICE_DEFINITION = "topology.service.definition";
 }

--- a/java/src/com/ibm/streamsx/topology/context/StreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/context/StreamsContext.java
@@ -218,7 +218,7 @@ public interface StreamsContext<T> {
          * cloud platform.
          * <P>
          * The returned type for the {@code submit} calls is
-         * a {@code Future&lt;BigInteger>} where the value is
+         * a {@code Future<BigInteger>} where the value is
          * the job identifier.
          * <BR>
          * When {@code submit} returns the {@code Future} will be complete,
@@ -235,12 +235,24 @@ public interface StreamsContext<T> {
          * <LI>Using the environment variable {@code VCAP_SERVICES}</LI>
          * </UL>
          * </P>
+         * <P>
+         * If the environment variable {@code STREAMS_INSTALL} is set to a non-empty value
+         * then a Streams Application bundle ({@code sab} file) is created locally using
+         * the IBM Streams install and submitted to the service. This may be overridden
+         * by setting the context property {@link ContextProperties#FORCE_REMOTE_BUILD FORCE_REMOTE_BUILD}
+         * to {@code true}.
+         * <.P>
          */
         STREAMING_ANALYTICS_SERVICE,
         
         /**
          * Testing variant of {@link #STREAMING_ANALYTICS_SERVICE}.
-         * 
+         * <P>
+         * This context ignores any local IBM Streams install defined by the
+         * environment variable {@code STREAMS_INSTALL}, thus
+         * the Streams Application bundle ({@code sab} file) is created using
+         * the build service.
+         * </P>
          * @since 1.7
          */
         STREAMING_ANALYTICS_SERVICE_TESTER,

--- a/java/src/com/ibm/streamsx/topology/internal/context/JSONStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/JSONStreamsContext.java
@@ -122,6 +122,8 @@ public abstract class JSONStreamsContext<T> extends StreamsContextImpl<T> {
             return new JsonPrimitive((Number) value);
         else if (value instanceof String) {
             return new JsonPrimitive((String) value);
+        } else if (value instanceof JsonElement) {
+            return (JsonElement) value;
         } else if (JSON4JBridge.isJson4J(value)) {
             return JSON4JBridge.fromJSON4J(value);
         } else if (value instanceof Collection) {

--- a/java/src/com/ibm/streamsx/topology/internal/context/streams/AnalyticsServiceStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streams/AnalyticsServiceStreamsContext.java
@@ -4,11 +4,9 @@
  */
 package com.ibm.streamsx.topology.internal.context.streams;
 
-import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.SERVICE_NAME;
-import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.VCAP_SERVICES;
 import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.deploy;
 import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.keepArtifacts;
-import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
+import static com.ibm.streamsx.topology.internal.context.remote.RemoteBuildAndSubmitRemoteContext.streamingAnalyticServiceFromDeploy;
 import static com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices.getVCAPService;
 
 import java.io.File;
@@ -25,7 +23,6 @@ import com.ibm.streamsx.topology.internal.context.remote.DeployKeys;
 import com.ibm.streamsx.topology.internal.context.remote.SubmissionResultsKeys;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.internal.process.CompletedFuture;
-import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 
 public class AnalyticsServiceStreamsContext extends
         BundleUserStreamsContext<BigInteger> {
@@ -89,10 +86,7 @@ public class AnalyticsServiceStreamsContext extends
         JsonObject deploy =  deploy(submission);
         JsonObject jco = DeployKeys.copyJobConfigOverlays(deploy);
 
-        JsonObject vcapServices = VcapServices.getVCAPServices(deploy.get(VCAP_SERVICES));
-
-        final StreamingAnalyticsService sas = StreamingAnalyticsService.of(vcapServices,
-                jstring(deploy, SERVICE_NAME));
+        final StreamingAnalyticsService sas = streamingAnalyticServiceFromDeploy(deploy); 
 
         Result<Job, JsonObject> submitResult = sas.submitJob(bundle, jco);
         final JsonObject submissionResult = GsonUtilities.objectCreate(submission,

--- a/java/src/com/ibm/streamsx/topology/internal/streaminganalytics/VcapServices.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streaminganalytics/VcapServices.java
@@ -92,12 +92,7 @@ public class VcapServices {
         if (deploy.has(SERVICE_DEFINITION)) {
             JsonObject definition = GsonUtilities.object(deploy, SERVICE_DEFINITION);
             services = vcapFromServiceDefinition(definition);
-            serviceName = nameFromServiceDefinition(definition);
-            
-            // Add the values to use back into the deploy
-            //deploy.add(VCAP_SERVICES, services);
-            //deploy.addProperty(SERVICE_NAME, serviceName);
-            
+            serviceName = nameFromServiceDefinition(definition);            
         } else {      
              services = getVCAPServices(deploy.get(VCAP_SERVICES));
         }

--- a/java/src/com/ibm/streamsx/topology/internal/streaminganalytics/VcapServices.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streaminganalytics/VcapServices.java
@@ -21,7 +21,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.ibm.streamsx.topology.context.AnalyticsServiceProperties;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 
 /**

--- a/java/src/com/ibm/streamsx/topology/internal/tester/rest/RESTTesterRuntime.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/rest/RESTTesterRuntime.java
@@ -4,8 +4,7 @@
  */
 package com.ibm.streamsx.topology.internal.tester.rest;
 
-import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.SERVICE_NAME;
-import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.VCAP_SERVICES;
+import static com.ibm.streamsx.topology.internal.context.remote.RemoteBuildAndSubmitRemoteContext.streamingAnalyticServiceFromDeploy;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jobject;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
 import static java.util.Objects.requireNonNull;
@@ -14,12 +13,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.ibm.streams.flow.handlers.StreamHandler;
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streamsx.rest.Job;
-import com.ibm.streamsx.rest.StreamingAnalyticsConnection;
 import com.ibm.streamsx.rest.StreamingAnalyticsService;
 import com.ibm.streamsx.topology.TSink;
 import com.ibm.streamsx.topology.TStream;
@@ -52,10 +49,8 @@ public class RESTTesterRuntime extends TesterRuntime {
     public void start(Object info) throws Exception {
         
         JsonObject deployment = (JsonObject) info;
-
-        JsonElement vcapServices = deployment.get(VCAP_SERVICES);
-        String serviceName = jstring(deployment, SERVICE_NAME);
-        StreamingAnalyticsService sas = StreamingAnalyticsService.of(vcapServices, serviceName);
+        
+        final StreamingAnalyticsService sas = streamingAnalyticServiceFromDeploy(deployment);  
 
         JsonObject submission = jobject(deployment, "submissionResults");
         requireNonNull(submission);

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -341,6 +341,7 @@
              excludes="**/samples/*Test.java" >
              <include name="**/StreamsConnectionTest.java"/>
              <include name="**/StreamingAnalyticsConnectionTest.java"/>
+             <include name="**/StreamingAnalyticsServiceTest.java"/>
           </fileset>
        </batchtest>
      </junit>

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsServiceTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsServiceTest.java
@@ -1,0 +1,112 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+ */
+
+package com.ibm.streamsx.rest.test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeNotNull;
+
+import java.io.File;
+import java.io.FileReader;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.ibm.streamsx.rest.Instance;
+import com.ibm.streamsx.rest.StreamingAnalyticsService;
+
+/**
+ * Basic initial test of StreamingAnalyticsService
+ * Test assumes VCAP_SERVICES and STREAMING_ANALYTICS_SERVICE name are setup
+ * in order to test.
+ */
+public class StreamingAnalyticsServiceTest {
+    
+    @BeforeClass
+    public static void checkRunnable() throws Exception {
+
+        String vcapServices = System.getenv("VCAP_SERVICES");
+        assumeNotNull(serviceName(), vcapServices);
+    }
+    
+    private static JsonElement services() {
+        String vcapServices = System.getenv("VCAP_SERVICES");
+        if (vcapServices.startsWith(File.separator))
+            return new JsonPrimitive(vcapServices);
+        JsonParser parser = new JsonParser();
+       
+        return parser.parse(vcapServices);
+    }  
+    
+    private static String serviceName() {
+        return System.getenv("STREAMING_ANALYTICS_SERVICE_NAME");
+    }
+    
+    private static JsonObject credentials() throws Exception {
+        JsonElement _services = services();
+        JsonObject services;
+        if (_services.isJsonObject()) {
+            services = _services.getAsJsonObject();
+        } else {
+            JsonParser parser = new JsonParser();
+            services = parser.parse(new FileReader(_services.getAsString())).getAsJsonObject();
+        }
+        
+        String name = serviceName();
+        JsonArray sas = services.get("streaming-analytics").getAsJsonArray();
+        for (JsonElement e : sas) {
+            JsonObject service = e.getAsJsonObject();
+            if (name.equals(service.get("name").getAsString())) {
+                return service.getAsJsonObject("credentials");
+            }
+        }
+        
+        throw new IllegalStateException("No service!");
+    }
+    
+    @Test
+    public void testUsingDefaults()throws Exception {
+        use_it(StreamingAnalyticsService.of(null, null));
+    }
+    
+    @Test
+    public void testUsingExplicitName()throws Exception {
+        use_it(StreamingAnalyticsService.of(null, serviceName()));
+    }
+    @Test
+    public void testUsingExplicitServices()throws Exception {
+        use_it(StreamingAnalyticsService.of(services(), null));
+    }
+    @Test
+    public void testUsingExplicit()throws Exception {
+        use_it(StreamingAnalyticsService.of(services(), serviceName()));
+    }
+    
+    @Test
+    public void testUsingCredentials()throws Exception {
+        use_it(StreamingAnalyticsService.of(credentials()));
+    }
+    @Test
+    public void testUsingDescriptor()throws Exception {
+        JsonObject desc = new JsonObject();
+        desc.addProperty("type", "streaming-analytics");
+        desc.addProperty("name", "my-cool-service");
+        desc.add("credentials", credentials());
+        
+        use_it(StreamingAnalyticsService.of(desc));
+    }
+    
+    private void use_it(StreamingAnalyticsService service) throws Exception {
+        assertNotNull(service);
+        Instance instance = service.getInstance();
+        assertNotNull(instance);      
+        assertNotNull(instance.getJobs());
+    }
+}

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsServiceTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsServiceTest.java
@@ -49,7 +49,7 @@ public class StreamingAnalyticsServiceTest {
         return System.getenv("STREAMING_ANALYTICS_SERVICE_NAME");
     }
     
-    private static JsonObject credentials() throws Exception {
+    public static JsonObject credentials() throws Exception {
         JsonElement _services = services();
         JsonObject services;
         if (_services.isJsonObject()) {

--- a/test/java/src/com/ibm/streamsx/topology/test/cloud/ServiceSubmissionAPITest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/cloud/ServiceSubmissionAPITest.java
@@ -1,0 +1,141 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2015  
+ */
+package com.ibm.streamsx.topology.test.cloud;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.math.BigInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.ibm.streamsx.rest.Job;
+import com.ibm.streamsx.rest.StreamingAnalyticsService;
+import com.ibm.streamsx.rest.test.StreamingAnalyticsServiceTest;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.context.AnalyticsServiceProperties;
+import com.ibm.streamsx.topology.context.StreamsContext;
+import com.ibm.streamsx.topology.context.StreamsContextFactory;
+import com.ibm.streamsx.topology.test.TestTopology;
+
+public class ServiceSubmissionAPITest extends TestTopology {
+    
+    private String vcapServices;
+    private String serviceName;
+    private boolean localInstall;
+    
+    @Before
+    public void checkServiceAndSaveEnv() {
+        
+        assumeTrue(isStreamingAnalyticsRun());
+        
+        vcapServices = System.getenv("VCAP_SERVICES");
+        serviceName = System.getenv("STREAMING_ANALYTICS_SERVICE_NAME");
+        
+        String si = System.getenv("STREAMS_INSTALL");
+        localInstall = si != null && !si.isEmpty();
+        
+        assumeTrue(vcapServices != null);
+        assumeTrue(serviceName != null);
+    }
+    
+    @Test
+    public void testFromEnv() throws Exception {
+        submitApp("testFromEnv");
+    }
+    
+    @Test
+    public void testFromConfig() throws Exception {
+        getConfig().put(AnalyticsServiceProperties.VCAP_SERVICES, vcapServices);
+        getConfig().put(AnalyticsServiceProperties.SERVICE_NAME, serviceName);
+              
+        submitApp("testFromConfig");
+    }
+    
+    @Test
+    public void testFromCredentials() throws Exception {
+        getConfig().put(AnalyticsServiceProperties.SERVICE_DEFINITION, StreamingAnalyticsServiceTest.credentials());
+        
+        getConfig().put(AnalyticsServiceProperties.VCAP_SERVICES, "{}");
+        getConfig().put(AnalyticsServiceProperties.SERVICE_NAME, "no such service - ignored");
+              
+        submitApp("testFromCredentials");
+    }
+    
+    @Test
+    public void testFromDefinitions() throws Exception {
+        
+        JsonObject def = new JsonObject();
+        def.addProperty("type", "streaming-analytics");
+        def.addProperty("name", serviceName);
+        def.add("credentials", StreamingAnalyticsServiceTest.credentials());
+        
+        getConfig().put(AnalyticsServiceProperties.SERVICE_DEFINITION, def);
+        
+        getConfig().put(AnalyticsServiceProperties.VCAP_SERVICES, "{}");
+        getConfig().put(AnalyticsServiceProperties.SERVICE_NAME, "no such service - ignored");
+              
+        submitApp("testFromDefinition");
+    }
+    
+    
+    /**
+     * Create a simple app for testing, really only
+     * interested if a job can be submitted, not what the job does.
+     */
+    private TStream<String> createTopology(String name) {
+        final Topology topo = newTopology(name);
+        
+        TStream<String> source = topo.strings("streaming", "analytics", "service");
+        
+        return source;
+    }
+    
+       
+    private void submitApp(String name) throws Exception {
+       
+        TStream<String> source = createTopology(name);
+        
+        if (localInstall) {
+            submitFromBundle(source.topology());
+            return;
+        }
+ 
+        // testing service always submits using a remote build.
+        completeAndValidate(source, 10, "streaming", "analytics", "service");
+    }
+
+    private void submitFromBundle(Topology topology) throws Exception {
+        
+        @SuppressWarnings("unchecked")
+        StreamsContext<BigInteger> ctx = (StreamsContext<BigInteger>) StreamsContextFactory.getStreamsContext("STREAMING_ANALYTICS_SERVICE");
+        BigInteger jobId = ctx.submit(topology, getConfig()).get();
+        assertNotNull(jobId);
+        
+        JsonElement vse;
+        if (vcapServices.startsWith(File.separator))
+            vse = new JsonPrimitive(vcapServices);
+        else
+            vse = new JsonParser().parse(vcapServices);
+        
+        StreamingAnalyticsService sas = StreamingAnalyticsService.of(
+                vse, serviceName);
+        
+        Job job = sas.getInstance().getJob(jobId.toString());
+        assertNotNull(job);
+        boolean canceled = job.cancel();
+        assertTrue(canceled);
+        
+        
+    }
+}


### PR DESCRIPTION
See #1331

- [x]  Creation of Java `StreamingAnalyticsService` from service definition.
- [x]  Submission of jobs from Java using service definition.

Includes a new `StreamingAnalyticServiceTest` to test the new & existing factory method.