### PR TITLE
Convert token expiry time to milliseconds.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -226,7 +226,7 @@ class _IAMStreamsRestClient(_StreamsRestClient):
         self.handle_http_errors(res)
         res = res.json()
 
-        self._auth_expiry_time = int(res[_IAMConstants.EXPIRATION]) - _IAMConstants.EXPIRY_PAD_MS
+        self._auth_expiry_time = int(res[_IAMConstants.EXPIRATION] * 1000) - _IAMConstants.EXPIRY_PAD_MS
         self._bearer_token = self._create_bearer_auth(res[_IAMConstants.ACCESS_TOKEN])
 
     def _create_bearer_auth(self, token):


### PR DESCRIPTION
The token expiry time is not being converted to milliseconds. As such, a new IAM token was retrieved on every REST call.

This PR converts the expiry time to MS.