### PR TITLE
Foundation work to allow optional skipping of items in toolkit for build archive.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/context.py
@@ -92,6 +92,7 @@ class _BaseSubmitter(object):
             # Make copy of config to avoid modifying
             # the callers config
             self.config.update(config)
+        self.config['contextType'] = str(self.ctxtype)
         self.graph = graph
         self.fn = None
         self.results_file = None
@@ -187,6 +188,8 @@ class _BaseSubmitter(object):
         pi = {}
         pi["prefix"] = sys.exec_prefix
         pi["version"] = sys.version
+        pi['major'] = sys.version_info.major
+        pi['minor'] = sys.version_info.minor
         self.config["python"] = pi
 
     def _create_job_config_overlays(self):

--- a/java/src/com/ibm/streamsx/topology/internal/context/JSONStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/JSONStreamsContext.java
@@ -116,6 +116,7 @@ public abstract class JSONStreamsContext<T> extends StreamsContextImpl<T> {
         
         JsonObject deploy = new JsonObject();        
         addConfigToDeploy(deploy, entity.config);
+        deploy.addProperty("contextType", this.getType().name());
         
         submission.add(DEPLOY,deploy);
         submission.add(SUBMISSION_GRAPH, entity.app.builder()._complete());

--- a/test/python/topology/test_build_archive.py
+++ b/test/python/topology/test_build_archive.py
@@ -5,6 +5,9 @@ from __future__ import print_function
 import unittest
 import sys
 import os
+import shutil
+import tempfile
+import zipfile
 
 import test_functions
 
@@ -20,12 +23,50 @@ class TestBuildArchive(unittest.TestCase):
         if self._si is not None:
             os.unsetenv('STREAMS_INSTALL')
 
+        self.archive = None
+        self.tmp = None
+
     def test_build_archive(self):
         topo = Topology("test_build_archive")
         hw = topo.source((1,2,3))
         hw.print()
-        streamsx.topology.context.submit("BUILD_ARCHIVE", topo)
+        sr = streamsx.topology.context.submit("BUILD_ARCHIVE", topo)
+        self.assertIn('archivePath', sr)
+        self.archive = sr['archivePath']
+        self._check_archive()
+
+    def _check_archive(self):
+        self.assertTrue(os.path.exists(self.archive))
+
+        self.tmp = tempfile.mkdtemp()
+        self.assertTrue(self.archive.endswith('.zip'))
+        with zipfile.ZipFile(self.archive, 'r') as zip_ref:
+            zip_ref.extractall(self.tmp)
+
+        # Verify expected build files
+        for fn in ['Makefile', 'main_composite.txt', 'manifest_tk.txt']:
+            self.assertTrue(os.path.isfile(os.path.join(self.tmp, fn)))
+
+        # Verify topology toolkit
+        topo_tk = os.path.join(self.tmp, 'com.ibm.streamsx.topology')
+        self.assertTrue(os.path.isdir(topo_tk))
+
+        # Verify each toolkit
+        with open(os.path.join(self.tmp, 'manifest_tk.txt')) as fp:
+            for tkn in  fp.read().splitlines():
+                tkd = os.path.join(self.tmp, tkn)
+                for nd in ['doc', 'output', 'samples', 'toolkit.xml']:
+                    self.assertFalse(os.path.exists(os.path.join(tkd, nd)))
+                for root, dirs, files in os.walk(tkd):
+                    for fn in files:
+                        self.assertFalse(fn.endswith('.pyi'))
+                        self.assertFalse(fn.endswith('.pyc'))
 
     def tearDown(self):
         if self._si is not None:
             os.environ['STREAMS_INSTALL'] = self._si
+        if self.archive:
+            os.remove(self.archive);
+        if self.tmp:
+            shutil.rmtree(self.tmp);
+


### PR DESCRIPTION
Mainly foundational work for #1476

- Reworked toolkit file exclusion to be consistent across files and directories.
- Pass submission object (to allow access to `deploy` information) down into the toolkit contexts
- Add Python version major/minor to `deploy`
- Add intended submission context to `deploy`
- Exclude `*.pyi` files.
