### PR TITLE
Attempt to initialize StreamsConnection from environment variables.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -62,8 +62,14 @@ class StreamsConnection:
     retrieve that information.
 
     Args:
-        username (str): Username of an authorized Streams user.
+        username (str): Username of an authorized Streams user. If None, the username is taken from the 
+        STREAMS_USERNAME environment variable. If the STREAMS_USERNAME environment variable is not set,
+        the default `streamsadmin` is used.
+
         password (str): Password for `username`
+        If None, the password is taken from the STREAMS_PASSWORD environment variable. If the 
+        STREAMS_PASSWORD environment variable is not set, the default `passw0rd` is used.
+
         resource_url (str, optional): Root URL for IBM Streams REST API.
 
     Example:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -87,8 +87,8 @@ class StreamsConnection:
             pass
         elif st._has_local_install:
             # Assume quickstart
-            username = 'streamsadmin'
-            password = 'passw0rd'
+            username = os.getenv("STREAMS_USERNAME", "streamsadmin")
+            password = os.getenv("STREAMS_PASSWORD", "passw0rd")
         else:
             raise ValueError("Must supply either a Bluemix VCAP Services or a username, password"
                              " to the StreamsConnection constructor.")

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -186,9 +186,6 @@ class Tester(object):
         if not 'STREAMS_DOMAIN_ID' in os.environ:
             raise unittest.SkipTest("Skipped due to STREAMS_DOMAIN_ID environment variable not set")
 
-        test.username = os.getenv("STREAMS_USERNAME", "streamsadmin")
-        test.password = os.getenv("STREAMS_PASSWORD", "passw0rd")
-
         test.test_ctxtype = stc.ContextTypes.DISTRIBUTED
         test.test_config = {}
 
@@ -446,7 +443,9 @@ class Tester(object):
             config: Configuration for submission.
             assert_on_fail(bool): True to raise an assertion if the test fails, False to return the passed status.
             username(str): username for distributed tests
+                .. deprecated:: 1.8.3
             password(str): password for distributed tests
+                .. deprecated:: 1.8.3
 
         Attributes:
             result: The result of the test. This can contain exit codes, application log paths, or other relevant test information.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -444,8 +444,10 @@ class Tester(object):
             assert_on_fail(bool): True to raise an assertion if the test fails, False to return the passed status.
             username(str): username for distributed tests
                 .. deprecated:: 1.8.3
+                Pass the username via the STREAMS_USERNAME environment variable instead.
             password(str): password for distributed tests
                 .. deprecated:: 1.8.3
+                Pass the password via the STREAMS_PASSWORD environment variable instead.
 
         Attributes:
             result: The result of the test. This can contain exit codes, application log paths, or other relevant test information.

--- a/test/python/topology/test2_submission_result.py
+++ b/test/python/topology/test2_submission_result.py
@@ -12,6 +12,8 @@ import test_vers
 class TestSubmissionResult(unittest.TestCase):
     def setUp(self):
         Tester.setup_distributed(self)
+        self.username = os.getenv("STREAMS_USERNAME", "streamsadmin")
+        self.password = os.getenv("STREAMS_PASSWORD", "passw0rd")
 
     def _correct_job_ids(self):
         # Test that result.job exists and you can pull values from it.

--- a/test/python/topology/test2_unicode.py
+++ b/test/python/topology/test2_unicode.py
@@ -76,10 +76,10 @@ class TestDistributedUnicode(TestUnicode):
         Tester.setup_distributed(self)
 
         # Get username and password
-        self.username = os.getenv("STREAMS_USERNAME", "streamsadmin")
-        self.password = os.getenv("STREAMS_PASSWORD", "passw0rd")
+        username = os.getenv("STREAMS_USERNAME", "streamsadmin")
+        password = os.getenv("STREAMS_PASSWORD", "passw0rd")
 
-        self.sc = rest.StreamsConnection(username=self.username, password=self.password)
+        self.sc = rest.StreamsConnection(username=username, password=password)
 
         # Disable SSL verification
         self.sc.session.verify = False

--- a/test/python/topology/test2_unicode.py
+++ b/test/python/topology/test2_unicode.py
@@ -76,10 +76,10 @@ class TestDistributedUnicode(TestUnicode):
         Tester.setup_distributed(self)
 
         # Get username and password
-        username = self.username
-        password = self.password
+        self.username = os.getenv("STREAMS_USERNAME", "streamsadmin")
+        self.password = os.getenv("STREAMS_PASSWORD", "passw0rd")
 
-        self.sc = rest.StreamsConnection(username=username, password=password)
+        self.sc = rest.StreamsConnection(username=self.username, password=self.password)
 
         # Disable SSL verification
         self.sc.session.verify = False


### PR DESCRIPTION
Presently, it just tries to use the VM defaults only. When running distributed unit tests in a non-VM environment, some tests will incorrectly have the username and password set to `streamsadmin` and `passw0rd`.