### PR TITLE
Fix code coverage reporting.

### DIFF
--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -202,7 +202,7 @@
      <property name="topology.test.coverage" value="true"/>
      <property name="topology.test.resource_dir" location="resources"/>
    <echo message="PYTHONHOME:${topology.test.python.prefix}"/>
-   <jacoco:coverage enabled="${topology.test.coverage}">
+   <jacoco:coverage enabled="${topology.test.coverage}" destfile="${test.dir}/jacoco.exec">
      <junit fork="yes" dir="${topology.test.dir}" printsummary="yes" showoutput="${topology.test.showoutput}"
            threads="${topology.test.threads}"
            haltonfailure="${topology.test.haltonfailure}" failureproperty="topology.tests.failed">
@@ -231,7 +231,7 @@
        </batchtest>
      </junit>
    </jacoco:coverage>
-   <jacoco:coverage enabled="${topology.test.coverage}">
+   <jacoco:coverage enabled="${topology.test.coverage}"  destfile="${test.dir}/jacoco.exec">
      <junit fork="yes" dir="${topology.test.dir}" printsummary="yes"
            threads="${topology.test.threads}"
            haltonfailure="${topology.test.haltonfailure}" failureproperty="topology.tests.failed">
@@ -318,7 +318,7 @@
      <mkdir dir="${test.dir}"/>
      <tempfile property="topology.test.dir" prefix="testrun" destDir="${test.dir}"/>
      <mkdir dir="${topology.test.dir}"/>
-   <jacoco:coverage enabled="${topology.test.coverage}">
+   <jacoco:coverage enabled="${topology.test.coverage}" destfile="${test.dir}/jacoco.exec">
      <junit fork="yes" dir="${topology.test.dir}" printsummary="yes" showoutput="${topology.test.showoutput}"
            threads="${topology.test.threads}"
            haltonfailure="${topology.test.haltonfailure}" failureproperty="topology.tests.failed">
@@ -361,7 +361,7 @@
      <property name="topology.test.coverage" value="true"/>
      <property name="topology.test.resource_dir" location="resources"/>
      <property name="topology.test.external.run" value="false"/>
-   <jacoco:coverage enabled="${topology.test.coverage}">
+   <jacoco:coverage enabled="${topology.test.coverage}" destfile="${test.dir}/jacoco.exec">
      <junit fork="yes" dir="${topology.test.dir}" printsummary="yes" showoutput="${topology.test.showoutput}"
            haltonfailure="${topology.test.haltonfailure}" failureproperty="topology.tests.failed">
        <sysproperty key="topology.test.root" value="${topology.test.root}"/>


### PR DESCRIPTION
When running unittests, the jacoco code coverage would report zero coverage. This happened because the ant script was looking for `jacoco.exec` in the `unittest` directory, when it was generated at the top level.

Added a fix which looks for `jacoco.exec` at the top level.