### PR TITLE
postJob code is common to both v1/v2 services with minimal differences

### DIFF
--- a/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
@@ -17,9 +17,15 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
+import org.apache.http.HttpEntity;
 import org.apache.http.auth.AUTH;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
@@ -80,10 +86,8 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
     /** Version-specific handling for job submit URL with file bundle. */
     protected abstract String getJobSubmitUrl(CloseableHttpClient httpClient,
             File bundle) throws IOException, UnsupportedEncodingException;
-    /** Version-specific post job. */
-    protected abstract JsonObject postJob(CloseableHttpClient httpClient,
-            JsonObject service, File bundle, JsonObject jobConfigOverlay)
-            throws IOException;
+    /** Version-specific submit job bundle keys in . */
+    protected abstract String[] getBundleEntityKeys();
     /** Version-specific handling for job submit URL with artifact. */
     protected abstract String getJobSubmitUrl(JsonObject build)
             throws IOException, UnsupportedEncodingException;
@@ -320,5 +324,33 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
         default:
             throw new IllegalStateException("Unknown Streaming Analytics Service version");
         }
+    }
+    
+    /**
+     * Submit an application bundle to execute as a job.
+     */
+    protected JsonObject postJob(CloseableHttpClient httpClient,
+            JsonObject service, File bundle, JsonObject jobConfigOverlay)
+            throws IOException {
+
+        String url = getJobSubmitUrl(httpClient, bundle);
+
+        HttpPost postJobWithConfig = new HttpPost(url);
+        postJobWithConfig.addHeader(AUTH.WWW_AUTH_RESP, getAuthorization());
+        FileBody bundleBody = new FileBody(bundle, ContentType.APPLICATION_OCTET_STREAM);
+        StringBody configBody = new StringBody(jobConfigOverlay.toString(), ContentType.APPLICATION_JSON);
+
+        String[] entityKeys = getBundleEntityKeys();
+        HttpEntity reqEntity = MultipartEntityBuilder.create()
+                .addPart(entityKeys[0], bundleBody)
+                .addPart(entityKeys[1], configBody).build();
+
+        postJobWithConfig.setEntity(reqEntity);
+
+        JsonObject jsonResponse = StreamsRestUtils.getGsonResponse(httpClient, postJobWithConfig);
+
+        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + getName() + "): submit job response:" + jsonResponse.toString());
+
+        return jsonResponse;
     }
 }

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
@@ -86,8 +86,6 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
     /** Version-specific handling for job submit URL with file bundle. */
     protected abstract String getJobSubmitUrl(CloseableHttpClient httpClient,
             File bundle) throws IOException, UnsupportedEncodingException;
-    /** Version-specific submit job bundle keys in . */
-    protected abstract String[] getBundleEntityKeys();
     /** Version-specific handling for job submit URL with artifact. */
     protected abstract String getJobSubmitUrl(JsonObject build)
             throws IOException, UnsupportedEncodingException;
@@ -340,10 +338,9 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
         FileBody bundleBody = new FileBody(bundle, ContentType.APPLICATION_OCTET_STREAM);
         StringBody configBody = new StringBody(jobConfigOverlay.toString(), ContentType.APPLICATION_JSON);
 
-        String[] entityKeys = getBundleEntityKeys();
         HttpEntity reqEntity = MultipartEntityBuilder.create()
-                .addPart(entityKeys[0], bundleBody)
-                .addPart(entityKeys[1], configBody).build();
+                .addPart("bundle_file", bundleBody)
+                .addPart("job_options", configBody).build();
 
         postJobWithConfig.setEntity(reqEntity);
 

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
@@ -29,7 +29,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
-import com.ibm.streamsx.topology.internal.context.remote.DeployKeys;
 
 /**
  * Implementation of StreamingAnalyticsService for Version 1.
@@ -61,13 +60,6 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
         sb.append("bundle_id=");
         sb.append(URLEncoder.encode(bundle.getName(), StandardCharsets.UTF_8.name()));
         return sb.toString();
-    }
-    
-    // Bundle then job config overlay
-    private final String[] BUNDLE_ENTITY_KEYS = {"sab", DeployKeys.JOB_CONFIG_OVERLAYS};
-    @Override
-    protected String[] getBundleEntityKeys() {
-        return BUNDLE_ENTITY_KEYS;
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
@@ -25,6 +25,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
+import com.ibm.streamsx.topology.internal.context.remote.DeployKeys;
 
 class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
 
@@ -190,30 +191,11 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
         return jso;
     }
 
-    /**
-     * Submit an application bundle to execute as a job.
-     */
-    protected JsonObject postJob(CloseableHttpClient httpClient,
-            JsonObject service, File bundle, JsonObject jobConfigOverlay)
-            throws IOException {
-
-        String url = getJobSubmitUrl(httpClient, bundle);
-
-        HttpPost postJobWithConfig = new HttpPost(url);
-        postJobWithConfig.addHeader(AUTH.WWW_AUTH_RESP, getAuthorization());
-
-        FileBody bundleBody = new FileBody(bundle, ContentType.APPLICATION_OCTET_STREAM);
-        StringBody configBody = new StringBody(jobConfigOverlay.toString(), ContentType.APPLICATION_JSON);
-        HttpEntity reqEntity = MultipartEntityBuilder.create()
-                .addPart("bundle_file", bundleBody)
-                .addPart("job_options", configBody).build();
-        postJobWithConfig.setEntity(reqEntity);
-
-        JsonObject jsonResponse = StreamsRestUtils.getGsonResponse(httpClient, postJobWithConfig);
-
-        RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + getName() + "): submit job response:" + jsonResponse.toString());
-
-        return jsonResponse;
+    // Bundle then job config overlay
+    private final String[] BUNDLE_ENTITY_KEYS = {"bundle_file", "job_options"};
+    @Override
+    protected String[] getBundleEntityKeys() {
+        return BUNDLE_ENTITY_KEYS;
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
@@ -25,7 +25,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.context.remote.RemoteContext;
-import com.ibm.streamsx.topology.internal.context.remote.DeployKeys;
 
 class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
 
@@ -189,13 +188,6 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
         JsonObject jso = StreamsRestUtils.getGsonResponse(httpclient, postArtifact);
         RemoteContext.REMOTE_LOGGER.info("Streaming Analytics service (" + getName() + "): submit job response: " + jso.toString());
         return jso;
-    }
-
-    // Bundle then job config overlay
-    private final String[] BUNDLE_ENTITY_KEYS = {"bundle_file", "job_options"};
-    @Override
-    protected String[] getBundleEntityKeys() {
-        return BUNDLE_ENTITY_KEYS;
     }
 
     @Override


### PR DESCRIPTION
Noticed this while looking at adding post bundle to Python REST api.

`postJob` is basically the same between V1 & V2, with the difference being the URL ~and the entity keys~.

Update: actually the entity keys can be the same, only the position seems to be important.