### PR TITLE
Add checkStatus

### DIFF
--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -92,6 +92,35 @@ public interface StreamingAnalyticsService {
     }
     
     /**
+     * Get the service name.
+     * If the name is unknown then {@code service} is returned.
+     * @return Service name or {@code service} if it is unknown.
+     */
+    String getName();
+    
+    /**
+     * Check the status of this Streaming Analytics Service.
+     * <P>
+     * The returned {@link Result} instance has:
+     * <UL>
+     * <LI>{@link Result#getId()} returning {@code null}.</LI>
+     * <LI>{@link Result#getElement()} returning {@code this}.</LI>
+     * <LI>{@link Result#getRawResult()} return the raw JSON response.</LI>
+     * <LI>{@link Result#isOk()} returns {@code true} if the service is running otherwise {@code false}.</LI>
+     * </UL>
+     * </P>
+     * 
+     * @param requireRunning If {@code true} and the service is not running then an {@code IllegalStateException}
+     * is thrown, otherwise the return indicates the status of the service.
+     * 
+     * @return Result of the status check.
+     * 
+     * @throws IOException Error communicating with the service.
+     * @throws IllegalStateException {@code requireRunning} is {@code true} and the service is not running.
+     */
+    Result<StreamingAnalyticsService,JsonObject> checkStatus(boolean requireRunning) throws IOException;
+    
+    /**
      * Submit a Streams bundle to run on the Streaming Analytics Service.
      * <P>
      * The returned {@link Result} instance has:

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
@@ -172,7 +172,7 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
 
         JsonObject jso = StreamsRestUtils.getGsonResponse(httpclient, httpput);
 
-        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + serviceName + "): submit job response: " + jso.toString());
+        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + getName() + "): submit job response: " + jso.toString());
         return jso;
     }
 
@@ -197,7 +197,7 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
 
         JsonObject jsonResponse = StreamsRestUtils.getGsonResponse(httpClient, postJobWithConfig);
 
-        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + serviceName + "): submit job response:" + jsonResponse.toString());
+        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + getName() + "): submit job response:" + jsonResponse.toString());
 
         return jsonResponse;
     }

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
@@ -186,7 +186,7 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
         postArtifact.setEntity(reqEntity);
 
         JsonObject jso = StreamsRestUtils.getGsonResponse(httpclient, postArtifact);
-        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + serviceName + "): submit job response: " + jso.toString());
+        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + getName() + "): submit job response: " + jso.toString());
         return jso;
     }
 
@@ -211,7 +211,7 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
 
         JsonObject jsonResponse = StreamsRestUtils.getGsonResponse(httpClient, postJobWithConfig);
 
-        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + serviceName + "): submit job response:" + jsonResponse.toString());
+        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + getName() + "): submit job response:" + jsonResponse.toString());
 
         return jsonResponse;
     }

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteBuildAndSubmitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteBuildAndSubmitRemoteContext.java
@@ -52,6 +52,9 @@ public class RemoteBuildAndSubmitRemoteContext extends ZippedToolkitRemoteContex
 	    File buildArchive =  archive.get();
 		
 	    try {
+	        
+	        RemoteContexts.checkServiceRunning(sas);
+	        
 	        Result<Job, JsonObject> submitResult = sas.buildAndSubmitJob(buildArchive, jco, buildName);
 	        final JsonObject submissionResult = GsonUtilities.objectCreate(submission,
 	                RemoteContext.SUBMISSION_RESULTS);

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteContexts.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteContexts.java
@@ -8,6 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import com.google.gson.JsonObject;
+import com.ibm.streamsx.rest.Result;
+import com.ibm.streamsx.rest.StreamingAnalyticsService;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 
@@ -27,5 +29,15 @@ public class RemoteContexts {
         // Write to the file and close the file.
         JsonObject results_json = GsonUtilities.objectCreate(submission, RemoteContext.SUBMISSION_RESULTS);        
         Files.write(Paths.get(resultsFile), results_json.toString().getBytes(StandardCharsets.UTF_8));
+    }
+    
+    public static void checkServiceRunning(StreamingAnalyticsService service) throws IOException {
+        final String serviceName = service.getName();
+        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + serviceName + "): Checking status");
+
+        Result<StreamingAnalyticsService, JsonObject> status = service.checkStatus(true);
+
+        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + serviceName + "): instance status response:" +
+                status.getRawResult().toString());
     }
 }

--- a/java/src/com/ibm/streamsx/topology/internal/context/streams/AnalyticsServiceStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streams/AnalyticsServiceStreamsContext.java
@@ -20,6 +20,7 @@ import com.ibm.streamsx.rest.Result;
 import com.ibm.streamsx.rest.StreamingAnalyticsService;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
 import com.ibm.streamsx.topology.internal.context.remote.DeployKeys;
+import com.ibm.streamsx.topology.internal.context.remote.RemoteContexts;
 import com.ibm.streamsx.topology.internal.context.remote.SubmissionResultsKeys;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.internal.process.CompletedFuture;
@@ -87,6 +88,8 @@ public class AnalyticsServiceStreamsContext extends
         JsonObject jco = DeployKeys.copyJobConfigOverlays(deploy);
 
         final StreamingAnalyticsService sas = streamingAnalyticServiceFromDeploy(deploy); 
+        
+        RemoteContexts.checkServiceRunning(sas);
 
         Result<Job, JsonObject> submitResult = sas.submitJob(bundle, jco);
         final JsonObject submissionResult = GsonUtilities.objectCreate(submission,

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsConnectionTest.java
@@ -33,7 +33,6 @@ public class StreamingAnalyticsConnectionTest extends StreamsConnectionTest {
             String vcapServices = System.getenv("VCAP_SERVICES");
 
             // if we don't have serviceName or vcapServices, skip the test
-            System.out.println("Checking STREAMING_ANALYTICS_SERVICE_NAME and VCAP_SERVICES is not NULL ...");
             assumeNotNull(serviceName, vcapServices);
 
             testType = "STREAMING_ANALYTICS_SERVICE";

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsServiceTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamingAnalyticsServiceTest.java
@@ -6,6 +6,9 @@
 package com.ibm.streamsx.rest.test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeNotNull;
 
 import java.io.File;
@@ -20,6 +23,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import com.ibm.streamsx.rest.Instance;
+import com.ibm.streamsx.rest.Result;
 import com.ibm.streamsx.rest.StreamingAnalyticsService;
 
 /**
@@ -104,9 +108,30 @@ public class StreamingAnalyticsServiceTest {
     }
     
     private void use_it(StreamingAnalyticsService service) throws Exception {
+        
+        
         assertNotNull(service);
+                
+        Result<StreamingAnalyticsService, JsonObject> cs = service.checkStatus(false);
+        assertNotNull(cs);
+        assertSame(service, cs.getElement());
+        assertNull(cs.getId());
+        assertTrue(cs.isOk());
+        assertNotNull(cs.getRawResult());
+        
+        cs = service.checkStatus(true);
+        assertNotNull(cs);
+        assertSame(service, cs.getElement());
+        assertNull(cs.getId());
+        assertTrue(cs.isOk());
+        assertNotNull(cs.getRawResult());
+
+
+        
         Instance instance = service.getInstance();
         assertNotNull(instance);      
         assertNotNull(instance.getJobs());
+        
+        
     }
 }


### PR DESCRIPTION
Add `StreamingAnalyticsService.checkStatus`.

Since the REST api is a wrapper around the Service REST api don't perform check status calls in the submit job methods, instead that's a choice for *clients* of the api.

Now topology as a client performs the check status before it submits a job.

