### PR TITLE
Ensure Java tester conditions perform exactly once behaviour in CR.

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/tester/fns/ConditionChecker.java
+++ b/java/src/com/ibm/streamsx/topology/internal/tester/fns/ConditionChecker.java
@@ -27,10 +27,24 @@ public abstract class ConditionChecker<T> implements Consumer<T>, Initializable 
     private static final long serialVersionUID = 1L;
     
     private final String name;
-    private transient AtomicBoolean valid;
-    private transient AtomicLong seq;
-    private transient AtomicBoolean fail;
-    private transient long count;
+    private final AtomicBoolean valid = new AtomicBoolean();
+    private final AtomicLong seq = new AtomicLong();
+    private final AtomicBoolean fail = new AtomicBoolean();
+    private long count;
+    
+    /**
+     * We need an addition transient fail status so that in the case of a
+     * reset after a consistent region checkpoint we don't reset the state
+     * to be non-failed.
+     * 
+     * Assumption is currently that a PE failure/restart always causes
+     * the test to fail, so the window of a condition fails but
+     * the PE fails before the tester notices is not currently a hidden failure.
+     * 
+     * fail is persistent so that if the PE does restart we maintain
+     * at best effort that we've already seen a failure.
+     */
+    private transient AtomicBoolean failSinceStart = new AtomicBoolean();
     
     public ConditionChecker(String name) {
         this.name = name;
@@ -38,10 +52,6 @@ public abstract class ConditionChecker<T> implements Consumer<T>, Initializable 
     
     @Override
     public void initialize(FunctionContext functionContext) throws Exception {
-        
-        valid = new AtomicBoolean();
-        seq = new AtomicLong();
-        fail = new AtomicBoolean();
        
         functionContext.createCustomMetric(metricName("valid", name),
                 "Condition: " + name + " is valid", "gauge",
@@ -53,7 +63,7 @@ public abstract class ConditionChecker<T> implements Consumer<T>, Initializable 
         
         functionContext.createCustomMetric(metricName("fail", name),
                 "Condition: " + name + " failed", "gauge",
-                () -> fail.get() ? 1L: 0L);       
+                () -> failed() ? 1L: 0L);       
     }
     
     /**
@@ -63,6 +73,7 @@ public abstract class ConditionChecker<T> implements Consumer<T>, Initializable 
     void setFailed(String why) {
         TEST_TRACE.severe(name + ": " + why);
         fail.set(true);
+        failSinceStart.set(true);
         valid.set(false);
     }
     
@@ -76,7 +87,7 @@ public abstract class ConditionChecker<T> implements Consumer<T>, Initializable 
     }   
     
     void setValid() {
-        if (!fail.get()) {
+        if (!failed()) {
             valid.set(true);
         }
     }
@@ -90,7 +101,7 @@ public abstract class ConditionChecker<T> implements Consumer<T>, Initializable 
     }
     
     boolean failed() {
-        return fail.get();
+        return fail.get() || failSinceStart.get();
     }
     
     @Override

--- a/java/src/com/ibm/streamsx/topology/tester/Condition.java
+++ b/java/src/com/ibm/streamsx/topology/tester/Condition.java
@@ -14,6 +14,34 @@ package com.ibm.streamsx.topology.tester;
  * {@link Tester#atLeastTupleCount(com.ibm.streamsx.topology.TStream, long) at least N}
  * tuples have been seen on the stream.
  * 
+ * <P>
+ * In a consistent region a condition exhibits exactly once behavior. For example
+ * an {@link Tester#tupleCount(com.ibm.streamsx.topology.TStream, long) exact tuple count} condition
+ * placed against the stream will become valid when the tuple count is reached taking the resets into
+ * account, even though more tuples may have been seen on the stream. This is because the
+ * conditions are stateful and part of the consistent region.
+ * <BR>
+ * After a region reset or failure the condition's state is reset
+ * to the last consistent state. For example with a tuple count condition on a stream of 1,000 tuples
+ * assume the region became consistent after 800 tuples. Subsequently a failure occurs after 950 tuples,
+ * the region is reset, and the tuple counter condition is reset to 800 tuples. The source operator
+ * then replays any required tuples and after another 200 tuples the condition becomes valid,
+ * even though the stream actually processed 1,150 tuples.
+ * <BR>
+ * If at least once behavior is required for a condition on a stream then it can be placed
+ * outside of the region by applying it to an {@link com.ibm.streamsx.topology.TStream#autonomous() autonomous} stream
+ * created from the stream in the region:
+ * <pre>
+ * <code>
+ * TStream<String> s = ...;
+ * 
+ * // Add a condition that will perform at least once behavior
+ * // and count all tuples seen on s including any replayed tuples.
+ * s.autonomous().atLeastTupleCount(1150);
+ * </code>
+ * </pre>
+ * </P>
+ * 
  * @param T Result type.
  * 
  * @see Tester#atLeastTupleCount(com.ibm.streamsx.topology.TStream, long)
@@ -21,6 +49,8 @@ package com.ibm.streamsx.topology.tester;
  * @see Tester#tupleContents(com.ibm.streamsx.topology.spl.SPLStream, com.ibm.streams.operator.Tuple...)
  * @see Tester#stringContents(com.ibm.streamsx.topology.TStream, String...)
  * @see Tester#stringContentsUnordered(com.ibm.streamsx.topology.TStream, String...)
+ * 
+ * @since 1.9 Support for consistent region added.
  */
 public interface Condition<T> {
     

--- a/test/java/src/com/ibm/streamsx/topology/test/consistent/ConsistentRegionTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/consistent/ConsistentRegionTest.java
@@ -42,30 +42,36 @@ public class ConsistentRegionTest extends TestTopology {
     public void testConsistentPeriodic() throws Exception {
         Topology topology = new Topology("testConsistentPeriodic");
         
+        final int N = 2000;
+        
         StreamSchema schema = Type.Factory.getStreamSchema("tuple<uint64 id>");
         Map<String,Object> params = new HashMap<>();
-        params.put("iterations", 200);
-        params.put("period", 0.05);
-        
+        params.put("iterations", N);
+        params.put("period", 0.01);      
         SPLStream b = SPL.invokeSource(topology, "spl.utility::Beacon", params, schema);
         
         ConsistentRegionConfig config = periodic(2);
         assertSame(b, b.setConsistent(config));
         
-        Condition<Long> atLeast = topology.getTester().atLeastTupleCount(b, 200);
+        // Create a mini-flow
+        b = b.filter(t -> true);
+        
+        Condition<Long> exact = topology.getTester().tupleCount(b, N);
         Condition<Void> resets = topology.getTester().resetConsistentRegions(null);
         assertNotNull(resets);
-        complete(topology.getTester(), atLeast, 80, TimeUnit.SECONDS);
+        complete(topology.getTester(), exact, 80, TimeUnit.SECONDS);
     }
     
     @Test
     public void testConsistentOperatorDriven() throws Exception {
         Topology topology = new Topology("testConsistentOperatorDriven");
         
+        final int N = 2000;
+        
         StreamSchema schema = Type.Factory.getStreamSchema("tuple<uint64 id>");
         Map<String,Object> params = new HashMap<>();
-        params.put("iterations", 500);
-        params.put("period", 0.05);
+        params.put("iterations", N);
+        params.put("period", 0.01);
         params.put("triggerCount", SPL.createValue(37, Type.MetaType.UINT32));
         
         SPLStream b = SPL.invokeSource(topology, "spl.utility::Beacon", params, schema);
@@ -73,11 +79,14 @@ public class ConsistentRegionTest extends TestTopology {
         ConsistentRegionConfig config = ConsistentRegionConfig.operatorDriven();
         assertSame(b, b.setConsistent(config));
         
+        // Create a mini-flow
+        b = b.filter(t -> true);
+        
         Condition<Void> resets = topology.getTester().resetConsistentRegions(5);
         assertNotNull(resets);
         
-        Condition<Long> atLeast = topology.getTester().atLeastTupleCount(b, 500);
-        complete(topology.getTester(), atLeast, 80, TimeUnit.SECONDS);
+        Condition<Long> exact = topology.getTester().tupleCount(b, N);
+        complete(topology.getTester(), exact, 80, TimeUnit.SECONDS);
     }
     
     /**


### PR DESCRIPTION
Tester `Condition` instances act as exactly once in a consistent region, thus resetting state naturally after a reset.