### PR TITLE
Use a generic field for style specific object

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -32,7 +32,7 @@ using namespace streamsx::topology;
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
-   pyInNames_(NULL),
+   pyInStyleObj_(NULL),
    loads(NULL),
    occ_(-1),
    window_(<%=$windowCppInitializer%>)

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -48,8 +48,7 @@ if ($pyoutstyle eq 'dict') {
     SplpyFuncOp *funcop_;
     PyObject *spl_in_object_out;
     
-    // Names of input attributes
-    PyObject *pyInNames_;
+    PyObject *pyInStyleObj_;
 
     PyObject *loads;
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -16,26 +16,20 @@ using namespace streamsx::topology;
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
-   pyInNames_(NULL)
+   pyInStyleObj_(NULL)
 {
     funcop_ = new SplpyFuncOp(this, "<%=$pywrapfunc%>");
-  
-<% if ($pystyle eq 'dict') { %>
-     SplpyGIL lock;
-     pyInNames_ = streamsx::topology::Splpy::pyAttributeNames(
-               getInputPortAt(0));
-<% } %>
+
+@include "../pyspltuple_constructor.cgt"
 }
 
 // Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {
-<% if ($pystyle eq 'dict') { %>
-    if (pyInNames_) {
+    if (pyInStyleObj_) {
       SplpyGIL lock;
-      Py_DECREF(pyInNames_);
+      Py_DECREF(pyInStyleObj_);
     }
-<% } %>
 
     delete funcop_;
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
@@ -26,8 +26,7 @@ private:
     // Control for interaction with Python
     SplpyFuncOp *funcop_;
     
-    // Names of input attributes
-    PyObject *pyInNames_;
+    PyObject *pyInStyleObj_;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
@@ -22,7 +22,7 @@ using namespace streamsx::topology;
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
-   pyInNames_(NULL),
+   pyInStyleObj_(NULL),
    occ_(-1)
 { 
     const char * wrapfn = "<%=$pywrapfunc%>";
@@ -60,23 +60,16 @@ MY_OPERATOR::MY_OPERATOR() :
 
     funcop_ = new SplpyFuncOp(this, wrapfn);
 
-<% if ($pystyle eq 'dict') { %>
-     SplpyGIL lock;
- 
-     pyInNames_ = streamsx::topology::Splpy::pyAttributeNames(
-               getInputPortAt(0));
-<% } %>
+@include "../pyspltuple_constructor.cgt"
 }
 
 // Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {
-<% if ($pystyle eq 'dict') { %>
-    if (pyInNames_) {
+  if (pyInStyleObj_) {
       SplpyGIL lock;
-      Py_DECREF(pyInNames_);
-    }
-<% } %>
+      Py_DECREF(pyInStyleObj_);
+  }
 
   delete funcop_;
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
@@ -26,8 +26,7 @@ private:
     // Control for interaction with Python
     SplpyFuncOp *funcop_;
     
-    // Names of input attributes
-    PyObject *pyInNames_;
+    PyObject *pyInStyleObj_;
 
     // Number of output connections when passing by ref
     // -1 when cannot pass by ref

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -16,26 +16,20 @@ using namespace streamsx::topology;
 // Constructor
 MY_OPERATOR::MY_OPERATOR():
    funcop_(NULL),
-   pyInNames_(NULL)
+   pyInStyleObj_(NULL)
 {
     funcop_ = new SplpyFuncOp(this, "<%=$pywrapfunc%>");
 
-<% if ($pystyle eq 'dict') { %>
-     SplpyGIL lock;
-     pyInNames_ = streamsx::topology::Splpy::pyAttributeNames(
-               getInputPortAt(0));
-<% } %>
+@include "../pyspltuple_constructor.cgt"
 }
 
 // Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {
-<% if ($pystyle eq 'dict') { %>
-    if (pyInNames_) {
+  if (pyInStyleObj_) {
       SplpyGIL lock;
-      Py_DECREF(pyInNames_);
-    }
-<% } %>
+      Py_DECREF(pyInStyleObj_);
+  }
 
   delete funcop_;
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_h.cgt
@@ -26,8 +26,7 @@ private:
   // Control for interaction with Python
   SplpyFuncOp *funcop_;
   
-  // Names of input attributes
-  PyObject *pyInNames_;
+  PyObject *pyInStyleObj_;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -16,26 +16,21 @@ using namespace streamsx::topology;
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
-   pyInNames_(NULL)
+   pyInStyleObj_(NULL)
 {
     funcop_ = new SplpyFuncOp(this, "<%=$pywrapfunc%>");
-<% if ($pystyle eq 'dict') { %>
-     SplpyGIL lock;
-     pyInNames_ = streamsx::topology::Splpy::pyAttributeNames(
-               getInputPortAt(0));
-<% } %>
+
+@include "../pyspltuple_constructor.cgt"
 }
 
 
 // Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {
-<% if ($pystyle eq 'dict') { %>
-    if (pyInNames_) {
+    if (pyInStyleObj_) {
       SplpyGIL lock;
-      Py_DECREF(pyInNames_);
+      Py_DECREF(pyInStyleObj_);
     }
-<% } %>
 
     delete funcop_;
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
@@ -26,8 +26,7 @@ private:
     // Control for interaction with Python
     SplpyFuncOp *funcop_;
     
-    // Names of input attributes
-    PyObject *pyInNames_;
+    PyObject *pyInStyleObj_;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -20,7 +20,7 @@ using namespace streamsx::topology;
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
-   pyInNames_(NULL),
+   pyInStyleObj_(NULL),
    occ_(-1)
 {
     const char * wrapfn = "<%=$pywrapfunc%>";
@@ -54,22 +54,16 @@ MY_OPERATOR::MY_OPERATOR() :
 
     funcop_ = new SplpyFuncOp(this, wrapfn);
 
-<% if ($pystyle eq 'dict') { %>
-     SplpyGIL lock;
-     pyInNames_ = streamsx::topology::Splpy::pyAttributeNames(
-               getInputPortAt(0));
-<% } %>
+@include "../pyspltuple_constructor.cgt"
 }
 
 // Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {
-<% if ($pystyle eq 'dict') { %>
-    if (pyInNames_) {
+  if (pyInStyleObj_) {
       SplpyGIL lock;
-      Py_DECREF(pyInNames_);
-    }
-<% } %>
+      Py_DECREF(pyInStyleObj_);
+  }
 
   delete funcop_;
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
@@ -38,8 +38,7 @@ if ($pyoutstyle eq 'dict') {
     // Control for interaction with Python
     SplpyFuncOp *funcop_;
     
-    // Names of input attributes
-    PyObject *pyInNames_;
+    PyObject *pyInStyleObj_;
 
     // Number of output connections when passing by ref
     // -1 when cannot pass by ref

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/README.md
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/README.md
@@ -1,0 +1,18 @@
+# Shared aspects of operators
+
+## Fields
+
+* `funcop_` - Maintains the life-cycle object that holds the Python callable.
+* `pyInStyleObj_` field : Operators with input ports have an instance field that
+  optionally holds a Python object for aiding in handling input tuples.
+  The specific value is based upon the style:
+  * `dict` - Attribute names for input port 0 as a tuple. Defined as `pyInNames_`
+  Defines are in `pyspltuple.cgt` to provide more readable code indicating the actual use of the value.
+
+## Shared cgt files
+
+* `pyspltuple.cgt` - Setup for operators processing tuples, sets some perl variables.
+* `pyspltuple_constructor.cgt` - Common constructor code for operators processing tuples.
+* `pyspltuple2value.cgt` - Common process method code for for operators processing tuples. Results in a C++ variable `value` set to the Python object to be passed into Python callable.
+* `pyspltuple2dict.cgt` - Convert an SPL tuple to a Python dict object.
+* `pyspltuple2tuple.cgt` - Convert an SPL tuple to a Python tuple object.

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
@@ -22,3 +22,5 @@
  }
 %>
 
+#define pyInNames_ pyInStyleObj_
+

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple_constructor.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple_constructor.cgt
@@ -1,0 +1,5 @@
+<% if ($pystyle eq 'dict') { %>
+     SplpyGIL lock;
+     pyInNames_ = streamsx::topology::Splpy::pyAttributeNames(
+               getInputPortAt(0));
+<% } %>


### PR DESCRIPTION
Changes the functional operators to have a single field (`pyInStyleObj_`) that can be used by specific styles when converting input tuples.

Then simplified the destructor to simply decrement the reference of `pyInStyleObj_` if it is not `NULL` rather than having conditional perl code driving the decision.

Also move common constructor code for style support into a new shared cgt file: `pyspltuple_constructor.cgt`.

This simplifies the upcoming support of passing structured tuples as namedtuples.
