### PR TITLE
Support streamsx.ec and tester with Python 2.7

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy_ec.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_ec.h
@@ -372,6 +372,7 @@ static PyMethodDef __splpy_ec_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
+#if PY_MAJOR_VERSION == 3
 static struct PyModuleDef __splpy_ec_module = {
    PyModuleDef_HEAD_INIT,
    __SPLPY_EC_MODULE_NAME,   /* name of module */
@@ -380,11 +381,17 @@ static struct PyModuleDef __splpy_ec_module = {
                 or -1 if the module keeps state in global variables. */
    __splpy_ec_methods
 };
+#endif
 
 PyMODINIT_FUNC
 init_streamsx_ec(void)
 {
+#if PY_MAJOR_VERSION == 3
     return PyModule_Create(&__splpy_ec_module);
+#endif
+#if PY_MAJOR_VERSION == 2
+    (void) Py_InitModule(__SPLPY_EC_MODULE_NAME, __splpy_ec_methods);
+#endif
 }
 
 }

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_ec_api.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_ec_api.h
@@ -18,8 +18,7 @@
 #ifndef __SPL__SPLPY_EC_API_H
 #define __SPL__SPLPY_EC_API_H
 
-#if (PY_MAJOR_VERSION == 3) && \
-     ((_IBM_STREAMS_VER_ > 4) || \
+#if ((_IBM_STREAMS_VER_ > 4) || \
       ((_IBM_STREAMS_VER_ == 4) && (_IBM_STREAMS_REL_ >= 2)))
 
 #define __SPLPY_EC_MODULE_OK 1

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_setup.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_setup.h
@@ -224,13 +224,15 @@ class SplpySetup {
 
 #if __SPLPY_EC_MODULE_OK
 {
-          SPLAPPTRC(L_DEBUG, "Including Python extension: _streamsx_ec", "python");
 
+#if PY_MAJOR_VERSION == 3
+          SPLAPPTRC(L_DEBUG, "Including Python extension: _streamsx_ec", "python");
           typedef PyObject *(__splpy_initfunc)(void);
           typedef int (*__splpy_iai)(const char * name, __splpy_initfunc);
           __splpy_iai _SPLPyImport_AppendInittab =
              (__splpy_iai) dlsym(pydl, "PyImport_AppendInittab");
           _SPLPyImport_AppendInittab(__SPLPY_EC_MODULE_NAME, &init_streamsx_ec);
+#endif
 }
 #endif
 
@@ -257,7 +259,13 @@ class SplpySetup {
           const char *argv[] = {""};
           _SPLPySys_SetArgvEx(1, (char **) argv, 0);
 #endif
-
+#if __SPLPY_EC_MODULE_OK
+#if PY_MAJOR_VERSION == 2
+          SPLAPPTRC(L_DEBUG, "Including Python extension: _streamsx_ec", "python");
+          init_streamsx_ec();
+#endif
+#endif
+         
           _SPLPyEval_InitThreads();
           _SPLPyEval_SaveThread();
 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_sym.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_sym.h
@@ -184,8 +184,13 @@ extern "C" {
 typedef PyObject* (*__splpy_ogas_fp)(PyObject *, const char *);
 typedef int (*__splpy_rssf_fp)(const char *, PyCompilerFlags *);
 #if __SPLPY_EC_MODULE_OK
+#if PY_MAJOR_VERSION == 3
 typedef PyObject* (*__splpy_mc2_fp)(PyModuleDef *, int);
 typedef int (*__splpy_sam_fp)(PyObject *, PyModuleDef *);
+#endif
+#if PY_MAJOR_VERSION == 2
+typedef PyObject * (*__splpy_im4_fp)(const char *, PyMethodDef *, const char *doc, PyObject *self, int);
+#endif
 #endif
 
 extern "C" {
@@ -197,8 +202,14 @@ extern "C" {
   static __splpy_p_p_fp __spl_fp_PyImport_Import;
 
 #if __SPLPY_EC_MODULE_OK
+#if PY_MAJOR_VERSION == 3
   static __splpy_mc2_fp __spl_fp_PyModule_Create2;
   static __splpy_sam_fp __spl_fp_PyState_AddModule;
+#endif
+#if PY_MAJOR_VERSION == 2
+  static __splpy_im4_fp __spl_fp_Py_InitModule4 ;
+#endif
+
 #endif
 
   static PyObject * __spl_fi_PyObject_GetAttrString(PyObject *o, const char * attr_name) {
@@ -221,12 +232,19 @@ extern "C" {
   }
 
 #if __SPLPY_EC_MODULE_OK
+#if PY_MAJOR_VERSION == 3
   static PyObject * __spl_fi_PyModule_Create2(PyModuleDef *module, int apivers) {
      return __spl_fp_PyModule_Create2(module, apivers);
   }
   static int __spl_fi_PyState_AddModule(PyObject *module, PyModuleDef *def) {
      return __spl_fp_PyState_AddModule(module, def);
   }
+#endif
+#if PY_MAJOR_VERSION == 2
+  static PyObject * __spl_fi_Py_InitModule4(const char *name, PyMethodDef *methods, const char *doc, PyObject *self, int apiver) {
+     return __spl_fp_Py_InitModule4(name, methods, doc, self, apiver);
+  }
+#endif
 #endif
 }
 #pragma weak PyObject_GetAttrString = __spl_fi_PyObject_GetAttrString
@@ -237,8 +255,14 @@ extern "C" {
 #pragma weak PyImport_Import = __spl_fi_PyImport_Import
 
 #if __SPLPY_EC_MODULE_OK
+#if PY_MAJOR_VERSION == 3
 #pragma weak PyModule_Create2 = __spl_fi_PyModule_Create2
 #pragma weak PyState_AddModule = __spl_fi_PyState_AddModule
+#endif
+#if PY_MAJOR_VERSION == 2
+#pragma weak Py_InitModule4_64 = __spl_fi_Py_InitModule4
+#pragma weak Py_InitModule4TraceRefs_64 = __spl_fi_Py_InitModule4
+#endif
 #endif
 
 /*
@@ -437,6 +461,10 @@ extern "C" {
 
 #define __SPLFIX(_NAME, _TYPE) __SPLFIX_EX( __spl_fp_##_NAME, #_NAME, _TYPE ) 
 
+#define __SPL_STRINGIFY(_X) #_X
+
+#define __SPL_TOSTRING(_X) __SPL_STRINGIFY(_X)
+
 namespace streamsx {
   namespace topology {
 
@@ -478,8 +506,13 @@ class SplpySym {
      __SPLFIX(PyImport_Import, __splpy_p_p_fp);
 
 #if __SPLPY_EC_MODULE_OK
+#if PY_MAJOR_VERSION == 3
      __SPLFIX(PyModule_Create2, __splpy_mc2_fp);
      __SPLFIX(PyState_AddModule, __splpy_sam_fp);
+#endif
+#if PY_MAJOR_VERSION == 2
+     __SPLFIX_EX(__spl_fp_Py_InitModule4, __SPL_TOSTRING(Py_InitModule4), __splpy_im4_fp);
+#endif
 #endif
  
      __SPLFIX(PyTuple_New, __splpy_p_s_fp);

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/_streams/_placement.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/_streams/_placement.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017,2018
+from builtins import object,str
 
 class _Placement(object):
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/_streams/_placement.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/_streams/_placement.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017,2018
-from builtins import object,str
+from future.builtins import *
 
 class _Placement(object):
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -89,7 +89,6 @@ This module (`streamsx.ec`) provides access to the execution
 context when Python code is running in a Streams application.
 
 Access is only supported when running:
- * Python 3.5
  * Streams 4.2 or later
 
 This module may be used by Python functions or classes used
@@ -97,6 +96,8 @@ in a `Topology` or decorated SPL operators.
 
 Most functionality is only available when a Python class is
 being invoked in a Streams application.
+
+.. versionchanged:: 1.9 Support for Python 2.7
 
 """
 
@@ -140,7 +141,7 @@ def _check():
             _State._state = _State(False)
 
     if not _State._state._supported:
-        raise NotImplementedError("Access to the execution context requires Python 3.5 and Streams 4.2 or later")
+        raise NotImplementedError("Access to the execution context requires Streams 4.2 or later")
 
 def domain_id():
     """

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -100,7 +100,8 @@ being invoked in a Streams application.
 
 """
 
-from builtins import object,str
+from future.builtins import *
+
 import enum
 import pickle
 import threading

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -100,6 +100,7 @@ being invoked in a Streams application.
 
 """
 
+from builtins import object,str
 import enum
 import pickle
 import threading

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -38,7 +38,7 @@ In addtion `StreamingAnalyticsConnection` extends from :py:class:`StreamsConnect
         Reference documentation for the Streaming Analytics service REST API.
 
 """
-from builtins import object,str
+from future.builtins import *
 
 import os
 import json

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -38,6 +38,7 @@ In addtion `StreamingAnalyticsConnection` extends from :py:class:`StreamsConnect
         Reference documentation for the Streaming Analytics service REST API.
 
 """
+from builtins import object,str
 
 import os
 import json

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -13,7 +13,7 @@ Contains classes representing primitive Streams objects, such as
 :py:class:`Instance`, :py:class:`Job`, :py:class:`PE`, etc.
 
 """
-from builtins import object,str
+from future.builtins import *
 
 import logging
 import requests

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -13,6 +13,7 @@ Contains classes representing primitive Streams objects, such as
 :py:class:`Instance`, :py:class:`Job`, :py:class:`PE`, etc.
 
 """
+from builtins import object,str
 
 import logging
 import requests

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import object,str
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016,2017
 import sys

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/extract.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from builtins import object,str
+from future.builtins import *
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016,2017
 import sys

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/runner.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/runner.py
@@ -3,7 +3,7 @@
 # Copyright IBM Corp. 2017
 
 from __future__ import print_function
-from builtins import object,str
+from future.builtins import *
 
 import sys
 import sysconfig

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/runner.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/runner.py
@@ -3,6 +3,8 @@
 # Copyright IBM Corp. 2017
 
 from __future__ import print_function
+from builtins import object,str
+
 import sys
 import sysconfig
 import inspect

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/op.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/op.py
@@ -116,7 +116,7 @@ For example invoking a SPL `Beacon` operator using an output function to set the
 
 """
 
-from builtins import object,str
+from future.builtins import *
 
 import streamsx.topology.exop as exop
 import streamsx._streams._placement as _placement

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/op.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/op.py
@@ -116,6 +116,8 @@ For example invoking a SPL `Beacon` operator using an output function to set the
 
 """
 
+from builtins import object,str
+
 import streamsx.topology.exop as exop
 import streamsx._streams._placement as _placement
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
@@ -15,7 +15,7 @@
 # b) iterable is a decorated function that returns an iterator
 #
 
-from builtins import object,str
+from future.builtins import *
 
 def _splpy_iter_source(iterable) :
   try:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
@@ -14,6 +14,9 @@
 # a) iterable is a decorated class and is iterable
 # b) iterable is a decorated function that returns an iterator
 #
+
+from builtins import object,str
+
 def _splpy_iter_source(iterable) :
   try:
       it = iter(iterable)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -540,7 +540,7 @@ The list may be empty resulting in no tuples being submitted.
 
 """
 
-from builtins import object,str
+from future.builtins import *
 from enum import Enum
 import functools
 import inspect

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -540,6 +540,7 @@ The list may be empty resulting in no tuples being submitted.
 
 """
 
+from builtins import object,str
 from enum import Enum
 import functools
 import inspect

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/toolkit.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/toolkit.py
@@ -18,7 +18,7 @@ Toolkits shipped with the IBM Streams product under
 must not be added through ``add_toolkit``.
 
 """
-from builtins import object,str
+from future.builtins import *
 
 import os
 import streamsx.topology.topology

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/toolkit.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/toolkit.py
@@ -18,6 +18,7 @@ Toolkits shipped with the IBM Streams product under
 must not be added through ``add_toolkit``.
 
 """
+from builtins import object,str
 
 import os
 import streamsx.topology.topology

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
@@ -13,7 +13,7 @@ using classes from ``streamsx.spl.op`` then any parameters
 must use the SPL type required by the operator.
 
 """
-from builtins import object,str
+from future.builtins import *
 
 import collections
 import datetime

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
@@ -13,6 +13,7 @@ using classes from ``streamsx.spl.op`` then any parameters
 must use the SPL type required by the operator.
 
 """
+from builtins import object,str
 
 import collections
 import datetime

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/st.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/st.py
@@ -46,7 +46,8 @@ def _cancel_job(job_id, force):
 
 def _run_st(args, lines=None):
     args.insert(0, os.path.join(_install, 'bin', 'streamtool'))
-    process = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.DEVNULL)
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    process.stdin.close()
     while True:
         line = process.stdout.readline()
         if len(line) == 0:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/st.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/st.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
+from builtins import object,str
 import subprocess
 import io
 import os

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/st.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/st.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2017
-from builtins import object,str
+from future.builtins import *
+
 import subprocess
 import io
 import os

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -24,7 +24,7 @@ try:
 except (ImportError, NameError):
     # nothing to do here
     pass
-from builtins import object,str
+from future.builtins import *
 
 from streamsx import rest, rest_primitives
 import logging
@@ -138,7 +138,7 @@ class _BaseSubmitter(object):
 
         args = [jvm, '-classpath', cp, submit_class, self.ctxtype, self.fn]
         logger.info("Generating SPL and submitting application.")
-        proc_env = env=self._get_java_env()
+        proc_env = self._get_java_env()
         process = subprocess.Popen(args, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0, env=proc_env)
 
         stderr_thread = threading.Thread(target=_print_process_stderr, args=([process, self]))
@@ -180,7 +180,7 @@ class _BaseSubmitter(object):
 
     def _get_java_env(self):
         "Get the environment to be passed to the Java execution"
-        return dict(os.environ)
+        return os.environ.copy()
 
     def _add_python_info(self):
         # Python information added to deployment

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -24,6 +24,7 @@ try:
 except (ImportError, NameError):
     # nothing to do here
     pass
+from builtins import object,str
 
 from streamsx import rest, rest_primitives
 import logging

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/dependency.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/dependency.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016,2017
+from builtins import object,str
 import os.path
 import sys
 import site

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/dependency.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/dependency.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016,2017
-from builtins import object,str
+from future.builtins import *
+
 import os.path
 import sys
 import site

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/exop.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/exop.py
@@ -2,6 +2,8 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
 
+from builtins import object,str
+
 import streamsx.topology.topology
 import streamsx.topology.schema
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/exop.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/exop.py
@@ -2,7 +2,8 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
 
-from builtins import object,str
+from future.builtins import *
+from past.builtins import basestring
 
 import streamsx.topology.topology
 import streamsx.topology.schema
@@ -51,7 +52,7 @@ class ExtensionOperator(object):
         self.outputs = []
         if schemas is not None:
             stream_name = None
-            if isinstance(schemas, str):
+            if isinstance(schemas, basestring):
                 schemas = (schemas,)
                 stream_name = self._op().name
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/functions.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/functions.py
@@ -3,7 +3,8 @@
 # Copyright IBM Corp. 2015,2017
 
 from __future__ import print_function
-from builtins import object,str
+from future.builtins import *
+
 import sys
 
 # Print function that flushes

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/functions.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/functions.py
@@ -3,6 +3,7 @@
 # Copyright IBM Corp. 2015,2017
 
 from __future__ import print_function
+from builtins import object,str
 import sys
 
 # Print function that flushes

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -3,7 +3,7 @@
 # Copyright IBM Corp. 2015,2016
 
 from __future__ import unicode_literals
-from builtins import str
+from builtins import object, str
 
 import sys
 import uuid

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -3,7 +3,7 @@
 # Copyright IBM Corp. 2015,2016
 
 from __future__ import unicode_literals
-from builtins import object, str
+from future.builtins import *
 
 import sys
 import uuid

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/mqtt.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/mqtt.py
@@ -9,6 +9,7 @@ Additional information at http://mqtt.org and
 http://ibmstreams.github.io/streamsx.messaging
 """
 
+from builtins import object,str
 from streamsx.topology.topology import *
 from streamsx.topology import schema
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/mqtt.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/mqtt.py
@@ -9,7 +9,8 @@ Additional information at http://mqtt.org and
 http://ibmstreams.github.io/streamsx.messaging
 """
 
-from builtins import object,str
+from future.builtins import *
+
 from streamsx.topology.topology import *
 from streamsx.topology import schema
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/param.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/param.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
-from builtins import object,str
+from future.builtins import *
 
 class OpParam(object) :
     """generic operator parameter"""

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/param.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/param.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
+from builtins import object,str
 
 class OpParam(object) :
     """generic operator parameter"""

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
 from __future__ import unicode_literals
-from builtins import object, str
+from future.builtins import *
 
 import os
 import sys

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -2,7 +2,7 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
 from __future__ import unicode_literals
-from builtins import str
+from builtins import object, str
 
 import os
 import sys

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -16,7 +16,7 @@ The supported types are defined by IBM Streams Streams Processing Language (SPL)
 """
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
-from builtins import object,list
+from builtins import object,list,str
 
 import collections
 import enum

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -24,7 +24,7 @@ _spl_dict = dict
 _spl_object = object
 
 from future.builtins import *
-from past.builtins import basestring
+from past.builtins import basestring, unicode
 
 import collections
 import enum

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -16,7 +16,7 @@ The supported types are defined by IBM Streams Streams Processing Language (SPL)
 """
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
-from builtins import *
+from builtins import object,list
 
 import collections
 import enum

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/schema.py
@@ -16,7 +16,8 @@ The supported types are defined by IBM Streams Streams Processing Language (SPL)
 """
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
-from builtins import object,list,str
+from future.builtins import *
+from past.builtins import basestring
 
 import collections
 import enum
@@ -42,7 +43,7 @@ def is_common(schema):
         return schema.schema() in _SCHEMA_COMMON
     if isinstance(schema, CommonSchema):
         return True
-    if isinstance(schema, str):
+    if isinstance(schema, basestring):
         return is_common(StreamSchema(schema))
     return False
 
@@ -356,7 +357,7 @@ class StreamSchema(object) :
     def _make_named_tuple(self, name):
         if self.__spl_type:
             return tuple
-        if name == True:
+        if name is True:
             name = 'StreamTuple'
         fields = _attribute_names(self._types)
         nt = collections.namedtuple(name, fields, rename=True)
@@ -417,7 +418,7 @@ class StreamSchema(object) :
         if not named:
             return self._copy(tuple)
 
-        if named == True or isinstance(named, str):
+        if named == True or isinstance(named, basestring):
             return self._copy(self._make_named_tuple(name=named))
 
         return self._copy(tuple)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -80,7 +80,10 @@ between tuples are within the timeout period the test remains running until ten 
 .. note:: The submitted job (application under test) has additional elements (streams & operators) inserted to implement the conditions. These are visible through various APIs including the Streams console raw graph view. Such elements are put into the `Tester` category.
 
 .. warning::
-    Python 3.5 and Streaming Analytics service or IBM Streams 4.2 or later is required when using `Tester`.
+    Streaming Analytics service or IBM Streams 4.2 or later is required when using `Tester`.
+
+
+.. versionchanged:: 1.9 - Python 2.7 supported (except with Streaming Analytics service).
 
 """
 from __future__ import unicode_literals
@@ -98,6 +101,7 @@ from streamsx.rest import StreamingAnalyticsConnection
 from streamsx.topology.context import ConfigParams
 import time
 import json
+import sys
 
 import streamsx.topology.tester_runtime as sttrt
 
@@ -216,8 +220,13 @@ class Tester(object):
             service_name(str): Name of Streaming Analytics service to use. Must exist as an
                 entry in the VCAP services. Defaults to value of STREAMING_ANALYTICS_SERVICE_NAME environment variable.
 
+        If run with Python 2 the test is skipped, only Python 3.5
+        is supported with Streaming Analytics service.
+
         Returns: None
         """
+        if sys.version_info.major == 2:
+            raise unittest.SkipTest('Skipped due to running with Python 2')
         if not 'VCAP_SERVICES' in os.environ:
             raise unittest.SkipTest("Skipped due to VCAP_SERVICES environment variable not set")
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -87,7 +87,7 @@ between tuples are within the timeout period the test remains running until ten 
 
 """
 from __future__ import unicode_literals
-from builtins import str
+from builtins import object, str
 
 import streamsx.ec as ec
 import streamsx.topology.context as stc

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -87,7 +87,7 @@ between tuples are within the timeout period the test remains running until ten 
 
 """
 from __future__ import unicode_literals
-from builtins import object, str
+from future.builtins import *
 
 import streamsx.ec as ec
 import streamsx.topology.context as stc

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester_runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester_runtime.py
@@ -20,6 +20,7 @@ the runtime execution code from the test definition module
 
 """
 
+from builtins import object,str
 import streamsx.ec as ec
 import streamsx.topology.context as stc
 import os

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester_runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester_runtime.py
@@ -20,7 +20,8 @@ the runtime execution code from the test definition module
 
 """
 
-from builtins import object,str
+from future.builtins import *
+
 import streamsx.ec as ec
 import streamsx.topology.context as stc
 import os

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -171,7 +171,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import object, str
+from future.builtins import *
 try:
     from future import standard_library
     standard_library.install_aliases()

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -171,7 +171,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import str
+from builtins import object, str
 try:
     from future import standard_library
     standard_library.install_aliases()

--- a/test/python/rest/test_rest_bluemix.py
+++ b/test/python/rest/test_rest_bluemix.py
@@ -26,7 +26,6 @@ instance_response_keys = [
 ]
 
 
-@unittest.skipIf(not test_vers.tester_supported() , "Tester not supported")
 class TestRestFeaturesBluemix(CommonTests):
     @classmethod
     def setUpClass(cls):

--- a/test/python/rest/test_vers.py
+++ b/test/python/rest/test_vers.py
@@ -15,7 +15,5 @@ def get_version():
     return vers['Version']
 
 def tester_supported():
-    if sys.version_info.major == 2:
-        return False
     v = get_version()
     return not v.startswith('4.0.') and not v.startswith('4.1.')

--- a/test/python/topology/test2.py
+++ b/test/python/topology/test2.py
@@ -200,8 +200,18 @@ class TestTopologyMethodsNew(unittest.TestCase):
 
     def test_TopologySourceItertools(self):
         topo = Topology('test_TopologySourceItertools')
-        hw = topo.source(itertools.repeat(9, 3))
-        hw = hw.filter(test_functions.check_asserts_disabled)
+        if sys.version_info.major == 2:
+            # Iterators not serializable in 2.7
+            hw = topo.source(lambda : itertools.repeat(9, 3))
+        else:
+            hw = topo.source(itertools.repeat(9, 3))
+
+        if sys.version_info.major == 2:
+            # Disabling assertions not supported on Python 2.7
+            # See splpy_setup.h
+            pass
+        else:
+            hw = hw.filter(test_functions.check_asserts_disabled)
         tester = Tester(topo)
         tester.contents(hw, [9, 9, 9])
         tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/topology/test2_python_window.py
+++ b/test/python/topology/test2_python_window.py
@@ -54,6 +54,8 @@ class TimeCounter(object):
         self.count += 1
         time.sleep(self.period)
         return to_return
+    def next(self):
+        return self.__next__()
 
 class TriggerDiff(object):
     """Given any input, returns the timespan (in seconds) between now
@@ -97,7 +99,8 @@ class TestPythonWindowing(unittest.TestCase):
     def test_BasicCountCountWindow(self):
         topo = Topology()
         s = topo.source([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
-        s = s.last(10).trigger(2).aggregate(lambda x: sum(x)/len(x))
+        # Need a float cast to make the value consistent with Python 2/3
+        s = s.last(10).trigger(2).aggregate(lambda x: float(sum(x))/float(len(x)))
 
         tester = Tester(topo)
         tester.contents(s, [1.5,2.5,3.5,4.5,5.5,7.5,9.5])

--- a/test/python/topology/test_functions.py
+++ b/test/python/topology/test_functions.py
@@ -25,7 +25,7 @@ _hwcountU = 0
 # because sc defaults to optimized
 # compilation
 def check_asserts_disabled(tuple):
-    assert False
+    assert False, "Expect assertions to be disabled"
     return True
     
 

--- a/test/python/topology/test_schemas.py
+++ b/test/python/topology/test_schemas.py
@@ -1,10 +1,12 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2016
+from past.builtins import unicode
 import unittest
 import random
 import collections
 import sys
 import threading
+
 
 from streamsx.topology.topology import Topology, Routing
 from streamsx.topology.schema import _SchemaParser

--- a/test/python/topology/test_schemas.py
+++ b/test/python/topology/test_schemas.py
@@ -194,7 +194,7 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(dict, sd2.style)
 
         self.assertEqual(object, _sch.CommonSchema.Python.value.style)
-        self.assertEqual(str, _sch.CommonSchema.String.value.style)
+        self.assertEqual(unicode if sys.version_info.major == 2 else str, _sch.CommonSchema.String.value.style)
         self.assertEqual(dict, _sch.CommonSchema.Json.value.style)
 
         snt = s.as_tuple(named='Alert')

--- a/test/python/topology/test_vers.py
+++ b/test/python/topology/test_vers.py
@@ -15,7 +15,5 @@ def get_version():
     return vers['Version']
 
 def tester_supported():
-    if sys.version_info.major == 2:
-        return False
     v = get_version()
     return not v.startswith('4.0.') and not v.startswith('4.1.')


### PR DESCRIPTION
Passes all tests except one in `test/python/topology` when running in standalone.

Failing test is that `StreamSchema.style` returns a future `dict` rather than `dict`. It should return `dict` since the Python object used to represent a stream tuple is a raw `dict` as it is created using the C api.

Initial set of work for #1442 
