### PR TITLE
Use V1/Basic when given a mixed credentials object

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -1321,7 +1321,7 @@ class StreamingAnalyticsService(object):
         # Delegators are required because we need to keep StreamingAnalyticsService
         # around for backwards compatibility, yet it also needs to work with basic
         # and IAM authentication.
-        if 'v2_rest_url' in credentials and 'username' not in credentials and 'password' not in credentials:
+        if 'v2_rest_url' in credentials and 'userid' not in credentials and 'password' not in credentials:
             self._delegator = _StreamingAnalyticsServiceV2Delegator(rest_client, credentials)
         else:
             self._delegator = _StreamingAnalyticsServiceV1Delegator(rest_client, credentials)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -1321,7 +1321,7 @@ class StreamingAnalyticsService(object):
         # Delegators are required because we need to keep StreamingAnalyticsService
         # around for backwards compatibility, yet it also needs to work with basic
         # and IAM authentication.
-        if 'v2_rest_url' in credentials:
+        if 'v2_rest_url' in credentials and 'username' not in credentials and 'password' not in credentials:
             self._delegator = _StreamingAnalyticsServiceV2Delegator(rest_client, credentials)
         else:
             self._delegator = _StreamingAnalyticsServiceV1Delegator(rest_client, credentials)


### PR DESCRIPTION
If given a "mixed" credentials object with `v2_rest_url`, `username`, and `password` fields, then use the V1 Streaming Analytics service REST API using HTTP basic authentication.

