### PR TITLE
Use remote build when local environment is not a match for service

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/context/JSONStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/JSONStreamsContext.java
@@ -39,16 +39,26 @@ public abstract class JSONStreamsContext<T> extends StreamsContextImpl<T> {
         public final Topology app;
         public final Map<String,Object> config;
         public JsonObject submission;
+        public final Map<Object,Object> saved = Collections.synchronizedMap(new HashMap<>());
         
-        public AppEntity(Topology app, Map<String,Object> config) throws Exception {
+        AppEntity(Topology app, Map<String,Object> config) throws Exception {
             this.app = app;
             this.config = config;
             
         }
-        public AppEntity(JsonObject submission) {
+        AppEntity(JsonObject submission) {
             this.app = null;
             this.config = null;
             this.submission = submission;
+        }
+        
+        public Object getSavedObject(Object key) {
+            return saved.get(key);
+        }
+        
+        public <T> T saveObject(Object key, T value) {
+            saved.put(key, value);
+            return value;
         }
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/context/streams/AnalyticsServiceStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streams/AnalyticsServiceStreamsContext.java
@@ -13,7 +13,11 @@ import static com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.util.List;
 import java.util.concurrent.Future;
 
 import com.google.gson.JsonObject;
@@ -60,11 +64,83 @@ public class AnalyticsServiceStreamsContext extends
      * 
      * Remote build if:
      *  - FORCE_REMOTE_BUILD is set to true.
+     *  - Architecture cannot be determined as x86_64. (assumption that service is always x86_64)
+     *  - OS is not Linux.
+     *  - OS is not centos or redhat
+     *  - OS is less than version 6.
      */
     private boolean useRemoteBuild(AppEntity entity) {
-        if (jboolean(deploy(entity.submission), FORCE_REMOTE_BUILD))
+        
+        assert System.getenv("STREAMS_INSTALL") != null;
+        assert !System.getenv("STREAMS_INSTALL").isEmpty();
+        
+        final JsonObject deploy = deploy(entity.submission);        
+        if (jboolean(deploy, FORCE_REMOTE_BUILD))
             return true;
         
+        try {
+            final OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+            
+            final String arch = os.getArch();
+            boolean x86_64 = "x86_64".equalsIgnoreCase(arch) || "amd64".equalsIgnoreCase(arch);
+            if (!x86_64)
+                return true;
+            
+            if (!"Linux".equalsIgnoreCase(os.getName()))
+                return true; 
+                        
+            // /etc/system-release-cpe examples
+            //
+            // cpe:/o:centos:linux:6:GA
+            // cpe:/o/redhat:enterprise_linux:7.2:ga:server
+           
+            File cpeFile = new File("/etc/system-release-cpe");
+            if (!cpeFile.isFile())
+                return true;
+            List<String> lines = Files.readAllLines(cpeFile.toPath());
+            
+            String osVendor = null;
+            String osVersion = null;
+            String osUpdate = null;
+            for (String cpe : lines) {
+                cpe = cpe.trim();
+                if (!cpe.startsWith("cpe:"))
+                    continue;
+                String[] comps = cpe.split(":");
+                if (comps.length < 6)
+                    continue;
+                if (!"cpe".equals(comps[0]))
+                    continue;  
+                if (!"/o".equals(comps[1]))
+                    continue;
+                
+                if (!comps[2].isEmpty()) {
+                    osVendor = comps[2];
+                    osVersion = comps[4];
+                    osUpdate = comps[5];
+                }
+            }
+            
+            // If we can' determine the info, force remote
+            if (osVendor == null || osVendor.isEmpty())
+                return true;
+            if (osVersion == null || osVersion.isEmpty())
+                return true;
+            if (osUpdate == null || osUpdate.isEmpty())
+                return true;
+            
+            if (!"centos".equals(osVendor) && !"redhat".equals(osVendor))
+                return true;
+
+            double version = Double.valueOf(osVersion);
+            if (version < 6)
+                return true;
+            
+        } catch (SecurityException | IOException | NumberFormatException e) {
+            // Can't determine information, force remote.
+            return true;
+        }
+     
         return false;
     }
     


### PR DESCRIPTION
- [x] Add local conditions that force remote build (ones that do not require a check of the service, such as running on non x86_64)
- [x] Check service OS version and force remote build if not a match.