### PR TITLE
Add StreamingAnalyticsConnection.of_definition

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -42,6 +42,7 @@ import os
 import json
 import logging
 from pprint import pformat
+import streamsx.topology.context
 
 from streamsx import st
 from .rest_primitives import (Domain, Instance, Installation, Resource, _StreamsRestClient, StreamingAnalyticsService,
@@ -209,6 +210,25 @@ class StreamingAnalyticsConnection(StreamsConnection):
         super(StreamingAnalyticsConnection, self).__init__(self.credentials['userid'], self.credentials['password'])
         self._analytics_service = True
 
+    @staticmethod
+    def of_definition(service_def):
+       """Create a connection to a Streaming Analytics service.
+
+       The single service is defined by `service_def` which can be one of
+
+               * The `service credentials` copied from the `Service credentials` page of the service console (not the Streams console). Credentials are provided in JSON format. They contain such as the API key and secret, as well as connection information for the service. 
+               * A JSON object (`dict`) of the form: ``{ "type": "streaming-analytics", "name": "service name", "credentials": {...} }`` with the `service credentials` as the value of the ``credentials`` key.
+
+       Args:
+           service_def(dict): Definition of the service to connect to.
+
+       Returns:
+           StreamingAnalyticsConnection: Connection to defined service.
+       """
+       vcap_services = streamsx.topology.context._vcap_from_service_definition(service_def)
+       service_name = streamsx.topology.context._name_from_service_definition(service_def)
+       return StreamingAnalyticsConnection(vcap_services, service_name)
+        
     @property
     def resource_url(self):
         """str: Root URL for IBM Streams REST API"""

--- a/test/python/rest/test_rest_service_definition.py
+++ b/test/python/rest/test_rest_service_definition.py
@@ -1,0 +1,42 @@
+import unittest
+import os
+import json
+from streamsx.rest import StreamingAnalyticsConnection
+
+class TestServiceDefinition(unittest.TestCase):
+    """Tests getting a connection using a service definition
+    rather than a vcap, service name pair.
+    """
+    def setUp(self):
+        self.vcap_file = os.environ.get('VCAP_SERVICES')
+        if self.vcap_file is None:
+            raise unittest.SkipTest("No VCAP SERVICES env var")
+
+        with open(self.vcap_file) as vcap_json_data:
+            self.vcap_services = json.load(vcap_json_data)
+        self.service_name = os.environ.get('STREAMING_ANALYTICS_SERVICE_NAME')
+ 
+
+    def test_service_def(self):
+        """ Test a connection using a service definition."""
+        creds = {}
+        for s in self.vcap_services['streaming-analytics']:
+            if s['name'] == self.service_name:
+               creds = s['credentials']
+
+        service = {'type':'streaming-analytics', 'name':self.service_name}
+        service['credentials'] = creds
+        sasc = StreamingAnalyticsConnection.of_definition(service)
+        instances = sasc.get_instances()
+        self.assertEqual(1, len(instances))
+
+    def test_credentials(self):
+        """ Test a connection using a credentials."""
+        creds = {}
+        for s in self.vcap_services['streaming-analytics']:
+            if s['name'] == self.service_name:
+               creds = s['credentials']
+
+        sasc = StreamingAnalyticsConnection.of_definition(creds)
+        instances = sasc.get_instances()
+        self.assertEqual(1, len(instances))


### PR DESCRIPTION
Allows a connection to a service directly from a service definition instead of a vcap services, service name pair.