### PR TITLE
Implement Java TStream.setConsistent 

### DIFF
--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1222,13 +1222,22 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * consistent region to support at least once and exactly once
      * processing.
      * IBM Streams calculates the boundaries of the consistent region
-     * that is based on the reachability graph of this stream.
+     * based on the reachability graph of this stream. A region
+     * can be bounded though use of {@link #autonomous()}.
      * 
      * <P>
      * Consistent regions are only supported in distributed contexts.
      * </P>
+     * <P>
+     * This must be called on a stream directly produced by an
+     * SPL operator that supports consistent regions.
+     * Source streams produced by methods on {@link Topology}
+     * do not support consistent regions.
+     * </P>
 
-     * @since v1.5
+     * @since 1.5 API added
+     * @since 1.8 Working implementation.
+     * 
      * @return this
      * 
      * @see com.ibm.streamsx.topology.consistent.ConsistentRegionConfig

--- a/java/src/com/ibm/streamsx/topology/generator/operator/OpProperties.java
+++ b/java/src/com/ibm/streamsx/topology/generator/operator/OpProperties.java
@@ -88,6 +88,11 @@ public interface OpProperties {
      * Stored within {@link OpProperties#CONFIG}.
      */
     String PLACEMENT = "placement";
+    
+    /**
+     * Attribute for start of a consistent region.
+     */
+    String CONSISTENT = "consistent";
 
 
 }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -5,6 +5,7 @@
 package com.ibm.streamsx.topology.generator.spl;
 
 import static com.ibm.streamsx.topology.builder.JParamTypes.TYPE_SUBMISSION_PARAMETER;
+import static com.ibm.streamsx.topology.generator.operator.OpProperties.CONSISTENT;
 import static com.ibm.streamsx.topology.generator.operator.OpProperties.PLACEMENT;
 import static com.ibm.streamsx.topology.generator.operator.WindowProperties.POLICY_COUNT;
 import static com.ibm.streamsx.topology.generator.operator.WindowProperties.POLICY_DELTA;
@@ -61,6 +62,7 @@ class OperatorGenerator {
         noteAnnotations(_op, sb);
         parallelAnnotation(_op, sb);
         viewAnnotation(_op, sb);
+        consistentAnnotation(_op, sb);
         AutonomousRegions.autonomousAnnotation(_op, sb);
         threadingAnnotation(graphConfig, _op, sb);
         boolean singlePortSingleName = outputPortClause(_op, sb);
@@ -239,6 +241,36 @@ class OperatorGenerator {
             sb.append("@threading(");
             sb.append("model=");
             sb.append(jstring(threading, "model"));
+            sb.append(")\n");
+        }
+    }
+    private static void asFloat64(StringBuilder sb, JsonObject obj, String key) {
+        SPLGenerator.numberLiteral(sb, obj.getAsJsonPrimitive(key), "FLOAT64");
+    }
+    
+    private void consistentAnnotation(JsonObject op, StringBuilder sb) {
+
+        JsonObject consistent = object(op, CONSISTENT);
+        if (consistent != null) {
+            sb.append("@consistent(");
+            if (consistent.has("period")) {
+                sb.append("trigger=periodic,period=");
+                asFloat64(sb, consistent, "period");
+                sb.append(",");
+            } else {
+                sb.append("trigger=operatorDriven,");
+            }
+            sb.append("drainTimeout=");
+            asFloat64(sb, consistent, "drainTimeout");
+            sb.append(",");
+            
+            sb.append("resetTimeout=");
+            asFloat64(sb, consistent, "resetTimeout");
+            sb.append(",");
+            
+            sb.append("maxConsecutiveResetAttempts=");
+            asFloat64(sb, consistent, "maxConsecutiveResetAttempts");
+            
             sb.append(")\n");
         }
     }

--- a/test/java/src/com/ibm/streamsx/topology/test/consistent/ConsistentRegionTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/consistent/ConsistentRegionTest.java
@@ -1,0 +1,98 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016  
+ */
+package com.ibm.streamsx.topology.test.consistent;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assume.assumeTrue;
+import static com.ibm.streamsx.topology.consistent.ConsistentRegionConfig.periodic;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.streams.operator.StreamSchema;
+import com.ibm.streams.operator.Type;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.consistent.ConsistentRegionConfig;
+import com.ibm.streamsx.topology.spl.SPL;
+import com.ibm.streamsx.topology.spl.SPLStream;
+import com.ibm.streamsx.topology.spl.SPLStreams;
+import com.ibm.streamsx.topology.test.TestTopology;
+import com.ibm.streamsx.topology.tester.Condition;
+
+/**
+ * Test topologies with consistent region.
+ * Currently effectively testing that the annotation is applied.
+ * 
+ * We assume Streams product testing tests consistent region itself.
+ */
+public class ConsistentRegionTest extends TestTopology {
+    
+    @Before
+    public void checkIsDistributed() {
+        assumeTrue(isDistributedOrService());
+    }
+   
+    @Test
+    public void testConsistentPeriodic() throws Exception {
+        Topology topology = new Topology("testConsistentPeriodic");
+        
+        StreamSchema schema = Type.Factory.getStreamSchema("tuple<uint64 id>");
+        Map<String,Object> params = new HashMap<>();
+        params.put("iterations", 200);
+        params.put("period", 0.05);
+        
+        SPLStream b = SPL.invokeSource(topology, "spl.utility::Beacon", params, schema);
+        
+        ConsistentRegionConfig config = periodic(2);
+        assertSame(b, b.setConsistent(config));
+        
+        Condition<Long> atLeast = topology.getTester().atLeastTupleCount(b, 200);
+        complete(topology.getTester(), atLeast, 80, TimeUnit.SECONDS);
+    }
+    
+    @Test
+    public void testConsistentOperatorDriven() throws Exception {
+        Topology topology = new Topology("testConsistentOperatorDriven");
+        
+        StreamSchema schema = Type.Factory.getStreamSchema("tuple<uint64 id>");
+        Map<String,Object> params = new HashMap<>();
+        params.put("iterations", 300);
+        params.put("triggerCount", SPL.createValue(37, Type.MetaType.UINT32));
+        
+        SPLStream b = SPL.invokeSource(topology, "spl.utility::Beacon", params, schema);
+        
+        ConsistentRegionConfig config = ConsistentRegionConfig.operatorDriven();
+        assertSame(b, b.setConsistent(config));
+        
+        Condition<Long> atLeast = topology.getTester().atLeastTupleCount(b, 300);
+        complete(topology.getTester(), atLeast, 40, TimeUnit.SECONDS);
+    }
+    
+    /**
+     * Expected to raise an exception as triggerCount requires it
+     * be in a operator driven consistent region. Somewhat
+     * enforces that testConsistentOperatorDriven() is doing the correct thing.
+     * @throws Exception
+     */
+    @Test(expected=Exception.class)
+    public void testMissingOperatorDrivenConsistent() throws Exception {
+        Topology topology = new Topology("testConsistentOperatorDriven");
+        
+        StreamSchema schema = Type.Factory.getStreamSchema("tuple<uint64 id>");
+        Map<String,Object> params = new HashMap<>();
+        params.put("iterations", 300);
+        params.put("triggerCount", SPL.createValue(37, Type.MetaType.UINT32));
+        
+        SPLStream b = SPL.invokeSource(topology, "spl.utility::Beacon", params, schema);
+        
+        Condition<Long> atLeast = topology.getTester().atLeastTupleCount(b, 300);
+        complete(topology.getTester(), atLeast, 40, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
The Java api existed but just threw a WIP exception.

Now the consistent annotation info is maintained in the JSON graph and used to produce a `@consistent` annotation.