### PR TITLE
Add --bundle to streamsx.runner

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/runner.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/runner.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 from future.builtins import *
 
+import collections
 import sys
 import sysconfig
 import inspect
@@ -19,6 +20,13 @@ import streamsx.topology.context as ctx
 from streamsx.topology.topology import Topology
 import streamsx.spl.toolkit as tk
 import streamsx.spl.op as op
+import streamsx.rest
+import streamsx.scripts.extract
+
+# Structure for an application
+# app - Topology object or str (sab file)
+# cfg - dict configuration holding JobConfig at least.
+_App = collections.namedtuple('_App', ['app', 'cfg'])
 
 class _SubmitParamArg(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -33,8 +41,10 @@ def main():
     cmd_args = _parse_args()
     if cmd_args.topology is not None:
         app = _get_topology_app(cmd_args)
-    if cmd_args.main_composite is not None:
+    elif cmd_args.main_composite is not None:
         app = _get_spl_app(cmd_args)
+    elif cmd_args.bundle is not None:
+        app = _get_bundle(cmd_args)
     _job_config_args(cmd_args, app)
     sr = _submit(cmd_args, app)
     print(sr)
@@ -48,18 +58,23 @@ def _parse_args():
 
     ctx_group = cmd_parser.add_mutually_exclusive_group(required=True)
     ctx_group.add_argument('--service-name', help='Submit to Streaming Analytics service')
-    ctx_group.add_argument('--create-bundle', action='store_true', help='Create a bundle')
+    ctx_group.add_argument('--create-bundle', action='store_true', help='Create a bundle using a local IBM Streams install. No job submission occurs.')
 
     app_group = cmd_parser.add_mutually_exclusive_group(required=True)
     app_group.add_argument('--topology', help='Topology to call')
     app_group.add_argument('--main-composite', help='SPL main composite')
+    app_group.add_argument('--bundle', help="Streams application bundle (sab file) to submit to service")
 
-    cmd_parser.add_argument('--toolkits', nargs='+', help='Additional SPL toolkits')
-    cmd_parser.add_argument('--job-name', help='Job name')
-    cmd_parser.add_argument('--preload', action='store_true', help='Preload job onto all resources in the instance')
-    cmd_parser.add_argument('--trace', choices=['error', 'warn', 'info', 'debug', 'trace'], help='Application trace level')
+    bld_group = cmd_parser.add_argument_group('Build options', 'Application build options')
+    bld_group.add_argument('--toolkits', nargs='+', help='SPL toolkit containing the main composite and any other required SPL toolkits.')
 
-    cmd_parser.add_argument('--submission-parameters', '-p', nargs='+', action=_SubmitParamArg, help="Submission parameters as name=value pairs")
+    jo_group = cmd_parser.add_argument_group('Job options', 'Job configuration options')
+
+    jo_group.add_argument('--job-name', help='Job name')
+    jo_group.add_argument('--preload', action='store_true', help='Preload job onto all resources in the instance')
+    jo_group.add_argument('--trace', choices=['error', 'warn', 'info', 'debug', 'trace'], help='Application trace level')
+
+    jo_group.add_argument('--submission-parameters', '-p', nargs='+', action=_SubmitParamArg, help="Submission parameters as name=value pairs")
 
     cmd_args = cmd_parser.parse_args()
     return cmd_args
@@ -70,7 +85,7 @@ def _get_topology_app(cmd_args):
     tf = getattr(fm, fn)
     app = tf()
     if isinstance(app, Topology):
-        app = (app, {})
+        app = _App(app, {})
     elif not isinstance(app, tuple):
         raise ValueError(app)
     if not isinstance(app[0], Topology):
@@ -78,7 +93,7 @@ def _get_topology_app(cmd_args):
     if isinstance(app[1], ctx.JobConfig):
         cfg = {}
         cfg[ctx.ConfigParams.JOB_CONFIG] = app[1]
-        app = (app[0], cfg)
+        app = _App(app[0], cfg)
     elif not isinstance(app[1], dict):
         raise ValueError(app)
 
@@ -91,23 +106,48 @@ def _get_spl_app(cmd_args):
     if cmd_args.toolkits is not None:
         for tk_path in cmd_args.toolkits:
             tk.add_toolkit(topo, tk_path)
+            if cmd_args.create_bundle:
+                # Mimic what the build service does by indexing
+                # any required toolkits including Python operator extraction
+                # but only if we can write to it.
+                if os.access(tk_path, os.W_OK):
+                    streamsx.scripts.extract.main(['-i', tk_path, '--make-toolkit'])
 
     op.Invoke(topo, cmd_args.main_composite)
-    return (topo, {})
+    return _App(topo, {})
+
+def _get_bundle(cmd_args):
+    return _App(cmd_args.bundle, {})
 
 def _submit(cmd_args, app):
-    cfg = app[1]
+    if isinstance(app.app, Topology):
+        return _submit_topology(cmd_args, app)
+    if isinstance(app.app, str):
+        return _submit_bundle(cmd_args, app)
+    
+def _submit_topology(cmd_args, app):
+    """Submit a Python topology to the service.
+    This includes an SPL main composite wrapped in a Python topology.
+    """
+    cfg = app.cfg
     if cmd_args.create_bundle:
         ctxtype = ctx.ContextTypes.BUNDLE
+        cfg['topology.keepArtifacts'] = True
     elif cmd_args.service_name:
         cfg[ctx.ConfigParams.FORCE_REMOTE_BUILD] = True
         cfg[ctx.ConfigParams.SERVICE_NAME] = cmd_args.service_name
         ctxtype = ctx.ContextTypes.STREAMING_ANALYTICS_SERVICE
-    sr = ctx.submit(ctxtype, app[0], cfg)
+    sr = ctx.submit(ctxtype, app.app, cfg)
     return sr
 
+def _submit_bundle(cmd_args, app):
+    """Submit an existing bundle to the service"""
+    sac = streamsx.rest.StreamingAnalyticsConnection(service_name=cmd_args.service_name)
+    sas = sac.get_streaming_analytics()
+    return sas.submit_job(bundle=app.app, job_config=app.cfg[ctx.ConfigParams.JOB_CONFIG])
+
 def _job_config_args(cmd_args, app):
-    cfg = app[1]
+    cfg = app.cfg
     if not ctx.ConfigParams.JOB_CONFIG in cfg:
         ctx.JobConfig().add(cfg)
     jc = cfg[ctx.ConfigParams.JOB_CONFIG]

--- a/python/sphinx/source/scripts/runner.rst
+++ b/python/sphinx/source/scripts/runner.rst
@@ -70,9 +70,8 @@ The application is submitted as source (except ``--bundle``)  and compiled into
 a Streams application bundle (``sab`` file) using the build service before
 being submitted as a running job to the service instance.
 
-*******************
 Python applications
-*******************
+===================
 
 To submit a Python application a Python function must be defined
 that returns the application (and optionally its configuration)
@@ -113,9 +112,8 @@ it is always submitted with the same job name `SensorIngester`.
 The function must be accessible from the current Python path
 (typically through environment variable ``PYTHONPATH``).
 
-****************
 SPL applications
-****************
+================
 
 The main composite that defines the application is specified using the ``-main-composite`` flag specifing the fully namespace qualified name.
 
@@ -129,9 +127,8 @@ For example, an application that uses the Slack toolkit might be submitted as::
 
 where ``$HOME/app/alerters`` is the location of the SPL application toolkit containing the ``com.example.alert::SlackAlerter`` main composite.
 
-***************************
 Streams application bundles
-***************************
+===========================
 
 A Streams application bundle is submitted to a service instance using ``--bundle``.  The argument to ``--bundle`` is a locally accessible file that will be uploaded to the service.
 
@@ -139,9 +136,8 @@ The bundle must have been created on using an IBM Streams install whose architec
 
 The ``--toolkits`` flag must not be specified when submitting a bundle.
 
-***********
 Job options
-***********
+===========
 
 Job options, such as ``--job-name``, configure the running job.
 

--- a/python/sphinx/source/scripts/runner.rst
+++ b/python/sphinx/source/scripts/runner.rst
@@ -12,6 +12,7 @@ The application to be submitted can be:
 
  * A Python application defined through :py:class:`~streamsx.topology.topology.Topology` using the ``--topology`` flag.
  * An SPL application (main composite) using the ``--main-composite`` flag.
+ * A Streams application bundle (``sab`` file) using the ``--bundle`` flag.
 
 *****
 Usage
@@ -20,23 +21,35 @@ Usage
 ::
 
     streamsx-runner [-h] (--service-name SERVICE_NAME | --create-bundle)
-                 (--topology TOPOLOGY | --main-composite MAIN_COMPOSITE)
+                 (--topology TOPOLOGY | --main-composite MAIN_COMPOSITE | --bundle BUNDLE)
                  [--toolkits TOOLKITS [TOOLKITS ...]] [--job-name JOB_NAME]
                  [--preload] [--trace {error,warn,info,debug,trace}]
                  [--submission-parameters SUBMISSION_PARAMETERS [SUBMISSION_PARAMETERS ...]]
-
+    
     Execute a Streams application using a Streaming Analytics service.
-
+    
     optional arguments:
       -h, --help            show this help message and exit
       --service-name SERVICE_NAME
                             Submit to Streaming Analytics service
-      --create-bundle       Create a bundle
+      --create-bundle       Create a bundle using a local IBM Streams install. No
+                            job submission occurs.
       --topology TOPOLOGY   Topology to call
       --main-composite MAIN_COMPOSITE
                             SPL main composite
+      --bundle BUNDLE       Streams application bundle (sab file) to submit to
+                            service
+    
+    Build options:
+      Application build options
+    
       --toolkits TOOLKITS [TOOLKITS ...]
-                            Additional SPL toolkits
+                            SPL toolkit containing the main composite and any
+                            other required SPL toolkits.
+    
+    Job options:
+      Job configuration options
+    
       --job-name JOB_NAME   Job name
       --preload             Preload job onto all resources in the instance
       --trace {error,warn,info,debug,trace}
@@ -53,8 +66,8 @@ An application is submitted to a Streaming Analytics service using
 VCAP services defintion pointed to by the ``VCAP_SERVICES`` environment
 variable.
 
-The application is submitted as source (Python or SPL) and compiled into
-a Streams application bundle (sab file) using the build service before
+The application is submitted as source (except ``--bundle``)  and compiled into
+a Streams application bundle (``sab`` file) using the build service before
 being submitted as a running job to the service instance.
 
 *******************
@@ -97,9 +110,8 @@ For example the above function might be defined as::
 Thus when this application is submitted using the `sensor_ingester` function
 it is always submitted with the same job name `SensorIngester`.
 
-
 The function must be accessible from the current Python path
-(typically through enviornment variable ``PYTHONPATH``).
+(typically through environment variable ``PYTHONPATH``).
 
 ****************
 SPL applications
@@ -115,4 +127,43 @@ For example, an application that uses the Slack toolkit might be submitted as::
         --main-composite com.example.alert::SlackAlerter \
         --toolkits $HOME/app/alerters $HOME/toolkits/com.ibm.streamsx.slack
 
-where ``$HOME/app/alerts`` is the location of the SPL application toolkit containing the ``com.example.alert::SlackAlerter`` main composite.
+where ``$HOME/app/alerters`` is the location of the SPL application toolkit containing the ``com.example.alert::SlackAlerter`` main composite.
+
+***************************
+Streams application bundles
+***************************
+
+A Streams application bundle is submitted to a service instance using ``--bundle``.  The argument to ``--bundle`` is a locally accessible file that will be uploaded to the service.
+
+The bundle must have been created on using an IBM Streams install whose architecture and OS version matches the service instance. Currently this is ``x86_64`` and RedHat/CentOS 6 or 7 depending on the service instance.
+
+The ``--toolkits`` flag must not be specified when submitting a bundle.
+
+***********
+Job options
+***********
+
+Job options, such as ``--job-name``, configure the running job.
+
+For ``--topology`` job options set as arguments to ``streamsx-runner`` override any configuration returned from the function defining the application.
+
+************************************
+Creating Streams application bundles
+************************************
+
+``--create-bundle`` uses a local IBM Streams install to attempt to mimic the build that would occur with ``-topology`` or ``--main-composite``. Differences between the local environment and the IBM Cloud Streaming Analytics build environment may cause build failures in one and not the other.
+
+This can be used as a mechanism to perform a local test build before using the service, or as a valid mechanism to create bundles for later upload with ``--bundle``.
+
+For example simply changing the ``--service-name name`` to ``--create-bundle`` perfoms a local build of the same application::
+
+    # Submit to an Streaming Analytics service
+    streamsx-runner --service-name Streaming-Analytics-xd \
+        --main-composite com.example.alert::SlackAlerter \
+        --toolkits $HOME/app/alerters $HOME/toolkits/com.ibm.streamsx.slack
+
+    # Build the same application locally
+    streamsx-runner --create-bundle \
+        --main-composite com.example.alert::SlackAlerter \
+        --toolkits $HOME/app/alerters $HOME/toolkits/com.ibm.streamsx.slack
+


### PR DESCRIPTION
Adds the ability to submit a bundle `.sab` file to a Streaming Analytics instance using `streamsx-runner`.

The bundle must be a local file that will then be uploaded and submitted to the service.

For example:
```
streamsx-runner --service-name myservice --bundle ns1.MyApp.sab --job-name MyCoolJob
```

Code & test is complete.

Need to update the `strreamsx