### PR TITLE
[Issue #1429] Add getLocialName() to Java REST Operator

### DIFF
--- a/java/src/com/ibm/streamsx/rest/Operator.java
+++ b/java/src/com/ibm/streamsx/rest/Operator.java
@@ -33,6 +33,8 @@ public class Operator extends Element {
     @Expose
     private String job;
     @Expose
+    private String logicalName;
+    @Expose
     private String metrics;
     @Expose
     private String name;
@@ -62,6 +64,16 @@ public class Operator extends Element {
             opList = Collections.<Operator> emptyList();
         }
         return opList;
+    }
+
+    /**
+     * The logical name of this operator.
+     * 
+     * @return the logical name of the operator, which is just the name if the
+     * operator is not part of a parallel region.
+     */
+    public String getLogicalName() {
+        return logicalName == null ? name : logicalName;
     }
 
     /**

--- a/java/src/com/ibm/streamsx/rest/Operator.java
+++ b/java/src/com/ibm/streamsx/rest/Operator.java
@@ -71,6 +71,7 @@ public class Operator extends Element {
      * 
      * @return the logical name of the operator, which is just the name if the
      * operator is not part of a parallel region.
+     * @since 1.9
      */
     public String getLogicalName() {
         return logicalName == null ? name : logicalName;

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -339,9 +339,7 @@
        <batchtest todir="${topology.test.dir}">
           <fileset dir="${basedir}/src"
              excludes="**/samples/*Test.java" >
-             <include name="**/StreamsConnectionTest.java"/>
-             <include name="**/StreamingAnalyticsConnectionTest.java"/>
-             <include name="**/StreamingAnalyticsServiceTest.java"/>
+             <include name="**/rest/test/*Test.java"/>
           </fileset>
        </batchtest>
      </junit>

--- a/test/java/src/com/ibm/streamsx/rest/test/ParallelOperatorsTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/ParallelOperatorsTest.java
@@ -1,0 +1,107 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+ */
+
+package com.ibm.streamsx.rest.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.streamsx.rest.Operator;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.context.StreamsContext;
+import com.ibm.streamsx.topology.context.StreamsContextFactory;
+
+public class ParallelOperatorsTest {
+
+    StreamsConnectionTest helper;
+
+    @After
+    public void removeJob() throws Exception {
+        helper.removeJob();
+    }
+
+    @Before
+    public void setupJob() throws Exception {
+        if (null == helper) {
+            helper = new StreamsConnectionTest();
+        }
+        helper.setupInstance();
+        if (helper.jobId == null) {
+            // avoid clashes with sub-class tests
+            Topology topology = new Topology(getClass().getSimpleName(), 
+                    "JobForRESTApiTest");
+
+            TStream<Integer> source = topology.periodicSource(() -> (int) (Math.random() * 5000 + 1), 200, TimeUnit.MILLISECONDS);
+            source.invocationName("IntegerPeriodicMultiSource");
+            TStream<Integer> parallelSource = source.parallel(3);
+            TStream<Integer> sourceDouble = parallelSource.map(StreamsConnectionTest.doubleNumber());
+            sourceDouble.invocationName("Outer");
+            TStream<Integer> encore = sourceDouble.parallel(2);
+            TStream<Integer> encoreDouble = encore.map(StreamsConnectionTest.doubleNumber());
+            encoreDouble.invocationName("Inner");
+            TStream<Integer> joinDouble = encoreDouble.endParallel();
+            TStream<Integer> sourceDoubleAgain = joinDouble.endParallel().isolate().map(StreamsConnectionTest.doubleNumber());
+            sourceDoubleAgain.invocationName("ZIntegerTransformInteger");
+
+            if (helper.testType.equals("DISTRIBUTED")) {
+                helper.jobId = StreamsContextFactory.getStreamsContext(StreamsContext.Type.DISTRIBUTED).submit(topology).get()
+                        .toString();
+            } else if (helper.testType.equals("STREAMING_ANALYTICS_SERVICE")) {
+                helper.jobId = StreamsContextFactory.getStreamsContext(StreamsContext.Type.STREAMING_ANALYTICS_SERVICE)
+                        .submit(topology).get().toString();
+            } else {
+                fail("This test should be skipped");
+            }
+
+            helper.job = helper.instance.getJob(helper.jobId);
+            helper.job.waitForHealthy(60, TimeUnit.SECONDS);
+
+            assertEquals("healthy", helper.job.getHealth());
+        }
+        System.out.println("jobId: " + helper.jobId + " is setup.");
+    }
+
+    @Test
+    public void testParallelOperators() throws Exception {
+        List<Operator> operators = helper.job.getOperators();
+        Iterator<Operator> curr = operators.iterator();
+
+        assertTrue("Missing source operator", curr.hasNext());
+        Operator op = curr.next();
+        assertEquals("IntegerPeriodicMultiSource", op.getLogicalName());
+
+        for (int outer = 0; outer < 3; ++outer) {
+            assertTrue("Missing expected outer parallel operator " + outer, curr.hasNext());
+            op = curr.next();
+            assertEquals("PARALLEL.Outer", op.getLogicalName());
+            assertFalse("Logical name should not match name for outer parallel operator " + outer,
+                    op.getName().equals(op.getLogicalName()));
+            for (int inner = 0; inner < 2; ++inner) {
+                String id = "[" + outer + "," + inner + "]";
+                assertTrue("Missing expected inner parallel operator " + id, curr.hasNext());
+                op = curr.next();
+                assertEquals("PARALLEL.PARALLEL_2.Inner", op.getLogicalName());
+                assertFalse("Logical name should not match name for inner parallel operator " + id,
+                        op.getName().equals(op.getLogicalName()));
+            }
+        }
+
+        assertTrue("Missing final operator", curr.hasNext());
+        op = curr.next();
+        assertEquals("ZIntegerTransformInteger", op.getLogicalName());
+    }
+
+}


### PR DESCRIPTION
Returns the logical name from the REST API if the operator is in a parallel region, or the plain name otherwise.