### PR TITLE
Initial code-drop for Python -> SPL translator.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/_streams/_placement.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/_streams/_placement.py
@@ -101,7 +101,6 @@ class _Placement(object):
         return self._colocate(others, 'colocate')
 
     def _colocate(self, others, why):
-       
         other_ops = list()
         try:
             for p in others:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/opcodes.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/opcodes.py
@@ -2,11 +2,11 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2018
 
-import streamsx.spl.code.types
+import streamsx.spl.code.types as code_types
 import dis
 
 def _cannot_translate(*args):
-    raise streamsx.spl.code.types.CannotTranslate()
+    raise code_types.CannotTranslate()
 
 def _load_fast(ctx, stack, code, ins):
     if ins.arg == 0:
@@ -24,17 +24,17 @@ def _load_attr(ctx, stack, code, ins):
     if tos is ctx._tuple:
         # TODO - assert is a named tuple
         if attr_name in ctx.in_attrs_name:
-            stack.append(streamsx.spl.code.types.ReadAttribute(tos, ctx.in_attrs_name[attr_name]))
+            stack.append(ctx.read_attribute(name=attr_name))
             return
     _cannot_translate()
 
 def _binary_op(ctx, stack, code, ins, op):
     tos = stack.pop()
     tos1 = stack.pop()
-    tos, tos1 = streamsx.spl.code.types.binary_upcast(tos, tos1)
+    tos, tos1 = code_types.arith_upcast(tos, tos1)
     expr = '(' + str(tos1) + ' ' + op + ' ' + str(tos) + ')'
-    et = streamsx.spl.code.types.value_type(tos)
-    val = streamsx.spl.code.types.CodeValue(et, expr)
+    et = code_types.value_type(tos)
+    val = code_types.CodeValue(et, expr)
     stack.append(val)
 
 def _binary_add(ctx, stack, code, ins):
@@ -42,6 +42,9 @@ def _binary_add(ctx, stack, code, ins):
 
 def _binary_subtract(ctx, stack, code, ins):
     _binary_op(ctx, stack, code, ins, '-')
+
+def _binary_multiply(ctx, stack, code, ins):
+    _binary_op(ctx, stack, code, ins, '*')
 
 def _binary_subscr(ctx, stack, code, ins):
     """ supports tuple_[int|str]"""
@@ -53,13 +56,13 @@ def _binary_subscr(ctx, stack, code, ins):
                 # TODO: Actually an attribute error
                 _cannot_translate()
             if tos in ctx.in_attrs_name:
-                stack.append(streamsx.spl.code.types.ReadAttribute(tos1, ctx.in_attrs_name[tos]))
+                stack.append(ctx.read_attribute(name=tos))
                 return
         if isinstance(tos, int) and tos >=0 and tos < len(ctx.in_attrs_pos):
              if ctx.in_schema.style is dict:
                 # TODO: Actually an attribute error
                 _cannot_translate()
-             stack.append(streamsx.spl.code.types.ReadAttribute(tos1, ctx.in_attrs_pos[tos]))
+             stack.append(code_types.ReadAttribute(tos1, ctx.in_attrs_pos[tos]))
              return
 
     _cannot_translate()
@@ -68,27 +71,12 @@ def _compare_op(ctx, stack, code, ins):
     rhs = stack.pop()
     lhs = stack.pop()
 
-    lt = streamsx.spl.code.types.value_type(lhs)
-    rt = streamsx.spl.code.types.value_type(rhs)
-    if lt == rt:
-        pass
-    elif lt in streamsx.spl.code.types.CT_INTS:
-        if rt is int:
-            rhs = streamsx.spl.code.types.code_cast(rhs, lt)
-        elif rt in streamsx.spl.code.types.CT_INTS:
-            t = streamsx.spl.code.types.CT_INTS[max(streamsx.spl.code.types.CT_INTS.index(lt), streamsx.spl.code.types.CT_INTS.index(rt))]
-            lhs = streamsx.spl.code.types.code_cast(lhs, t)
-            rhs = streamsx.spl.code.types.code_cast(rhs, t)
-        else:
-            _cannot_translate()
-    else:
-        _cannot_translate()
-    
-    cv = '(' + str(lhs) + ' ' + dis.cmp_op[ins.arg] + ' ' + str(rhs) + ') '
-    stack.append(streamsx.spl.code.types.CodeValue(bool, cv))
+    lhs, rhs = code_types.arith_upcast(lhs, rhs)
+
+    stack.append(code_types.CodeValue('boolean', code_types.binary(lhs, dis.cmp_op[ins.arg], rhs)))
 
 def _build_tuple(ctx, stack, code, ins):
-    items = streamsx.spl.code.types.CodeTuple(tuple(stack[len(stack)-ins.arg:]))
+    items = code_types.CodeTuple(tuple(stack[len(stack)-ins.arg:]))
     for _ in range(ins.arg):
         stack.pop()
     stack.append(items)
@@ -97,7 +85,19 @@ def _return_value(ctx, stack, code, ins):
     ctx._seen_return = True
     ctx._return = stack.pop()
     if stack:
-        raise streamsx.spl.code.types.CannotTranslate()
+        raise code_types.CannotTranslate()
+
+
+def _cond_jump(ctx, stack, code, ins):
+    if ins.arg < ins.offset:
+        raise code_types.CannotTranslate()
+    tos =  stack.pop()
+    if ins.arg in ctx.jumps:
+        items = ctx.jumps[ins.arg]
+    else:
+        items = []
+        ctx.jumps[ins.arg] = items
+    items.append((code_types.as_boolean(tos), ins))
 
 
 OPCODE_ACTION_TUPLE = dict()
@@ -110,11 +110,20 @@ OA['LOAD_ATTR'] = _load_attr
 
 OA['BINARY_ADD'] = _binary_add
 OA['BINARY_SUBTRACT'] = _binary_subtract
+
+OA['BINARY_MULTIPLY'] = _binary_multiply
+
 OA['BINARY_SUBSCR'] = _binary_subscr
 
 OA['COMPARE_OP'] = _compare_op
 
 OA['BUILD_TUPLE'] = _build_tuple
+
+# OA['POP_JUMP_IF_FALSE'] = _cond_jump
+# OA['POP_JUMP_IF_TRUE'] = _cond_jump
+OA['JUMP_IF_TRUE_OR_POP'] = _cond_jump
+OA['JUMP_IF_FALSE_OR_POP'] = _cond_jump
+
 
 OA['RETURN_VALUE'] = _return_value
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/opcodes.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/opcodes.py
@@ -1,0 +1,117 @@
+# coding=utf-8
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2018
+
+import streamsx.spl.code.types
+import dis
+
+def _cannot_translate(*args):
+    raise streamsx.spl.code.types.CannotTranslate()
+
+def _load_fast(ctx, stack, code, ins):
+    if ins.arg == 0:
+        stack.append(ctx._tuple)
+        return
+    stack.append(code.co_varnames[ins.arg])
+
+def _load_const(ctx, stack, code, ins):
+    stack.append(code.co_consts[ins.arg])
+
+def _load_attr(ctx, stack, code, ins):
+    tos = stack.pop()
+    attr_name = code.co_names[ins.arg]
+
+    if tos is ctx._tuple:
+        # TODO - assert is a named tuple
+        if attr_name in ctx.in_attrs_name:
+            stack.append(streamsx.spl.code.types.ReadAttribute(tos, ctx.in_attrs_name[attr_name]))
+            return
+    _cannot_translate()
+
+def _binary_op(ctx, stack, code, ins, op):
+    tos = stack.pop()
+    tos1 = stack.pop()
+    stack.append('(' + str(tos1) + ' ' + op + ' ' + str(tos) + ')')
+
+def _binary_add(ctx, stack, code, ins):
+    _binary_op(ctx, stack, code, ins, '+')
+
+def _binary_subtract(ctx, stack, code, ins):
+    _binary_op(ctx, stack, code, ins, '-')
+
+def _binary_subscr(ctx, stack, code, ins):
+    """ supports tuple_[str_constant]"""
+    tos = stack.pop()
+    tos1 = stack.pop()
+    if tos1 is ctx._tuple:
+        if isinstance(tos, str):
+            if not ctx.in_schema.style is dict:
+                # TODO: Actually an attribute error
+                _cannot_translate()
+            if tos in ctx.in_attrs_name:
+                stack.append(streamsx.spl.code.types.ReadAttribute(tos1, ctx.in_attrs_name[tos]))
+                return
+        if isinstance(tos, int) and tos >=0 and tos < len(ctx.in_attrs_pos):
+             if ctx.in_schema.style is dict:
+                # TODO: Actually an attribute error
+                _cannot_translate()
+             stack.append(streamsx.spl.code.types.ReadAttribute(tos1, ctx.in_attrs_pos[tos]))
+             return
+
+    _cannot_translate()
+
+def _compare_op(ctx, stack, code, ins):
+    rhs = stack.pop()
+    lhs = stack.pop()
+
+    lt = streamsx.spl.code.types.value_type(lhs)
+    rt = streamsx.spl.code.types.value_type(rhs)
+    if lt == rt:
+        pass
+    elif lt in streamsx.spl.code.types.CT_INTS:
+        if rt is int:
+            rhs = streamsx.spl.code.types.code_cast(rhs, lt)
+        elif rt in streamsx.spl.code.types.CT_INTS:
+            t = streamsx.spl.code.types.CT_INTS[max(streamsx.spl.code.types.CT_INTS.index(lt), streamsx.spl.code.types.CT_INTS.index(rt))]
+            lhs = streamsx.spl.code.types.code_cast(lhs, t)
+            rhs = streamsx.spl.code.types.code_cast(rhs, t)
+        else:
+            _cannot_translate()
+    else:
+        _cannot_translate()
+    
+    cv = '(' + str(lhs) + ' ' + dis.cmp_op[ins.arg] + ' ' + str(rhs) + ') '
+    stack.append(streamsx.spl.code.types.CodeValue(bool, cv))
+
+def _build_tuple(ctx, stack, code, ins):
+    items = tuple(stack[len(stack)-ins.arg:])
+    for _ in range(ins.arg):
+        stack.pop()
+    stack.append(items)
+
+def _return_value(ctx, stack, code, ins):
+    ctx._seen_return = True
+    ctx._return = stack.pop()
+    if stack:
+        raise streamsx.spl.code.types.CannotTranslate()
+
+
+OPCODE_ACTION_TUPLE = dict()
+
+OA = OPCODE_ACTION_TUPLE
+
+OA['LOAD_FAST'] = _load_fast
+OA['LOAD_CONST'] = _load_const
+OA['LOAD_ATTR'] = _load_attr
+
+OA['BINARY_ADD'] = _binary_add
+OA['BINARY_SUBTRACT'] = _binary_subtract
+OA['BINARY_SUBSCR'] = _binary_subscr
+
+OA['COMPARE_OP'] = _compare_op
+
+OA['BUILD_TUPLE'] = _build_tuple
+
+OA['RETURN_VALUE'] = _return_value
+
+

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/opcodes.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/opcodes.py
@@ -31,7 +31,11 @@ def _load_attr(ctx, stack, code, ins):
 def _binary_op(ctx, stack, code, ins, op):
     tos = stack.pop()
     tos1 = stack.pop()
-    stack.append('(' + str(tos1) + ' ' + op + ' ' + str(tos) + ')')
+    tos, tos1 = streamsx.spl.code.types.binary_upcast(tos, tos1)
+    expr = '(' + str(tos1) + ' ' + op + ' ' + str(tos) + ')'
+    et = streamsx.spl.code.types.value_type(tos)
+    val = streamsx.spl.code.types.CodeValue(et, expr)
+    stack.append(val)
 
 def _binary_add(ctx, stack, code, ins):
     _binary_op(ctx, stack, code, ins, '+')
@@ -40,7 +44,7 @@ def _binary_subtract(ctx, stack, code, ins):
     _binary_op(ctx, stack, code, ins, '-')
 
 def _binary_subscr(ctx, stack, code, ins):
-    """ supports tuple_[str_constant]"""
+    """ supports tuple_[int|str]"""
     tos = stack.pop()
     tos1 = stack.pop()
     if tos1 is ctx._tuple:
@@ -84,7 +88,7 @@ def _compare_op(ctx, stack, code, ins):
     stack.append(streamsx.spl.code.types.CodeValue(bool, cv))
 
 def _build_tuple(ctx, stack, code, ins):
-    items = tuple(stack[len(stack)-ins.arg:])
+    items = streamsx.spl.code.types.CodeTuple(tuple(stack[len(stack)-ins.arg:]))
     for _ in range(ins.arg):
         stack.pop()
     stack.append(items)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/translator.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/translator.py
@@ -1,0 +1,103 @@
+# coding=utf-8
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2018
+
+import copy
+import dis
+import streamsx.spl.code.opcodes
+import streamsx.spl.code.types
+import streamsx.topology.schema 
+import streamsx.spl.op
+
+    
+class _SPLCtx(object):
+    def __init__(self, code, in_schema):
+        self.code = code
+        self._tuple = streamsx.spl.code.types.InTuple(0, code.co_varnames[0])
+        self.in_schema = in_schema
+        # Attributes by position and name
+        attrs = streamsx.spl.code.types.attributes(in_schema)
+        self.in_attrs_pos = attrs[0]
+        self.in_attrs_name = attrs[1]
+        self._seen_return = False
+        self._return = None
+
+    def _calculate(self):
+        stack = list()
+        try:
+            for ins in dis.get_instructions(self.code):
+                if self._seen_return:
+                    raise streamsx.spl.code.types.CannotTranslate()
+                act = streamsx.spl.code.opcodes.OA.get(ins.opname)
+                if act is not None:
+                    act(self, stack, self.code, ins)
+                else:
+                    raise streamsx.spl.code.types.CannotTranslate()
+        except streamsx.spl.code.types.CannotTranslate as e:
+            print("!!!!!!!")
+            import traceback
+            traceback.print_exc()
+            return False
+        return True
+
+    def _tuple_spl(ctx, schema, tuple_):
+        st = '{'
+        attr_names = ['a', 'b', 'c']
+        for i in range(len(attr_names)):
+             if i:
+                 st += ', '
+             st += attr_names[i]
+             st += '=';
+             st += tuple_[i]
+        
+        st += '}'
+        return st
+
+def _translatable_schema(schema):
+    if streamsx.topology.schema.is_common(schema):
+        return False
+    if not hasattr(schema, '_types'):
+        return False
+    return True
+
+def translate_filter(stream, fn, name):
+    """Translate a Python filter to an SPL Filter if possible."""
+    schema = stream.oport.schema
+    if not _translatable_schema(schema):
+        return None
+
+    if hasattr(fn, '__code__'):
+        ctx = _FilterCtx(fn.__code__, schema)
+        if ctx.translate():
+            return ctx.add_translated(stream, name)
+    return None
+
+class _FilterCtx(_SPLCtx):
+    def __init__(self, code, in_schema):
+        super(_FilterCtx, self).__init__(code, in_schema)
+
+    def translate(self):
+        return self._calculate()
+
+    def add_translated(self, stream, name):
+        if type(self._return) in streamsx.spl.code.types.CT_BUILTINS:
+            self._return = bool(self._return)
+        if isinstance(self._return, bool):
+             self._return = 'true' if self._return else 'false'
+
+        stream = stream.aliased_as(self._tuple.name)
+
+        params = {'filter': streamsx.spl.op.Expression.expression(str(self._return))}
+        _op = streamsx.spl.op.Map('spl.relational::Filter', stream, params=params, name=name)
+        return _op.stream
+
+
+class _MapCtx(_SPLCtx):
+    def __init__(self, code, in_schema=None, out_schema=None):
+        super(_MapCtx, self).__init__(code, in_schema)
+
+    def _spl_json(self):
+        if self._calculate():
+            print(self._tuple_spl(None, self._return))
+
+

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/translator.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/translator.py
@@ -5,13 +5,15 @@
 import copy
 import dis
 import inspect
+import logging
+
 import streamsx.spl.code.opcodes
 import streamsx.spl.code.types as types
 import streamsx.topology.schema
 import streamsx.topology.topology
 import streamsx.spl.op
 
-
+trace = logging.getLogger('streamsx.topology.translator')
 
 class _SPLTupleCtx(object):
     """Code translator for a function passed a structured schema tuple as a single argument.
@@ -65,7 +67,7 @@ class _SPLTupleCtx(object):
                 tos = types.CodeValue('boolean', types.binary(jv_val, '||', types.as_boolean(stack.pop())))
                 stack.append(tos)
             else:
-                raise types.CannotTranslate()
+                raise types.CannotTranslate(jv_ins)
 
 
     def _calculate(self):
@@ -80,14 +82,14 @@ class _SPLTupleCtx(object):
         stack = list()
         for ins in dis.get_instructions(self.code):
             if self._seen_return:
-                raise types.CannotTranslate()
+                raise types.CannotTranslate(ins, 'Already seen return')
             act = streamsx.spl.code.opcodes.OA.get(ins.opname)
             if act is not None:
                 if ins.is_jump_target:
                     self.merge_jumps(stack, ins)
                 act(self, stack, self.code, ins)
             else:
-                raise types.CannotTranslate()
+                raise types.CannotTranslate(ins, "Not supported")
 
     def _tuple_spl(ctx, schema, tuple_):
         st = '{'
@@ -122,6 +124,7 @@ def enabled(topo, fn):
 def translatable_schema(schema):
     if streamsx.topology.schema.is_common(schema):
         return False
+    print("type:schema:" + str(type(schema)))
     if not hasattr(schema, '_types'):
         return False
     return True
@@ -168,7 +171,8 @@ class FilterCtx(_SPLTupleCtx):
             # following Python rules.
             self._return = types.as_boolean(self._return)
             return True
-        except types.CannotTranslate:
+        except types.CannotTranslate as e:
+            trace.debug(e.ins + " -- " + e.args)
             return False
 
     def filter_expression(self):
@@ -184,24 +188,35 @@ class FilterCtx(_SPLTupleCtx):
         params = {'filter': streamsx.spl.op.Expression.expression(str(self.filter_expression()))}
         _op = streamsx.spl.op.Map('spl.relational::Filter', stream, params=params, name=name)
         _op.stream._spl_translated = 'FromPython'
-        return _op.stream
+        return _op
 
 def translate_map(stream, fn, out_schema, name):
     """Translate a Python map to SPL if possible."""
 
+    trace.debug("Translator: Attempting " + str(name))
+
     if not enabled(stream.topology, fn):
+        trace.debug("Translator: Not enabled")
         return None
 
     if not translatable_schema(out_schema):
-        return None
-    in_schema = stream.oport.schema
-    if not translatable_schema(in_schema):
+        trace.debug("Translator: Output schema not supported." + str(out_schema))
         return None
 
-    if translatable_logic(fn):
-        ctx = MapCtx(fn.__code__, in_schema, out_schema)
-        if ctx.translate():
-            return ctx.add_translated(stream, name)
+    in_schema = stream.oport.schema
+    if not translatable_schema(in_schema):
+        trace.debug("Translator: Input schema not supported." + str(in_schema))
+        return None
+
+    if not translatable_logic(fn):
+        trace.debug('Translator: Callable not translatable:' + str(fn))
+        return None
+
+    ctx = MapCtx(fn.__code__, in_schema, out_schema)
+    if ctx.translate():
+        return ctx.add_translated(stream, name)
+
+    trace.debug("Translator: Code not translatable:" + str(fn))
     return None
 
 class MapCtx(_SPLTupleCtx):
@@ -212,7 +227,8 @@ class MapCtx(_SPLTupleCtx):
     def translate(self):
         try:
             self._calculate()
-        except types.CannotTranslate:
+        except types.CannotTranslate as e:
+            trace.debug(e.ins + " -- " + e.args)
             return False
 
         if not isinstance(self._return, types.CodeTuple):
@@ -226,7 +242,7 @@ class MapCtx(_SPLTupleCtx):
             assignments = []
             for i in range(len(self.out_attrs_pos)):
                 attr = self.out_attrs_pos[i]
-                assignments.append(types.unary_cast(values[i], attr.code_type))
+                assignments.append(types.assignment_cast(values[i], attr.code_type))
             self.assignments = assignments
             return True
         except types.CannotTranslate:
@@ -241,5 +257,5 @@ class MapCtx(_SPLTupleCtx):
             attr = self.out_attrs_pos[i]
             setattr(_op, attr.name, _op.output(str(self.assignments[i])))
         _op.stream._spl_translated = 'FromPython'
-        return _op.stream
+        return _op
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/types.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/types.py
@@ -31,16 +31,20 @@ class ReadAttribute(object):
 
 class CodeValue(object):
     def __init__(self, code_type, expr):
-        self.code_type_ = code_type
+        self.code_type = code_type
         self.expr = expr
 
     def __str__(self):
         return str(self.expr)
 
+class CodeTuple(object):
+    def __init__(self, args):
+        self.values = args
+
 CT_BUILTINS={int,float,bool}
 
-CT_INTS={'int8', 'int16', 'int32', 'int64'}
-CT_FLOATS={'float32', 'float64'}
+CT_INTS=['int8', 'int16', 'int32', 'int64']
+CT_FLOATS=['float32', 'float64']
 CT_BOOLEANS={'boolean', bool}
 
 def value_type(value):
@@ -51,33 +55,52 @@ def value_type(value):
          t = value.code_type
      return t
 
-def code_cast(value, code_type):
-    if hasattr(value, 'code_type') and value.code_type == code_type:
+def same_type(value, target_type):
+    return hasattr(value, 'code_type') and value.code_type == target_type
+
+def code_cast(value, target_type):
+    if same_type(value, target_type):
          return value
-    cv = '((' + code_type + ') ' + str(value) + ')'
-    return CodeValue(code_type, cv)
+    cv = '((' + target_type + ') ' + str(value) + ')'
+    return CodeValue(target_type, cv)
 
 def binary_upcast(lhs, rhs):
-    lt = streamsx.spl.code.types.value_type(lhs)
-    rt = streamsx.spl.code.types.value_type(rhs)
+    lt = value_type(lhs)
+    rt = value_type(rhs)
+    print("BUT:", lt, rt)
     if lt == rt:
         pass
-    elif lt in streamsx.spl.code.types.CT_INTS:
-        lhs,rhs = lhs_int_upcast(lhs, lt, rhs, rt)
-    elif rt in streamsx.spl.code.types.CT_INTS:
+    elif lt in CT_INTS:
+        lhs,rhs = int_upcast(lhs, lt, rhs, rt)
+    elif rt in CT_INTS:
         # yes args are swapped as the rhs is driving the type
-        rhs,lhs = lhs_int_upcast(rhs, rt, lhs, lt)
+        rhs,lhs = int_upcast(rhs, rt, lhs, lt)
     else:
         _cannot_translate()
     return (lhs, rhs)
 
+def unary_cast(value, target_type):
+    if same_type(value, target_type):
+         return value
+    print(type(value))
+    vt = value_type(value)
+    print("UNARY", vt, target_type)
+    if vt in CT_BUILTINS:
+        if target_type in CT_INTS:
+            return code_cast(int(value), target_type)
+    elif vt in CT_INTS:
+        return code_cast(value, target_type)
+    _cannot_translate()
+
 def int_upcast(v, t, ov, ot):
+    print("IUT:", t, ot)
     if ot is int:
-        ov = streamsx.spl.code.types.code_cast(ov, t)
-    elif ot in streamsx.spl.code.types.CT_INTS:
-        t = streamsx.spl.code.types.CT_INTS[max(streamsx.spl.code.types.CT_INTS.index(t), streamsx.spl.code.types.CT_INTS.index(ot))]
-        v = streamsx.spl.code.types.code_cast(v, t)
-        ov = streamsx.spl.code.types.code_cast(ov, t)
+        ov = code_cast(ov, t)
+    elif ot in CT_INTS:
+        print("IUT:", CT_INTS.index(t), CT_INTS.index(ot))
+        t = CT_INTS[max(CT_INTS.index(t), CT_INTS.index(ot))]
+        v = code_cast(v, t)
+        ov = code_cast(ov, t)
     else:
         _cannot_translate()
     return (v, ov)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/types.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/code/types.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2018
+
+class InTuple(object):
+    def __init__(self, port, name):
+        self.port = port
+        self.name = name
+
+class Attribute(object):
+    def __init__(self, code_type, name):
+        self.code_type = code_type
+        self.name = name
+
+def attributes(schema):
+    attrs_by_pos = list(Attribute(a[0], a[1]) for a in schema._types)
+    attrs_by_name = dict()
+    for a in attrs_by_pos:
+        attrs_by_name[a.name] = a
+    return (attrs_by_pos, attrs_by_name)
+
+
+class ReadAttribute(object):
+    def __init__(self, tuple_, attr):
+        self.tuple_ = tuple_
+        self.attr = attr
+        self.code_type = attr.code_type
+
+    def __str__(self):
+        return self.tuple_.name + '.' + self.attr.name
+
+class CodeValue(object):
+    def __init__(self, code_type, expr):
+        self.code_type_ = code_type
+        self.expr = expr
+
+    def __str__(self):
+        return str(self.expr)
+
+CT_BUILTINS={int,float,bool}
+
+CT_INTS={'int8', 'int16', 'int32', 'int64'}
+CT_FLOATS={'float32', 'float64'}
+CT_BOOLEANS={'boolean', bool}
+
+def value_type(value):
+     t = None
+     if type(value) in CT_BUILTINS:
+        t = type(value)
+     elif hasattr(value, 'code_type'):
+         t = value.code_type
+     return t
+
+def code_cast(value, code_type):
+    if hasattr(value, 'code_type') and value.code_type == code_type:
+         return value
+    cv = '((' + code_type + ') ' + str(value) + ')'
+    return CodeValue(code_type, cv)
+
+def binary_upcast(lhs, rhs):
+    lt = streamsx.spl.code.types.value_type(lhs)
+    rt = streamsx.spl.code.types.value_type(rhs)
+    if lt == rt:
+        pass
+    elif lt in streamsx.spl.code.types.CT_INTS:
+        lhs,rhs = lhs_int_upcast(lhs, lt, rhs, rt)
+    elif rt in streamsx.spl.code.types.CT_INTS:
+        # yes args are swapped as the rhs is driving the type
+        rhs,lhs = lhs_int_upcast(rhs, rt, lhs, lt)
+    else:
+        _cannot_translate()
+    return (lhs, rhs)
+
+def int_upcast(v, t, ov, ot):
+    if ot is int:
+        ov = streamsx.spl.code.types.code_cast(ov, t)
+    elif ot in streamsx.spl.code.types.CT_INTS:
+        t = streamsx.spl.code.types.CT_INTS[max(streamsx.spl.code.types.CT_INTS.index(t), streamsx.spl.code.types.CT_INTS.index(ot))]
+        v = streamsx.spl.code.types.code_cast(v, t)
+        ov = streamsx.spl.code.types.code_cast(ov, t)
+    else:
+        _cannot_translate()
+    return (v, ov)
+
+class CannotTranslate(Exception):
+     def __init__(self):
+         pass
+
+def _cannot_translate(*args):
+    raise CannotTranslate()
+

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -683,7 +683,11 @@ class Stream(_placement._Placement, object):
         """
         if schema is None:
             schema = streamsx.topology.schema.CommonSchema.Python
-     
+        else:
+            spl_map = streamsx.spl.code.translator.translate_map(self, func, schema, name)
+            if spl_map is not None:
+                return spl_map
+
         ms = self._map(func, schema=schema, name=name)._layout('Map')
         ms.oport.operator.sl = _SourceLocation(_source_info(), 'map')
         return ms

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -180,6 +180,7 @@ except (ImportError,NameError):
 import copy
 import random
 import streamsx._streams._placement as _placement
+import streamsx.spl.code.translator
 import streamsx.topology.graph
 import streamsx.topology.schema
 import streamsx.topology.functions
@@ -576,6 +577,11 @@ class Stream(_placement._Placement, object):
         """
         sl = _SourceLocation(_source_info(), 'filter')
         _name = self.topology.graph._requested_name(name, action="filter", func=func)
+        spl_filter = streamsx.spl.code.translator.translate_filter(self, func, name)
+        if spl_filter is not None:
+             return spl_filter
+
+
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::Filter", func, name=_name, sl=sl)
         op.addInputPort(outputPort=self.oport, name=self.name)
         streamsx.topology.schema.StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -291,6 +291,8 @@ class Topology(object):
            Package names in `include_packages` take precedence over package names in `exclude_packages`.
     """  
 
+    TRANSLATE_FEATURE = "TRANSLATE"
+
     def __init__(self, name=None, namespace=None, files=None):
         if name is None or namespace is None:
             # Take the name of the calling function
@@ -326,6 +328,10 @@ class Topology(object):
         self.exclude_packages.update(streamsx.topology._deppkgs._DEP_PACKAGES)
         
         self.graph = streamsx.topology.graph.SPLGraph(self, name, namespace)
+
+        # feature support
+        self.features = dict()
+        self.features[Topology.TRANSLATE_FEATURE] = os.environ.get('STREAMSX_TOPOLOGY_' + Topology.TRANSLATE_FEATURE, False)
 
     @property
     def name(self):

--- a/test/python/translator/test_filter.py
+++ b/test/python/translator/test_filter.py
@@ -1,0 +1,37 @@
+import unittest
+import itertools
+
+from streamsx.topology.schema import StreamSchema
+from streamsx.topology.topology import Topology
+from streamsx.topology.tester import Tester
+
+import translate_test_utils
+
+def check_lt900(t):
+    return t[0] < 900 
+
+class TestFilter(unittest.TestCase):
+    def setUp(self):
+        Tester.setup_standalone(self)
+
+    def test_filter_tuple(self):
+        for translate in [False, True]:
+            with self.subTest(translate=translate):
+                topo = Topology()
+
+                translate_test_utils.setup(topo, translate)
+                    
+                s1 = topo.source(range(2000))
+                translate_test_utils.check_stream(self, s1, False)
+
+                s = s1.map(lambda t : (t%1000,), schema=StreamSchema('tuple<int32 a>').as_tuple())
+                translate_test_utils.check_stream(self, s, False)
+
+                s = s.filter(lambda tuple_ : tuple_[0] < 900)
+                translate_test_utils.check_stream(self, s, translate, 'Filter')
+
+                tester = Tester(topo)
+                tester.tuple_count(s1, 2000)
+                tester.tuple_check(s, check_lt900)
+                tester.tuple_count(s, 1800)
+                tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/translator/test_filter_unit.py
+++ b/test/python/translator/test_filter_unit.py
@@ -1,0 +1,108 @@
+import unittest
+
+import streamsx.topology.schema as sts
+import streamsx.spl.code.translator as translator
+import streamsx.spl.code.types as code_types
+
+def my_filter(v):
+    return v.a != 9
+
+class TestFilterTranslator(unittest.TestCase):
+
+    def check_predicate(self, fn, schema, alias='val'):
+        ctx = translator.FilterCtx(fn.__code__, schema)
+        self.assertTrue(ctx.translate())
+        self.assertTrue(isinstance(ctx._return, code_types.CodeValue))
+        self.assertEqual('boolean', ctx._return.code_type)
+
+        self.assertEqual(alias, ctx.alias())
+        return ctx
+
+    def check_expr(self, ctx, *args):
+        pos = -1
+        expr = ctx.filter_expression()
+
+        for arg in args:
+            idx = expr.find(arg)
+            self.assertTrue(idx >= 0)
+            self.assertTrue(idx > pos)
+            pos = idx
+
+    def test_filter_tuple(self):
+        schema = sts.StreamSchema('tuple<int32 a, boolean b, int64 c>').as_tuple()
+
+        ctx = self.check_predicate(lambda val : True, schema)
+        self.assertEqual('true', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda val : 8, schema)
+        self.assertEqual('true', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda val : 0.0, schema)
+        self.assertEqual('false', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda val : val[0] < 20, schema)
+        self.check_expr(ctx, 'val.a', ' < ', '20')
+
+        ctx = self.check_predicate(lambda val : val[0] <= 20, schema)
+        self.check_expr(ctx, 'val.a', ' <= ', '20')
+
+        ctx = self.check_predicate(lambda val : val[0] == 20, schema)
+        self.check_expr(ctx, 'val.a', ' == ', '20')
+
+        ctx = self.check_predicate(lambda val : val[0] != 20, schema)
+        self.check_expr(ctx, 'val.a', ' != ', '20')
+
+        ctx = self.check_predicate(lambda val : val[0] >= 20, schema)
+        self.check_expr(ctx, 'val.a', ' >= ', '20')
+
+        ctx = self.check_predicate(lambda val : val[0] > 20, schema)
+        self.check_expr(ctx, 'val.a', ' > ', '20')
+
+        ctx = self.check_predicate(lambda val : val[1], schema)
+        self.assertEqual('val.b', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda val : val[0], schema)
+        self.check_expr(ctx, 'val.a', ' != ', '0')
+
+        ctx = self.check_predicate(lambda v : v[2], schema, 'v')
+        self.check_expr(ctx, 'v.c', ' != ', '0')
+        
+    def test_filter_dict(self):
+        schema = sts.StreamSchema('tuple<int32 a, boolean b, int64 c>')
+
+        ctx = self.check_predicate(lambda v : v['b'], schema, 'v')
+        self.assertEqual('v.b', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda v : v['c'], schema, 'v')
+        self.check_expr(ctx, 'v.c', ' != ', '0')
+
+    def test_filter_namedtuple(self):
+        schema = sts.StreamSchema('tuple<int32 a, boolean b, int64 c>').as_tuple(named=True)
+
+        ctx = self.check_predicate(lambda v : v[1], schema, 'v')
+        self.assertEqual('v.b', ctx.filter_expression())
+        ctx = self.check_predicate(lambda tuple_ : tuple_.b, schema, 'tuple_')
+        self.assertEqual('tuple_.b', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda v : v[0], schema, 'v')
+        self.check_expr(ctx, 'v.a', ' != ', '0')
+        ctx = self.check_predicate(lambda v : v.a, schema, 'v')
+        self.check_expr(ctx, 'v.a', ' != ', '0')
+
+        ctx = self.check_predicate(my_filter, schema, 'v')
+        self.check_expr(ctx, 'v.a', ' != ', '9')
+
+    def test_logic(self):
+        schema = sts.StreamSchema('tuple<boolean a, boolean b, boolean c, boolean d>').as_tuple(named=True)
+
+        ctx = self.check_predicate(lambda v : v.a and v.b, schema, 'v')
+        self.assertEqual('(v.a && v.b)', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda v : v.a or v.b, schema, 'v')
+        self.assertEqual('(v.a || v.b)', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda v : v.a or v.b or v.c, schema, 'v')
+        self.assertEqual('(v.a || (v.b || v.c))', ctx.filter_expression())
+
+        ctx = self.check_predicate(lambda v : v.a and v.b and v.c, schema, 'v')
+        self.assertEqual('(v.a && (v.b && v.c))', ctx.filter_expression())

--- a/test/python/translator/test_filter_unit.py
+++ b/test/python/translator/test_filter_unit.py
@@ -106,3 +106,10 @@ class TestFilterTranslator(unittest.TestCase):
 
         ctx = self.check_predicate(lambda v : v.a and v.b and v.c, schema, 'v')
         self.assertEqual('(v.a && (v.b && v.c))', ctx.filter_expression())
+
+    def test_string(self):
+        schema = sts.StreamSchema('tuple<rstring a, ustring b>').as_tuple(named=True)
+        ctx = self.check_predicate(lambda s : s.a, schema, 's')
+        self.assertEqual('(length(s.a) != 0)', ctx.filter_expression())
+        ctx = self.check_predicate(lambda s : s.b, schema, 's')
+        self.assertEqual('(length(s.b) != 0)', ctx.filter_expression())

--- a/test/python/translator/test_map.py
+++ b/test/python/translator/test_map.py
@@ -1,0 +1,38 @@
+import unittest
+import itertools
+
+from streamsx.topology.schema import StreamSchema
+from streamsx.topology.topology import Topology
+from streamsx.topology.tester import Tester
+
+import translate_test_utils
+
+def check_map_nt(t):
+    return t['b'] == (t['a'] * 3) and t['c'] == t['a'] * 17.5
+
+class TestMap(unittest.TestCase):
+    def setUp(self):
+        Tester.setup_standalone(self)
+
+    def test_map_namedtuple(self):
+        for translate in [False, True]:
+            with self.subTest(translate=translate):
+                topo = Topology()
+
+                translate_test_utils.setup(topo, translate)
+                    
+                s1 = topo.source(range(2000))
+                translate_test_utils.check_stream(self, s1, False)
+
+                s = s1.map(lambda t : (t,), schema=StreamSchema('tuple<int32 a>').as_tuple(named=True))
+                translate_test_utils.check_stream(self, s, False)
+
+                s = s.map(lambda val : (val.a, val.a * 3, val.a * 17.5) ,
+                     schema='tuple<int32 a, int64 b, float64 c>')
+                translate_test_utils.check_stream(self, s, translate, 'Functor')
+
+                tester = Tester(topo)
+                tester.tuple_count(s1, 2000)
+                tester.tuple_check(s, check_map_nt)
+                tester.tuple_count(s, 2000)
+                tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/translator/test_translate.py
+++ b/test/python/translator/test_translate.py
@@ -1,0 +1,18 @@
+import unittest
+import os
+
+from streamsx.topology.topology import Topology
+
+class TestForce(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get('STREAMSX_TOPOLOGY_TRANSLATE')
+    def tearDown(self):
+        if self._saved:
+            os.environ['STREAMSX_TOPOLOGY_TRANSLATE'] = self._saved
+
+    def test_envvar_setting(self):
+        for translate in ['True', 'yes']:
+            with self.subTest(translate=translate):
+                os.environ['STREAMSX_TOPOLOGY_TRANSLATE'] = translate
+                topo = Topology()
+                self.assertTrue(topo.features[Topology.TRANSLATE_FEATURE])

--- a/test/python/translator/translate_test_utils.py
+++ b/test/python/translator/translate_test_utils.py
@@ -1,0 +1,14 @@
+from streamsx.topology.topology import Topology
+
+def setup(topo, translate):
+    if translate:
+        topo.features[Topology.TRANSLATE_FEATURE] = True
+
+
+def check_stream(tc, stream, translate, kind=None):
+    if translate:
+        tc.assertTrue(stream._spl_translated)
+        print("TRANSLATED*********************")
+        #tc.assertEqual('spl.relational__' + kind, stream._op().kind)
+    else:
+        tc.assertFalse(hasattr(stream, '_spl_translated'))

--- a/test/python/translator/translate_test_utils.py
+++ b/test/python/translator/translate_test_utils.py
@@ -8,7 +8,6 @@ def setup(topo, translate):
 def check_stream(tc, stream, translate, kind=None):
     if translate:
         tc.assertTrue(stream._spl_translated)
-        print("TRANSLATED*********************")
-        #tc.assertEqual('spl.relational__' + kind, stream._op().kind)
+        tc.assertEqual('spl.relational::' + kind, stream._op().kind)
     else:
         tc.assertFalse(hasattr(stream, '_spl_translated'))


### PR DESCRIPTION
See #1424

Inital support added as an optional experimental feature to application api for `Stream.filter` and `Stream.map`.