### PR TITLE
Create PortProperties interface, and add setParallel to TStream.

### DIFF
--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1055,7 +1055,9 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * Sets the current stream as the start of a parallel region.
      * 
      * @param width The degree of parallelism.
-     * @return
+     * @see #parallel(int)
+     * @see #parallel(Supplier, Routing)
+     * @see #parallel(Supplier, Function)
      */
     void setParallel(Supplier<Integer> width);
     

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1059,7 +1059,7 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * @see #parallel(Supplier, Routing)
      * @see #parallel(Supplier, Function)
      */
-    void setParallel(Supplier<Integer> width);
+    TStream<T> setParallel(Supplier<Integer> width);
     
     /**
      * Ends a parallel region by merging the channels into a single stream.

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1058,6 +1058,7 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * @see #parallel(int)
      * @see #parallel(Supplier, Routing)
      * @see #parallel(Supplier, Function)
+     * @since v1.9
      */
     TStream<T> setParallel(Supplier<Integer> width);
     

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -1052,6 +1052,14 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
     TStream<T> parallel(Supplier<Integer> width, Function<T,?> keyer);
     
     /**
+     * Sets the current stream as the start of a parallel region.
+     * 
+     * @param width The degree of parallelism.
+     * @return
+     */
+    void setParallel(Supplier<Integer> width);
+    
+    /**
      * Ends a parallel region by merging the channels into a single stream.
      * 
      * @return A stream for which subsequent transformations are no longer parallelized.

--- a/java/src/com/ibm/streamsx/topology/builder/BInput.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BInput.java
@@ -4,7 +4,7 @@
  */
 package com.ibm.streamsx.topology.builder;
 
-public abstract class BInput extends BJSONObject {
+public class BInput extends BJSONObject {
 
     private final GraphBuilder builder;
 

--- a/java/src/com/ibm/streamsx/topology/builder/BInput.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BInput.java
@@ -4,7 +4,7 @@
  */
 package com.ibm.streamsx.topology.builder;
 
-public class BInput extends BJSONObject {
+public abstract class BInput extends BJSONObject {
 
     private final GraphBuilder builder;
 
@@ -15,4 +15,6 @@ public class BInput extends BJSONObject {
     public GraphBuilder builder() {
         return builder;
     }
+    
+    public abstract BOperator operator();
 }

--- a/java/src/com/ibm/streamsx/topology/builder/BInput.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BInput.java
@@ -15,6 +15,4 @@ public abstract class BInput extends BJSONObject {
     public GraphBuilder builder() {
         return builder;
     }
-    
-    public abstract BOperator operator();
 }

--- a/java/src/com/ibm/streamsx/topology/builder/BOutput.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOutput.java
@@ -10,5 +10,10 @@ public abstract class BOutput extends BJSONObject {
 
     public abstract void connectTo(BInputPort port);
     
+    /**
+     * Get the operator to which this output port is attached.
+     * @since v1.9
+     * @return The operator to which this output port is attached.
+     */
     public abstract BOperator operator();
 }

--- a/java/src/com/ibm/streamsx/topology/builder/BOutput.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOutput.java
@@ -9,4 +9,6 @@ public abstract class BOutput extends BJSONObject {
     public abstract String _type();
 
     public abstract void connectTo(BInputPort port);
+    
+    public abstract BOperator operator();
 }

--- a/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
+++ b/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.function.Consumer;
 import com.ibm.streamsx.topology.function.Supplier;
+import com.ibm.streamsx.topology.generator.port.PortProperties;
 import com.ibm.streamsx.topology.generator.spl.GraphUtilities;
 import com.ibm.streamsx.topology.generator.spl.GraphUtilities.Direction;
 import com.ibm.streamsx.topology.generator.spl.GraphUtilities.VisitController;
@@ -177,10 +178,10 @@ public class GraphBuilder extends BJSONObject {
     public BOutput parallel(BOutput parallelize, Supplier<Integer> width) {
         BOutput parallelOutput = addPassThroughMarker(parallelize, BVirtualMarker.PARALLEL, true);
         if (width.get() != null)
-            parallelOutput._json().addProperty("width", width.get());
+            parallelOutput._json().addProperty(PortProperties.WIDTH, width.get());
         else {
             SubmissionParameter<?> spw = (SubmissionParameter<?>) width;
-            parallelOutput._json().add("width", SubmissionParameterFactory.asJSON(spw));
+            parallelOutput._json().add(PortProperties.WIDTH, SubmissionParameterFactory.asJSON(spw));
         }
         return parallelOutput;
     }

--- a/java/src/com/ibm/streamsx/topology/generator/operator/OpProperties.java
+++ b/java/src/com/ibm/streamsx/topology/generator/operator/OpProperties.java
@@ -93,6 +93,17 @@ public interface OpProperties {
      * Attribute for start of a consistent region.
      */
     String CONSISTENT = "consistent";
+    
+	/** 
+	 * Top-level boolean parameter indicating whether the operator is the start of a 
+	 * parallel region.
+	 */
+	String PARALLEL = "parallel";
+	
+	/**
+	 * The width of the parallel region, if the operator is the start of a parallel region.
+	 */
+	String WIDTH = "width";
 
 
 }

--- a/java/src/com/ibm/streamsx/topology/generator/port/PortProperties.java
+++ b/java/src/com/ibm/streamsx/topology/generator/port/PortProperties.java
@@ -1,0 +1,33 @@
+package com.ibm.streamsx.topology.generator.port;
+
+public interface PortProperties {
+	/**
+	 * The width of the parallel region, if the port is the start of a parallel region.
+	 */
+	String WIDTH = "width";
+	
+	/**
+	 * Boolean top-level parameter indicating whether the port should broadcast tuples
+	 * to all channels in a parallel region, if the port is the start of a parallel
+	 * region.	
+	 */
+	String BROADCAST = "broadcast";
+	
+	/** 
+	 * Top-level boolean parameter indicating whether the port is the start of a 
+	 * parallel region.
+	 */
+	String PARALLEL = "parallel";
+	
+	/**
+	 * Top-level boolean parameter indicating that the downstream parallel region
+	 * is to be partitioned on the tuples of this port.
+	 */
+	String PARTITIONED = "partitioned";
+	
+	/**
+	 * Top-level parameter indicating a list of keys on which the downstream
+	 * parallel region is to be partitioned.
+	 */
+	String PARTITION_KEYS = "partitionedKeys";
+}

--- a/java/src/com/ibm/streamsx/topology/generator/port/PortProperties.java
+++ b/java/src/com/ibm/streamsx/topology/generator/port/PortProperties.java
@@ -1,10 +1,12 @@
 package com.ibm.streamsx.topology.generator.port;
 
+import com.ibm.streamsx.topology.generator.operator.OpProperties;
+
 public interface PortProperties {
 	/**
 	 * The width of the parallel region, if the port is the start of a parallel region.
 	 */
-	String WIDTH = "width";
+	String WIDTH = OpProperties.WIDTH;
 	
 	/**
 	 * Boolean top-level parameter indicating whether the port should broadcast tuples
@@ -12,7 +14,6 @@ public interface PortProperties {
 	 * region.	
 	 */
 	String BROADCAST = "broadcast";
-
 	
 	/**
 	 * Top-level boolean parameter indicating that the downstream parallel region

--- a/java/src/com/ibm/streamsx/topology/generator/port/PortProperties.java
+++ b/java/src/com/ibm/streamsx/topology/generator/port/PortProperties.java
@@ -12,12 +12,7 @@ public interface PortProperties {
 	 * region.	
 	 */
 	String BROADCAST = "broadcast";
-	
-	/** 
-	 * Top-level boolean parameter indicating whether the port is the start of a 
-	 * parallel region.
-	 */
-	String PARALLEL = "parallel";
+
 	
 	/**
 	 * Top-level boolean parameter indicating that the downstream parallel region

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -543,9 +543,10 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     }
     
     @Override
-    public void setParallel(Supplier<Integer> width){
+    public TStream<T> setParallel(Supplier<Integer> width){
     	output._json().addProperty(PortProperties.PARTITIONED, true);
     	output._json().addProperty(PortProperties.WIDTH, width.get());
+    	return this;
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -544,8 +544,8 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     
     @Override
     public TStream<T> setParallel(Supplier<Integer> width){
-    	output._json().addProperty(PortProperties.PARTITIONED, true);
-    	output._json().addProperty(PortProperties.WIDTH, width.get());
+    	output.operator().addConfig(OpProperties.PARALLEL, true);
+    	output.operator().addConfig(OpProperties.WIDTH, width.get());
     	return this;
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -544,9 +544,12 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     
     @Override
     public TStream<T> setParallel(Supplier<Integer> width){
+    	BOutputPort output = (BOutputPort)this.output;
     	output.operator().addConfig(OpProperties.PARALLEL, true);
     	output.operator().addConfig(OpProperties.WIDTH, width.get());
-    	return this;
+    	
+    	throw new UnsupportedOperationException("setParallel is not implemented.");
+    	//return this;
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -54,6 +54,7 @@ import com.ibm.streamsx.topology.function.Supplier;
 import com.ibm.streamsx.topology.function.ToIntFunction;
 import com.ibm.streamsx.topology.function.UnaryOperator;
 import com.ibm.streamsx.topology.generator.operator.OpProperties;
+import com.ibm.streamsx.topology.generator.port.PortProperties;
 import com.ibm.streamsx.topology.internal.functional.ObjectSchemas;
 import com.ibm.streamsx.topology.internal.functional.SubmissionParameter;
 import com.ibm.streamsx.topology.internal.gson.JSON4JBridge;
@@ -478,7 +479,7 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     private TStream<T> _parallel(Supplier<Integer> width, Function<T,?> keyer) {
 
         if (width == null)
-            throw new IllegalArgumentException("width");
+            throw new IllegalArgumentException(PortProperties.WIDTH);
         Integer widthVal;
         if (width.get() != null)
             widthVal = width.get();
@@ -511,10 +512,10 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
                 
         BOutput parallelOutput = builder().parallel(toBeParallelized, width);
         if (isPartitioned) {
-            parallelOutput._json().addProperty("partitioned", true);
+            parallelOutput._json().addProperty(PortProperties.PARTITIONED, true);
             JsonArray partitionKeys = new JsonArray();
             partitionKeys.add(new JsonPrimitive("__spl_hash"));
-            parallelOutput._json().add("partitionedKeys", partitionKeys);
+            parallelOutput._json().add(PortProperties.PARTITION_KEYS, partitionKeys);
             // Add hash remover
             StreamImpl<T> parallelStream = new StreamImpl<T>(this,
                     parallelOutput, getTupleType());
@@ -539,6 +540,12 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     @Override
     public TStream<T> parallel(Supplier<Integer> width) {
         return parallel(width, TStream.Routing.ROUND_ROBIN);
+    }
+    
+    @Override
+    public void setParallel(Supplier<Integer> width){
+    	output._json().addProperty(PortProperties.PARTITIONED, true);
+    	output._json().addProperty(PortProperties.WIDTH, width.get());
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/spl/SPLStream.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLStream.java
@@ -156,6 +156,12 @@ public interface SPLStream extends TStream<Tuple>, SPLInput {
      * {@inheritDoc}
      */
     @Override
+    SPLStream setParallel(Supplier<Integer> width);
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     SPLStream endParallel();
     
     /**

--- a/java/src/com/ibm/streamsx/topology/spl/SPLStreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/spl/SPLStreamImpl.java
@@ -138,6 +138,11 @@ class SPLStreamImpl extends StreamImpl<Tuple> implements SPLStream {
         return asSPL(super.parallel(width));
     }
     
+    @Override 
+    public SPLStream setParallel(Supplier<Integer> width){
+    	return asSPL(super.setParallel(width));
+    }
+    
     @Override
     public SPLStream parallel(Supplier<Integer> width,
             com.ibm.streamsx.topology.TStream.Routing routing) {


### PR DESCRIPTION
The setParallel() method on TStream adds the `width` and `parallel=true` properties to the output port of the invoked TStream.

To better organize and keep track of port properties, the `PortProperties` was created and minor refactoring was done in `TStream.parallel`.