### PR TITLE
Extract retrieve file logic

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -174,19 +174,22 @@ class _StreamsRestClient(object):
 
     def make_raw_request(self, url):
         logger.debug('Beginning a REST request to: ' + url)
-        res = self.session.get(url)
+        res = self.session.get(url, headers=headers)
         self.handle_http_errors(res)
         return res
 
-    def make_raw_streaming_request(self, url):
+    def make_raw_streaming_request(self, url, mimetype=None):
         logger.debug('Beginning a REST request to: ' + url)
-        res = self.session.get(url, stream=True)
+        headers = {}
+        if mimetype:
+            headers['Accept'] = mimetype
+        res = self.session.get(url, stream=True, headers=headers)
         self.handle_http_errors(res)
 
         return res
 
-    def _retrieve_file(self, url, filename, dir_=None):
-        logs = self.make_raw_streaming_request(url)
+    def _retrieve_file(self, url, filename, dir_, mimetype):
+        logs = self.make_raw_streaming_request(url, mimetype)
         
         if dir_ is None:
             dir_ = os.getcwd()
@@ -273,9 +276,12 @@ class _IAMStreamsRestClient(_StreamsRestClient):
         self.handle_http_errors(res)
         return res
 
-    def make_raw_streaming_request(self, url):
+    def make_raw_streaming_request(self, url, mimetype=None):
         logger.debug('Beginning a REST request to: ' + url)
-        req = requests.Request("GET", url, headers = {'Authorization' : self._get_authorization()})
+        headers = {'Authorization' : self._get_authorization()}
+        if mimetype:
+            headers['Accept'] = mimetype
+        req = requests.Request("GET", url, headers = headers)
         prepared = req.prepare()
         res = self.session.send(prepared, stream=True)
         self.handle_http_errors(res)
@@ -556,7 +562,7 @@ class Job(_ResourceElement):
         if not filename:
             filename = _file_name('job', self.id, '.tar.gz')
  
-        return self.rest_client._retrieve_file(self.applicationLogTrace, filename, dir)
+        return self.rest_client._retrieve_file(self.applicationLogTrace, filename, dir, 'application/json')
 
     def get_views(self, name=None):
         """Get the list of :py:class:`View` elements associated with this job.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -562,7 +562,7 @@ class Job(_ResourceElement):
         if not filename:
             filename = _file_name('job', self.id, '.tar.gz')
  
-        return self.rest_client._retrieve_file(self.applicationLogTrace, filename, dir, 'application/json')
+        return self.rest_client._retrieve_file(self.applicationLogTrace, filename, dir, 'application/x-compressed')
 
     def get_views(self, name=None):
         """Get the list of :py:class:`View` elements associated with this job.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -32,6 +32,8 @@ import streamsx.topology.schema
 
 logger = logging.getLogger('streamsx.rest')
 
+def _file_name(prefix, id_, suffix):
+    return prefix + '_' + id_ + '_' + str(int(time.time())) + suffix
 
 def _exact_resource(json_rep, id=None):
     if id is not None:
@@ -182,6 +184,27 @@ class _StreamsRestClient(object):
         self.handle_http_errors(res)
 
         return res
+
+    def _retrieve_file(self, url, filename, dir_=None):
+        logs = self.make_raw_streaming_request(url)
+        
+        if dir_ is None:
+            dir_ = os.getcwd()
+
+        path = os.path.join(dir_, filename)
+        try:
+            with open(path, 'w+b') as logfile:
+                for chunk in logs.iter_content(chunk_size=1024*64):
+                    if chunk:
+                        logfile.write(chunk)
+        except IOError as e:
+            logger.error("IOError({0}) writing application log files: {1}".format(e.errno, e.strerror))
+            raise e
+        except Exception as e:
+            logger.error("Error while writing application log files")
+            raise e
+
+        return path
 
     def __str__(self):
         return pformat(self.__dict__)
@@ -529,27 +552,11 @@ class Job(_ResourceElement):
         .. versionadded:: 1.8
         """
         logger.debug("Retrieving application logs from: " + self.applicationLogTrace)
-        logs = self.rest_client.make_raw_streaming_request(self.applicationLogTrace)
-        
-        if filename is None:
-            filename = 'job_' + self.id + '_' + str(int(time.time())) + '.tar.gz'
-        if dir is None:
-            dir = os.getcwd()
 
-        path = os.path.join(dir, filename)
-        try:
-            with open(path, 'w+b') as logfile:
-                for chunk in logs.iter_content(chunk_size=1024*64):
-                    if chunk:
-                        logfile.write(chunk)
-        except IOError as e:
-            logger.error("IOError({0}) writing application log files: {1}".format(e.errno, e.strerror))
-            raise e
-        except Exception as e:
-            logger.error("Error while writing application log files")
-            raise e
-
-        return path                    
+        if not filename:
+            filename = _file_name('job', self.id, '.tar.gz')
+ 
+        return self.rest_client._retrieve_file(self.applicationLogTrace, filename, dir)
 
     def get_views(self, name=None):
         """Get the list of :py:class:`View` elements associated with this job.


### PR DESCRIPTION
To allow support of PE based retrieve log/trace calls.

Basically a step towards "pulling" (actually reimplementing) some of the changes from the `rest_submit_job` branch.