### PR TITLE
Allow submission time parameter as topic when microservice is created with Java Application API

### DIFF
--- a/java/src/com/ibm/streamsx/topology/spl/SPLStreams.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLStreams.java
@@ -21,9 +21,11 @@ import com.ibm.streamsx.topology.builder.BInputPort;
 import com.ibm.streamsx.topology.builder.BOperatorInvocation;
 import com.ibm.streamsx.topology.function.BiFunction;
 import com.ibm.streamsx.topology.function.Function;
+import com.ibm.streamsx.topology.function.Supplier;
 import com.ibm.streamsx.topology.internal.core.JavaFunctional;
 import com.ibm.streamsx.topology.internal.core.JavaFunctionalOps;
 import com.ibm.streamsx.topology.internal.logic.LogicUtils;
+import com.ibm.streamsx.topology.logic.Value;
 
 /**
  * Utilities for SPL attribute schema streams.
@@ -43,9 +45,19 @@ public class SPLStreams {
      */
     public static SPLStream subscribe(TopologyElement te, String topic,
             StreamSchema schema) {
+    	return subscribe(te, Value.of(topic), schema);
+    }
 
+    public static SPLStream subscribe(TopologyElement te, Supplier<String> topic, StreamSchema schema) {
+    	return _subscribe(te, topic, schema);
+    }
+
+    private static SPLStream _subscribe(TopologyElement te, Supplier<String> topic, StreamSchema schema) {
         Map<String, Object> params = new HashMap<>();
-
+        
+        if(topic == null)
+        	throw new IllegalArgumentException("topic");
+                
         params.put("topic", topic);
         params.put("streamType", schema);
 
@@ -55,7 +67,7 @@ public class SPLStreams {
 
         return stream;
     }
-
+    
     /**
      * Convert a {@code Stream} to an {@code SPLStream}. For each tuple
      * {@code t} on {@code stream}, the returned stream will contain a tuple


### PR DESCRIPTION
@ddebrunner this is a change that James has made to the topology toolkit to allow for topic to be specified as submission parameter, when the microservice is written in Java.

He did not have a chance to contribute this and we do not have testcases to test it.

I am wondering if you can take a look at this and see if you want to pull this in.  

One of the health toolkit samples is built on top this feature...and we can't run without it at the moment.  We are running off our own version of the topology toolkit, which is probably not great in the long run.

Please take a look.  Thanks!