### PR TITLE
Fix Initializable protocol when running with checkpointing

### DIFF
--- a/java/execute/src/com/ibm/streamsx/topology/internal/functional/FunctionalHandler.java
+++ b/java/execute/src/com/ibm/streamsx/topology/internal/functional/FunctionalHandler.java
@@ -4,8 +4,6 @@
  */
 package com.ibm.streamsx.topology.internal.functional;
 
-import static com.ibm.streamsx.topology.internal.functional.FunctionalHelper.getLogicObject;
-
 import java.io.IOException;
 
 import com.ibm.streams.operator.logging.TraceLevel;
@@ -16,20 +14,13 @@ import com.ibm.streamsx.topology.internal.logic.WrapperFunction;
 public abstract class FunctionalHandler<T> {
 
     private final FunctionContext context;
-    private final String serializedLogic;
     
-    public FunctionalHandler(FunctionContext context, String serializedLogic) throws Exception {
+    public FunctionalHandler(FunctionContext context) throws Exception {
         this.context = context;
-        this.serializedLogic = serializedLogic;
     }
     
     public FunctionContext getFunctionContext() {
         return context;
-    }
-    
-    public T initialLogic() throws Exception {
-        T initialLogic = getLogicObject(serializedLogic);
-        return initialLogic;
     }
        
     public abstract T getLogic();
@@ -38,11 +29,11 @@ public abstract class FunctionalHandler<T> {
         closeLogic(getLogic());
     }
     
-    protected void initializeLogic() throws Exception {
+    public void initializeLogic() throws Exception {
         initializeLogic(getFunctionContext(), getLogic());
     }
         
-    static void initializeLogic(FunctionContext context, Object logicInstance) throws Exception {
+    private static void initializeLogic(FunctionContext context, Object logicInstance) throws Exception {
         for (;;) {
             if (logicInstance instanceof Initializable) {
                 ((Initializable) logicInstance).initialize(context);
@@ -59,7 +50,7 @@ public abstract class FunctionalHandler<T> {
      * If logicInstance implements AutoCloseable
      * then shut it down by calling it close() method.
      */
-    static void closeLogic(Object logicInstance) {
+    public static void closeLogic(Object logicInstance) {
         for (;;) {
             if (logicInstance instanceof AutoCloseable) {
                 try {

--- a/java/execute/src/com/ibm/streamsx/topology/internal/functional/StatelessFunctionalHandler.java
+++ b/java/execute/src/com/ibm/streamsx/topology/internal/functional/StatelessFunctionalHandler.java
@@ -6,16 +6,24 @@ package com.ibm.streamsx.topology.internal.functional;
 
 import com.ibm.streamsx.topology.function.FunctionContext;
 
+/**
+ * Functional logic handler used when 
+ * the logic is immutable
+ * or checkpointing/consistent region is not configured.
+ * 
+ * The logic's initialization occurs at operator initialization time.
+ */
 public final class StatelessFunctionalHandler<T> extends FunctionalHandler<T> {
-
-    private final T logic;
     
-    public StatelessFunctionalHandler(FunctionContext context, String serializedLogic) throws Exception {
-        super(context, serializedLogic);
-        logic = initialLogic();
+    private final T logic;
+   
+    public StatelessFunctionalHandler(FunctionContext context, T initialLogic) throws Exception {
+        super(context);
+        this.logic = initialLogic;
         initializeLogic();
     }
-       
+    
+    @Override
     public T getLogic() {
         return logic;
     }

--- a/java/runtime/src/com/ibm/streamsx/topology/function/Initializable.java
+++ b/java/runtime/src/com/ibm/streamsx/topology/function/Initializable.java
@@ -1,15 +1,40 @@
 /*
 # Licensed Materials - Property of IBM
-# Copyright IBM Corp. 2016  
+# Copyright IBM Corp. 2016, 2018
  */
 package com.ibm.streamsx.topology.function;
 
 /**
  * Optional interface that a function can implement
  * to perform initialization.
+ * <P>
+ * {@link #initialize(FunctionContext)} is called prior
+ * to the function being called to produce or process
+ * stream tuples. This will be when:
+ * <UL>
+ * <LI>the processing element (PE) containing the function starts.</LI>
+ * <LI>the PE restarts after a failure or manual request.</LI>
+ * <LI>the function is restored from a checkpoint.</LI>
+ * </UL>
+ * </P>
+ * <P>
+ * Initialization is used open resources that
+ * cannot be part of the function's serialized state, such
+ * as files or connections to external systems.
+ * Custom metrics can also be created using
+ * {@link FunctionContext#createCustomMetric(String, String, String, java.util.function.LongSupplier) createCustomMetric()}.
+ * <BR>
+ * A function that implements this interface may also
+ * implement {@code java.lang.AutoCloseable} to close
+ * any resources opened in {@link #initialize(FunctionContext)}.
+ * </P>
  */
 public interface Initializable {
     
+    /**
+     * Initialize this function.
+     * @param functionContext Context the function is executing in.
+     * @throws Exception Exception initializing function.
+     */
     void initialize(FunctionContext functionContext) throws Exception;
-
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/state/CheckpointTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/state/CheckpointTest.java
@@ -1,6 +1,6 @@
 /*
 # Licensed Materials - Property of IBM
-# Copyright IBM Corp. 2015  
+# Copyright IBM Corp. 2015, 2018 
  */
 package com.ibm.streamsx.topology.test.state;
 
@@ -32,6 +32,16 @@ public class CheckpointTest extends TestTopology {
     public void checkIsDistributed() {
         assumeTrue(SC_OK);
         assumeTrue(getTesterType() == StreamsContext.Type.DISTRIBUTED_TESTER);
+    }
+    
+    @Test
+    public void testInitializable() throws Exception {
+        final Topology topology = new Topology();
+        TStream<Long> s = StatefulApp.createApp(topology, true, true);
+        
+        Condition<Long> atLeast = topology.getTester().atLeastTupleCount(s, 50*50);
+        
+        complete(topology.getTester(), atLeast, 120, TimeUnit.SECONDS);
     }
     
     @Test

--- a/test/java/src/com/ibm/streamsx/topology/test/state/StatefulApp.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/state/StatefulApp.java
@@ -1,0 +1,173 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2018 
+ */
+package com.ibm.streamsx.topology.test.state;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.context.StreamsContext;
+import com.ibm.streamsx.topology.context.StreamsContext.Type;
+import com.ibm.streamsx.topology.context.StreamsContextFactory;
+import com.ibm.streamsx.topology.function.Consumer;
+import com.ibm.streamsx.topology.function.Function;
+import com.ibm.streamsx.topology.function.FunctionContext;
+import com.ibm.streamsx.topology.function.Initializable;
+import com.ibm.streamsx.topology.function.Predicate;
+import com.ibm.streamsx.topology.function.Supplier;
+
+/**
+ * Testing stateful app that uses checkpointing.
+ * 
+ * As well as being used as a test it can be launched manually
+ * using this class as the Java main class.
+ *
+ */
+public class StatefulApp {
+
+    public static void main(String[] args) throws InterruptedException, ExecutionException, Exception {
+        
+        String contextType = Type.DISTRIBUTED.name();
+        
+        if (args.length == 1)
+            contextType = args[0];
+        
+        Topology topology = new Topology();
+        
+        createApp(topology, false, true);
+        
+        Map<String,Object> config = new HashMap<>();
+
+        @SuppressWarnings("unchecked")
+        StreamsContext<BigInteger> context =
+             (StreamsContext<BigInteger>) StreamsContextFactory.getStreamsContext(contextType);
+        
+        BigInteger jobId = context.submit(topology, config).get();
+
+        System.out.println("Submitted job with jobId=" + jobId);
+    }
+    
+    
+    public static TStream<Long> createApp(Topology topology, boolean checkpoint, boolean fail) { 
+
+        if (checkpoint)
+            topology.checkpointPeriod(5, TimeUnit.SECONDS);
+        
+        TStream<Long> s = topology.periodicSource(new Stateful.Counter(fail), 21, TimeUnit.MILLISECONDS);
+        s = s.isolate().filter(new Stateful.Filter(fail));
+        s = s.isolate().map(new Stateful.Map(fail));
+        s.isolate().forEach(new Stateful.ForEach(fail));
+        
+        return s;
+    }
+    
+    static abstract class Stateful implements Initializable, Serializable {
+        private static final long serialVersionUID = 1L;
+        
+        private final AtomicLong start = new AtomicLong();
+        private final AtomicLong restart = new AtomicLong();
+        private final AtomicLong sequence = new AtomicLong();
+        
+        private final boolean fail;
+        private final int failWhen;
+        private transient FunctionContext functionContext;
+        
+        Stateful(boolean fail) {
+            this.fail = fail;
+            failWhen = fail && allowFailWhen() ? (5*50) + (int) (((double) (20*50)) * Math.random()) : -1;
+        }
+        
+        boolean allowFailWhen() {
+            return true;
+        }
+        
+        @Override
+        public void initialize(FunctionContext functionContext) throws Exception {
+            this.functionContext = functionContext;
+            
+            if (fail && functionContext.getContainer().getRelaunchCount() == 0)
+                throw new Exception("Injected initial Test failure" + this.getClass().getName());
+                            
+            final long now = System.currentTimeMillis();
+            if (start.get() == 0)
+                start.set(now);
+            restart.set(now);
+            
+            functionContext.createCustomMetric("start", "Job start time", "time", start::get);
+            functionContext.createCustomMetric("restart", "PE restart time", "time", restart::get);
+            functionContext.createCustomMetric("sequence", "", "counter", sequence::get);
+            functionContext.createCustomMetric("fail_at", "", "counter", () -> failWhen);
+        }
+        
+        long bump() {
+            if (fail && sequence.get() == failWhen) {
+                if (functionContext.getContainer().getRelaunchCount() == 1)
+                    throw new RuntimeException("Injected Test failure@" + failWhen + " : "+ this.getClass().getName());                
+            }
+            return sequence.getAndIncrement();
+        }
+        
+        static class Counter extends Stateful implements Supplier<Long> {
+            private static final long serialVersionUID = 1L;
+            
+            Counter(boolean fail) {
+                super(fail);
+            }
+            
+            boolean allowFailWhen() {
+                return false;
+            }         
+            
+            @Override
+            public Long get() {
+                return bump();
+            }
+        }
+        
+        static class Filter extends Stateful implements Predicate<Long> {
+            private static final long serialVersionUID = 1L;
+            Filter(boolean fail) {
+                super(fail);
+            }
+            @Override
+            public boolean test(Long tuple) {
+                bump();
+                return true;
+            }           
+        }
+        
+        static class Map extends Stateful implements Function<Long, Long> {
+            private static final long serialVersionUID = 1L;
+            
+            Map(boolean fail) {
+                super(fail);
+            }
+
+            @Override
+            public Long apply(Long v) {
+                bump();
+                return v;
+            }        
+        }
+        static class ForEach extends Stateful implements Consumer<Long> {
+            private static final long serialVersionUID = 1L;
+            
+            ForEach(boolean fail) {
+                super(fail);
+            }
+
+            @Override
+            public void accept(Long v) {
+                bump();
+            }      
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1491 

Ensures that `initialize` is called once with the correct logic (either the initial version or one deserialized from a checkpoint) after a PE restart.