### PR TITLE
Fix pickle/dill of Timestamp

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
@@ -19,6 +19,11 @@ import datetime
 import time
 import streamsx.spl.op
 
+# Used by Timestamp.__reduce__ to avoid dill
+# trying to treat a Timestamp as a namedtuple.
+def _stored_ts(s, ns, mid):
+    return Timestamp(s, ns, mid)
+
 class Timestamp(collections.namedtuple('Timestamp', ['seconds', 'nanoseconds', 'machine_id'])):
     """
     SPL native timestamp type with nanosecond resolution.
@@ -56,6 +61,7 @@ class Timestamp(collections.namedtuple('Timestamp', ['seconds', 'nanoseconds', '
 
     _EPOCH = datetime.datetime.utcfromtimestamp(0)
     _NS = 1000000000.0
+
 
     @staticmethod
     def from_datetime(dt, machine_id=0):
@@ -145,6 +151,9 @@ class Timestamp(collections.namedtuple('Timestamp', ['seconds', 'nanoseconds', '
             Timestamp is a `tuple` now.
         """
         return self
+
+    def __reduce__(self):
+        return _stored_ts, tuple(self)
 
 def _get_timestamp_tuple(ts):
     """

--- a/test/python/topology/test_types.py
+++ b/test/python/topology/test_types.py
@@ -3,6 +3,7 @@
 import unittest
 import sys
 import dill
+import pickle
 import datetime
 import time
 import random
@@ -52,7 +53,16 @@ class TestTypes(unittest.TestCase):
       self.assertEqual(23423, tsft.seconds)
       self.assertEqual(20*1000.0*1000.0, float(tsft.nanoseconds))
       self.assertEqual(93, tsft.machine_id)
- 
+
+  def test_timestamp_pickle(self):
+     ts = Timestamp(1,2,3)
+     tsp = pickle.loads(pickle.dumps(ts))
+     self.assertEqual(ts, tsp)
+
+  def test_timestamp_dill(self):
+     ts = Timestamp(4,5,6)
+     tsp = dill.loads(dill.dumps(ts))
+     self.assertEqual(ts, tsp)
 
   def test_timestamp_now(self):
       now = time.time()


### PR DESCRIPTION
Dill was (seemingly) treating `Timestamp` as a namedtuple and using the dill method `_create_namedtuple` to recreate an instance. however that method does not exist on the version of `dill` on the service.

Implementing `__reduce__` provides a fixed, definitive way `Timestamp` values are pickled/dilled.