### PR TITLE
Support named tuples.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -10,7 +10,7 @@ using namespace streamsx::topology;
 @include "../pyspltuple.cgt"
 <%
  # Select the Python wrapper function
- my $pywrapfunc= $pystyle . '_in';
+ my $pywrapfunc= $pystyle_fn . '_in';
 %>
 
 // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
@@ -11,7 +11,7 @@ using namespace streamsx::topology;
 @include "../pyspltuple.cgt"
 <%
  # Select the Python wrapper function
- my $pywrapfunc= $pystyle . '_in__pickle_iter';
+ my $pywrapfunc= $pystyle_fn . '_in__pickle_iter';
 %>
 
 // Default case is pass by pickled value in which case
@@ -37,7 +37,7 @@ MY_OPERATOR::MY_OPERATOR() :
  if ($oc) {
     my $occ = $oc->getValueAt(0)->getSPLExpression();
     if ($occ > 0) {
-        my $pybyrefwrapfunc = $pystyle . '_in__object_iter';
+        my $pybyrefwrapfunc = $pystyle_fn . '_in__object_iter';
 %>
 
 // Macro inserts an if passing by ref check then pass tuple

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -10,7 +10,7 @@ using namespace streamsx::topology;
 @include "../pyspltuple.cgt"
 <%
  # Select the Python wrapper function
- my $pywrapfunc= $pystyle . '_in';
+ my $pywrapfunc= $pystyle_fn . '_in';
 %>
 
 // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -10,7 +10,7 @@ using namespace streamsx::topology;
 @include "../pyspltuple.cgt"
 <%
  # Select the Python wrapper function
- my $pywrapfunc= $pystyle . '_in';
+ my $pywrapfunc= $pystyle_fn . '_in';
 %>
 
 // Constructor
@@ -46,7 +46,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
 @include "../pyspltuple2value.cgt"
 
-<%if ($pystyle eq 'dict' || $pystyle eq 'tuple') {%>
+<%if ($pystyle_fn eq 'dict' || $pystyle_fn eq 'tuple') {%>
 
   OPort0Type otuple;
   otuple.assignFrom(<%=$iport->getCppTupleName()%>, false);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -11,7 +11,7 @@ using namespace streamsx::topology;
 <%
  # Select the Python wrapper function
  my $pyoutstyle = splpy_tuplestyle($model->getOutputPortAt(0));
- my $pywrapfunc= $pystyle . '_in__' . $pyoutstyle . '_out';
+ my $pywrapfunc= $pystyle_fn . '_in__' . $pyoutstyle . '_out';
 %>
 
 #define SPLPY_TUPLE_MAP(f, v, r, occ) \
@@ -35,7 +35,7 @@ MY_OPERATOR::MY_OPERATOR() :
  if ($oc) {
     my $occ = $oc->getValueAt(0)->getSPLExpression();
     if ($occ > 0) {
-        my $pybyrefwrapfunc = $pystyle . '_in__object_out';
+        my $pybyrefwrapfunc = $pystyle_fn . '_in__object_out';
 %>
 
 #undef SPLPY_TUPLE_MAP

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
@@ -20,10 +20,14 @@
  } else {
      $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
  }
- my $fnpystyle = $pystyle;
- my $pystyle_nt = substr($fnpystyle, 0, 11) eq 'namedtuple:';
+ # $pystyle is the raw value from the operator parameter
+ # $pystyle_nt is the value that defines how the function is called
+ # (for style namedtuple:xxxx it is tuple)
+ # $pystyle_nt is non-zero if style is namedtuple
+ my $pystyle_fn = $pystyle;
+ my $pystyle_nt = substr($pystyle, 0, 11) eq 'namedtuple:';
  if ($pystyle_nt) {
-    $fnpystyle = 'tuple';
+    $pystyle_fn = 'tuple';
  }
 %>
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
@@ -16,9 +16,14 @@
 
  my $pystyle = $model->getParameterByName("pyStyle");
  if ($pystyle) {
-     $pystyle = substr $pystyle->getValueAt(0)->getSPLExpression(), 1, -1;
+     $pystyle = substr($pystyle->getValueAt(0)->getSPLExpression(), 1, -1);
  } else {
      $pystyle = splpy_tuplestyle($model->getInputPortAt(0));
+ }
+ my $fnpystyle = $pystyle;
+ my $pystyle_nt = substr($fnpystyle, 0, 11) eq 'namedtuple:';
+ if ($pystyle_nt) {
+    $fnpystyle = 'tuple';
  }
 %>
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple.cgt
@@ -30,6 +30,3 @@
     $pystyle_fn = 'tuple';
  }
 %>
-
-#define pyInNames_ pyInStyleObj_
-

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2tuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2tuple.cgt
@@ -19,11 +19,7 @@
      }
 %>
 <% if ($pystyle_nt) { %>
-    // Wrap the tuple in an tuple to pass it to _make as iterable of values.
-    PyObject *makeargs = PyTuple_New(1);
-    PyTuple_SET_ITEM(makeargs, 0, pyTuple);
-
-    pyTuple = streamsx::topology::SplpyGeneral::pyCallObject(pyNamedtupleMake_, makeargs);
+    pyTuple = streamsx::topology::SplpyGeneral::pyCallObject(pyNamedtupleCls_, pyTuple);
 
 <% } %>
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2tuple.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2tuple.cgt
@@ -18,5 +18,14 @@
          print convertAndAddToPythonTupleObject($iport->getCppTupleName(), $i, $la->getSPLType(), $la->getName());
      }
 %>
+<% if ($pystyle_nt) { %>
+    // Wrap the tuple in an tuple to pass it to _make as iterable of values.
+    PyObject *makeargs = PyTuple_New(1);
+    PyTuple_SET_ITEM(makeargs, 0, pyTuple);
+
+    pyTuple = streamsx::topology::SplpyGeneral::pyCallObject(pyNamedtupleMake_, makeargs);
+
+<% } %>
+
   value = pyTuple;
   }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2value.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple2value.cgt
@@ -15,7 +15,7 @@
 <%
 print splpy_inputtuple2value($pystyle, $iport);
 
-if ($pystyle eq 'dict' || $pystyle eq 'tuple') {
+if ($pystyle eq 'dict' || $pystyle eq 'tuple' || $pystyle_nt) {
 %>
 @include "../opt/python/codegen/py_splTupleCheckForBlobs.cgt"
 <%
@@ -24,6 +24,6 @@ if ($pystyle eq 'dict' || $pystyle eq 'tuple') {
 if ($pystyle eq 'dict') {
 %>
 @include "pyspltuple2dict.cgt"
-<% } elsif ($pystyle eq 'tuple') { %>
+<% } elsif ($pystyle eq 'tuple' || $pystyle_nt) { %>
 @include "pyspltuple2tuple.cgt"
 <% } %>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple_constructor.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple_constructor.cgt
@@ -8,11 +8,11 @@
 <% } %>
 
 <% if ($pystyle_nt) { %>
-#define pyNamedtupleMake_ pyInStyleObj_
+#define pyNamedtupleCls_ pyInStyleObj_
 {
      SplpyGIL lock;
-     pyNamedtupleMake_ = streamsx::topology::SplpyGeneral::callFunction(
-        "streamsx.topology.runtime", "_get_namedtuple_make",
+     pyNamedtupleCls_ = streamsx::topology::SplpyGeneral::callFunction(
+        "streamsx.topology.runtime", "_get_namedtuple_cls",
        streamsx::topology::pyUnicode_FromUTF8("<%=$iport->getSPLTupleType()%>"),
        streamsx::topology::pyUnicode_FromUTF8("<%=substr($pystyle, 11)%>"));
 }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple_constructor.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyspltuple_constructor.cgt
@@ -1,5 +1,19 @@
-<% if ($pystyle eq 'dict') { %>
+<% if ($pystyle_fn eq 'dict') { %>
+#define pyInNames_ pyInStyleObj_
+{
      SplpyGIL lock;
      pyInNames_ = streamsx::topology::Splpy::pyAttributeNames(
                getInputPortAt(0));
+}
+<% } %>
+
+<% if ($pystyle_nt) { %>
+#define pyNamedtupleMake_ pyInStyleObj_
+{
+     SplpyGIL lock;
+     pyNamedtupleMake_ = streamsx::topology::SplpyGeneral::callFunction(
+        "streamsx.topology.runtime", "_get_namedtuple_make",
+       streamsx::topology::pyUnicode_FromUTF8("<%=$iport->getSPLTupleType()%>"),
+       streamsx::topology::pyUnicode_FromUTF8("<%=substr($pystyle, 11)%>"));
+}
 <% } %>

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -7,6 +7,7 @@ import pickle
 from past.builtins import basestring
 
 import streamsx.ec as ec
+from streamsx.topology.schema import StreamSchema
 
 try:
     import dill
@@ -433,3 +434,8 @@ tuple_in__string_out = object_in__object_out
 tuple_in__json_out = object_in__json_out
 tuple_in__dict_out = object_in__dict_out
 tuple_in = object_in
+
+# Get the _make function for a named tuple.
+# used by functional operators.
+def _get_namedtuple_make(schema, name):
+    return StreamSchema(schema).as_tuple(named=name).style._make

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -435,7 +435,7 @@ tuple_in__json_out = object_in__json_out
 tuple_in__dict_out = object_in__dict_out
 tuple_in = object_in
 
-# Get the _make function for a named tuple.
+# Get the named tuple class for a schema.
 # used by functional operators.
-def _get_namedtuple_make(schema, name):
-    return StreamSchema(schema).as_tuple(named=name).style._make
+def _get_namedtuple_cls(schema, name):
+    return StreamSchema(schema).as_tuple(named=name).style

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -357,13 +357,10 @@ class StreamSchema(object) :
         if self.__spl_type:
             return tuple
         if name == True:
-            name = 'StreamSchemaNamedTuple'
-        fields = []
+            name = 'StreamTuple'
+        fields = _attribute_names(self._types)
         if sys.version_info.major == 2 or True:
-            for attr in self._types:
-                fields.append(attr[1])
-
-            nt = collections.namedtuple(name, fields)
+            nt = collections.namedtuple(name, fields, rename=True)
 
         nt._splpy_namedtuple = name
         return nt
@@ -401,6 +398,9 @@ class StreamSchema(object) :
         `typing.NamedTuple` and includes type hints according
         to the attribute types of the structured schema.
 
+        The value of `named` is used as the name of the named tuple
+        class with ``StreamTuple`` used when `named` is ``True``.
+
         It is not guaranteed that the class of the namedtuple is the
         same for all callables processing tuples with the same
         structured schema, only that the tuple is a named tuple
@@ -415,6 +415,7 @@ class StreamSchema(object) :
             StreamSchema: Schema passing stream tuples as ``tuple`` if allowed.
 
         .. versionadded:: 1.8
+        .. versionadded:: 1.9 Addition of `named` parameter.
         """
         if not named:
             return self._copy(tuple)
@@ -499,8 +500,8 @@ class StreamSchema(object) :
             ntp = 'tuple'
         elif schema.style == dict:
             ntp = 'dict'
-        elif _is_namedtuple(schema.style) and schema.style.hasattr('_splpy_namedtuple'):
-            ntp = 'namedtuple'
+        elif _is_namedtuple(schema.style) and hasattr(schema.style, '_splpy_namedtuple'):
+            ntp = 'namedtuple:' + schema.style._splpy_namedtuple
         else:
             return
         op.params[name] = ntp

--- a/test/python/topology/test2_schema_tuple.py
+++ b/test/python/topology/test2_schema_tuple.py
@@ -14,44 +14,58 @@ from streamsx.topology.tester import Tester
 Test that structured schemas can be passed into Python functions as tuples.
 """
 
-def check_is_tuple(t):
-    if type(t) != tuple:
+def check_correct(named, t):
+    if named:
+        if not isinstance(t, tuple):
+            raise ValueError("Expected a tuple:" + str(t) + " >> type:" + str(type(t)))
+    elif type(t) != tuple:
         raise ValueError("Expected a tuple:" + str(t) + " >> type:" + str(type(t)))
 
-def check_is_tuple_for_each(t):
-    check_is_tuple(t)
+class check_for_tuple_type(object):
+  def __init__(self, named):
+     self.named = named
+
+class check_is_tuple_for_each(check_for_tuple_type):
+  def __call__(self, t):
+    check_correct(self.named, t)
     if t[1] != str(t[0]*2) + "Hi!":
         raise ValueError("Incorrect value:" + str(t))
 
-def check_is_tuple_filter(t):
-    check_is_tuple_for_each(t)
+class check_is_tuple_filter(check_is_tuple_for_each):
+  def __call__(self, t):
+    super(check_is_tuple_filter, self).__call__(t)
     return t[0] != 2
 
 def check_is_tuple_hash(t):
-    print("ISHASH:", t, flush=True)
-    check_is_tuple_for_each(t)
-    print("ISHASH_RET:", t[0], flush=True)
+    check_correct(False, t)
+    if t[1] != str(t[0]*2) + "Hi!":
+        raise ValueError("Incorrect value:" + str(t))
     return t[0]
 
-def check_is_tuple_map(t):
-    check_is_tuple(t)
+class check_is_tuple_map(check_for_tuple_type):
+  def __call__(self, t):
+    check_correct(self.named, t)
     return (t[0]*7, t[1] + "-Map")
 
 
-def check_is_tuple_map_to_string(t):
-    check_is_tuple(t)
+class check_is_tuple_map_to_string(check_for_tuple_type):
+  def __call__(self, t):
+    check_correct(self.named, t)
     return str(t[0]*11) + t[1] + "-MapString"
 
-def check_is_tuple_map_to_schema(t):
-    check_is_tuple(t)
+class check_is_tuple_map_to_schema(check_for_tuple_type):
+  def __call__(self, t):
+    check_correct(self.named, t)
     return (t[0]*13, t[1] + "-MapSPL")
 
-def check_is_tuple_flat_map(t):
-    check_is_tuple(t)
+class check_is_tuple_flat_map(check_for_tuple_type):
+  def __call__(self, t):
+    check_correct(self.named, t)
     return [(t[0]*9, t[1] + "-FlatMap")]
 
-def check_is_tuple_map_to_json(t):
-    check_is_tuple(t)
+class check_is_tuple_map_to_json(check_for_tuple_type):
+  def __call__(self, t):
+    check_correct(self.named, t)
     return {'a':t[0]*15, 'b':t[1] + "-MapJSON"}
 
 @unittest.skipIf(not test_vers.tester_supported() , "tester not supported")
@@ -61,6 +75,12 @@ class TestSchemaTuple(unittest.TestCase):
     def setUp(self):
         Tester.setup_standalone(self)
 
+    def is_named(self):
+        return False
+
+    def hash_check(self):
+        return check_is_tuple_hash
+
     def _create_stream(self, topo):
         s = topo.source([1,2,3])
         schema=StreamSchema('tuple<int32 x, rstring msg>').as_tuple()
@@ -69,7 +89,7 @@ class TestSchemaTuple(unittest.TestCase):
     def test_as_tuple_for_each(self):
         topo = Topology()
         st = self._create_stream(topo)
-        st.for_each(check_is_tuple_for_each)
+        st.for_each(check_is_tuple_for_each(self.is_named()))
 
         tester = Tester(topo)
         tester.tuple_count(st, 3)
@@ -78,7 +98,7 @@ class TestSchemaTuple(unittest.TestCase):
     def test_as_tuple_map(self):
         topo = Topology()
         s = self._create_stream(topo)
-        st = s.map(check_is_tuple_map)
+        st = s.map(check_is_tuple_map(self.is_named()))
 
         tester = Tester(topo)
         tester.contents(st, [(7,'2Hi!-Map'), (14,'4Hi!-Map'), (21,'6Hi!-Map')])
@@ -87,7 +107,7 @@ class TestSchemaTuple(unittest.TestCase):
     def test_as_tuple_filter(self):
         topo = Topology()
         s = self._create_stream(topo)
-        s = s.filter(check_is_tuple_filter)
+        s = s.filter(check_is_tuple_filter(self.is_named()))
 
         tester = Tester(topo)
         tester.tuple_count(s, 2)
@@ -96,7 +116,7 @@ class TestSchemaTuple(unittest.TestCase):
     def test_as_tuple_flat_map(self):
         topo = Topology()
         s = self._create_stream(topo)
-        st = s.flat_map(check_is_tuple_flat_map)
+        st = s.flat_map(check_is_tuple_flat_map(self.is_named()))
 
         tester = Tester(topo)
         tester.contents(st, [(9,'2Hi!-FlatMap'), (18,'4Hi!-FlatMap'), (27,'6Hi!-FlatMap')])
@@ -105,8 +125,8 @@ class TestSchemaTuple(unittest.TestCase):
     def test_as_tuple_hash(self):
         topo = Topology()
         s = self._create_stream(topo)
-        s = s.parallel(width=2, routing=Routing.HASH_PARTITIONED, func=check_is_tuple_hash)
-        s = s.map(check_is_tuple_map)
+        s = s.parallel(width=2, routing=Routing.HASH_PARTITIONED, func=self.hash_check())
+        s = s.map(check_is_tuple_map(self.is_named()))
         s = s.end_parallel()
 
         tester = Tester(topo)
@@ -116,7 +136,7 @@ class TestSchemaTuple(unittest.TestCase):
     def test_as_tuple_map_to_string(self):
         topo = Topology()
         s = self._create_stream(topo)
-        st = s.map(check_is_tuple_map_to_string, schema=CommonSchema.String)
+        st = s.map(check_is_tuple_map_to_string(self.is_named()), schema=CommonSchema.String)
 
         tester = Tester(topo)
         tester.contents(st, ['112Hi!-MapString', '224Hi!-MapString', '336Hi!-MapString'])
@@ -125,7 +145,7 @@ class TestSchemaTuple(unittest.TestCase):
     def test_as_tuple_map_to_schema(self):
         topo = Topology()
         s = self._create_stream(topo)
-        st = s.map(check_is_tuple_map_to_schema, schema=StreamSchema('tuple<int32 y, rstring txt>'))
+        st = s.map(check_is_tuple_map_to_schema(self.is_named()), schema=StreamSchema('tuple<int32 y, rstring txt>'))
 
         tester = Tester(topo)
         tester.contents(st, [{'y':13, 'txt':'2Hi!-MapSPL'}, {'y':26, 'txt':'4Hi!-MapSPL'}, {'y':39, 'txt':'6Hi!-MapSPL'}])
@@ -134,7 +154,7 @@ class TestSchemaTuple(unittest.TestCase):
     def test_as_tuple_map_to_json(self):
         topo = Topology()
         s = self._create_stream(topo)
-        s = s.map(check_is_tuple_map_to_json, schema=CommonSchema.Json)
+        s = s.map(check_is_tuple_map_to_json(self.is_named()), schema=CommonSchema.Json)
         s = s.map(lambda x : str(x['a']) + x['b'])
 
         tester = Tester(topo)
@@ -144,6 +164,9 @@ class TestSchemaTuple(unittest.TestCase):
 
 @unittest.skipIf(not test_vers.tester_supported() , "tester not supported")
 class TestSchemaNamedTuple(TestSchemaTuple):
+    def is_named(self):
+        return True
+
     def _create_stream(self, topo):
         s = topo.source([1,2,3])
         schema=StreamSchema('tuple<int32 x, rstring msg>').as_tuple(named=True)

--- a/test/python/topology/test2_schema_tuple.py
+++ b/test/python/topology/test2_schema_tuple.py
@@ -18,6 +18,10 @@ def check_correct(named, t):
     if named:
         if not isinstance(t, tuple):
             raise ValueError("Expected a tuple:" + str(t) + " >> type:" + str(type(t)))
+        for fn in type(t)._fields:
+            if not hasattr(t, fn):
+                raise ValueError("Expected tuple:" + str(t) + " >> type:" + str(type(t)) + " to have attribute " + fn)
+ 
     elif type(t) != tuple:
         raise ValueError("Expected a tuple:" + str(t) + " >> type:" + str(type(t)))
 
@@ -41,6 +45,12 @@ def check_is_tuple_hash(t):
     if t[1] != str(t[0]*2) + "Hi!":
         raise ValueError("Incorrect value:" + str(t))
     return t[0]
+
+def check_is_namedtuple_hash(t):
+    check_correct(True, t)
+    if t.msg != str(t.x*2) + "Hi!":
+        raise ValueError("Incorrect value:" + str(t))
+    return t.x
 
 class check_is_tuple_map(check_for_tuple_type):
   def __call__(self, t):
@@ -166,6 +176,9 @@ class TestSchemaTuple(unittest.TestCase):
 class TestSchemaNamedTuple(TestSchemaTuple):
     def is_named(self):
         return True
+
+    def hash_check(self):
+        return check_is_namedtuple_hash
 
     def _create_stream(self, topo):
         s = topo.source([1,2,3])

--- a/test/python/topology/test2_schema_tuple.py
+++ b/test/python/topology/test2_schema_tuple.py
@@ -141,3 +141,10 @@ class TestSchemaTuple(unittest.TestCase):
         tester.contents(s, ['152Hi!-MapJSON', '304Hi!-MapJSON', '456Hi!-MapJSON'])
         tester.test(self.test_ctxtype, self.test_config)
 
+
+@unittest.skipIf(not test_vers.tester_supported() , "tester not supported")
+class TestSchemaNamedTuple(TestSchemaTuple):
+    def _create_stream(self, topo):
+        s = topo.source([1,2,3])
+        schema=StreamSchema('tuple<int32 x, rstring msg>').as_tuple(named=True)
+        return s.map(lambda x : (x,str(x*2) + "Hi!"), schema=schema)

--- a/test/python/topology/test_schemas.py
+++ b/test/python/topology/test_schemas.py
@@ -8,6 +8,9 @@ import sys
 from streamsx.topology.topology import Topology, Routing
 from streamsx.topology.schema import _SchemaParser
 import streamsx.topology.schema as _sch
+
+import streamsx.topology.runtime as _str
+
 _PRIMITIVES = ['boolean', 'blob', 'int8', 'int16', 'int32', 'int64',
                  'uint8', 'uint16', 'uint32', 'uint64',
                  'float32', 'float64',
@@ -201,8 +204,34 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(23, tv.a)
         self.assertTrue(tv[1])
         self.assertTrue(tv.alert)
-        
 
+        self.assertTrue(str(tv).startswith('Alert('))
+        
+        snt2 = s.as_tuple(named=True)
+        self.assertIsNot(s, snt2)
+        self.assertIsNot(snt, snt2)
+        self.assertTrue(issubclass(snt2.style, tuple))
+        self.assertTrue(hasattr(snt2.style, '_fields'))
+        self.assertTrue(hasattr(snt2.style, '_splpy_namedtuple'))
+        self.assertTrue('StreamTuple', snt2.style._splpy_namedtuple)
+
+        tv = snt2.style(83, False)
+        self.assertEqual(83, tv[0])
+        self.assertEqual(83, tv.a)
+        self.assertFalse(tv[1])
+        self.assertFalse(tv.alert)
+        self.assertTrue(str(tv).startswith('StreamTuple('))
+
+    def test_get_namedtuple_make(self):
+        sch = 'tuple<int32 b, rstring c>'
+        mk = _str._get_namedtuple_make(sch, 'MyTuple')
+        tv = mk((932, 'hello'))
+        self.assertEqual(932, tv.b)
+        self.assertEqual('hello', tv.c)
+        self.assertTrue(str(tv).startswith('MyTuple('))
+
+
+        
 
 class TestKeepSchema(unittest.TestCase):
     """
@@ -269,3 +298,4 @@ class TestKeepSchema(unittest.TestCase):
 
        s2 = s.union({s1})
        self.assertEqual(s.oport.schema, s2.oport.schema)
+

--- a/test/python/topology/test_schemas.py
+++ b/test/python/topology/test_schemas.py
@@ -189,6 +189,20 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(str, _sch.CommonSchema.String.value.style)
         self.assertEqual(dict, _sch.CommonSchema.Json.value.style)
 
+        snt = s.as_tuple(named='Alert')
+        self.assertIsNot(s, snt)
+        self.assertTrue(issubclass(snt.style, tuple))
+        self.assertTrue(hasattr(snt.style, '_fields'))
+        self.assertTrue(hasattr(snt.style, '_splpy_namedtuple'))
+        self.assertTrue('Alert', snt.style._splpy_namedtuple)
+
+        tv = snt.style(23, True)
+        self.assertEqual(23, tv[0])
+        self.assertEqual(23, tv.a)
+        self.assertTrue(tv[1])
+        self.assertTrue(tv.alert)
+        
+
 
 class TestKeepSchema(unittest.TestCase):
     """


### PR DESCRIPTION
Supports the ability to pass in stream tuples as Python named tuples.

```
sch = StreamSchema('tuple<rstring id, float64 value>') 
# Passed in as dict (the default)- e.g. {'id': 'TempSensor', 'value': 34.5}
# Fields accessed as t['id'], t['value']

sch = sch.as_tuple()
# Passed in as tuple e.g. ('TempSensor', 34.5)
# Fields accessed as t[0], t[1]

# NEW - the named parameter
sch = sch.as_tuple(named='Reading')
# Passed in as named tuple, e.g. Reading(id='TempSensor', value=34.5)
# Fields accessed as t.id, t.value  (and  t[0], t[1])
```
See #1235 - second item `collections.namedtuple`.
  