### PR TITLE
Add UDP broadcast support for TStream

### DIFF
--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -88,7 +88,16 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
 	     * Tuples will be consistently routed to the same channel based upon 
              * their {@code hashCode()}.
 	     */
-	    HASH_PARTITIONED	    
+	    HASH_PARTITIONED,
+	    
+	    /**
+	     * Tuples are broadcast to all channels.
+	     * For example with a width of four each tuple on the stream results
+	     * in four tuples, one per channel.
+	     * 
+	     * @since 1.9
+	     */
+	    BROADCAST
 	};
 	
     /**

--- a/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
+++ b/java/src/com/ibm/streamsx/topology/builder/GraphBuilder.java
@@ -175,8 +175,9 @@ public class GraphBuilder extends BJSONObject {
      * Add a marker operator, that is actually a PassThrough in OperatorGraph,
      * so that we can run this graph locally with a single thread.
      */
-    public BOutput parallel(BOutput parallelize, Supplier<Integer> width) {
+    public BOutput parallel(BOutput parallelize, String routing, Supplier<Integer> width) {
         BOutput parallelOutput = addPassThroughMarker(parallelize, BVirtualMarker.PARALLEL, true);
+        parallelOutput._json().addProperty(PortProperties.ROUTING, routing);
         if (width.get() != null)
             parallelOutput._json().addProperty(PortProperties.WIDTH, width.get());
         else {

--- a/java/src/com/ibm/streamsx/topology/generator/port/PortProperties.java
+++ b/java/src/com/ibm/streamsx/topology/generator/port/PortProperties.java
@@ -9,11 +9,9 @@ public interface PortProperties {
 	String WIDTH = OpProperties.WIDTH;
 	
 	/**
-	 * Boolean top-level parameter indicating whether the port should broadcast tuples
-	 * to all channels in a parallel region, if the port is the start of a parallel
-	 * region.	
+	 * Routing style for a parallel output port.
 	 */
-	String BROADCAST = "broadcast";
+	String ROUTING = "routing";
 	
 	/**
 	 * Top-level boolean parameter indicating that the downstream parallel region

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -41,6 +41,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.ibm.streamsx.topology.context.ContextProperties;
 import com.ibm.streamsx.topology.generator.operator.OpProperties;
+import com.ibm.streamsx.topology.generator.port.PortProperties;
 import com.ibm.streamsx.topology.generator.spl.SubmissionTimeValue.ParamsInfo;
 import com.ibm.streamsx.topology.internal.functional.FunctionalOpProperties;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
@@ -219,9 +220,10 @@ class OperatorGenerator {
             } else {
                 splValueSupportingSubmission(width.getAsJsonObject(), sb);
             }
+            String parallelInputPortName = jstring(op, "parallelInputPortName");
             boolean partitioned = jboolean(op, "partitioned");
             if (partitioned) {
-                String parallelInputPortName = jstring(op, "parallelInputPortName");
+                
                 JsonArray partitionKeys = op.get("partitionedKeys").getAsJsonArray();
 
                 parallelInputPortName = getSPLCompatibleName(parallelInputPortName);
@@ -234,6 +236,10 @@ class OperatorGenerator {
                     sb.append(partitionKeys.get(i).getAsString());
                 }
                 sb.append("]}]");
+            } else if ("BROADCAST".equals(jstring(op, PortProperties.ROUTING))) {
+                sb.append(", broadcast=[");
+                sb.append(parallelInputPortName);
+                sb.append("]");
             }
             sb.append(")\n");
         }

--- a/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
@@ -197,7 +197,6 @@ class Preprocessor {
     private void relocateHashAdder(JsonObject hashAdder){
         int numHashAdderCopies = 0;
         int numHashRemoverCopies = 0;
-        String routing = GsonUtilities.jstring(hashAdder, "routing");
 
         // The hashremover object
         // hashAdder -> $Parallel$ -> $Isolate -> hashremover

--- a/test/java/src/com/ibm/streamsx/topology/test/api/ChannelAndSequence.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/ChannelAndSequence.java
@@ -23,5 +23,10 @@ public class ChannelAndSequence implements Serializable {
     public int getSequence() {
         return sequence;
     }
+    
+    @Override
+    public String toString() {
+        return "CS:" + getChannel() + ":" + getSequence();
+    }
 
 }


### PR DESCRIPTION
Adds the first item in the checklist in #1460 

Tested with standalone, distributed and streaming analytics.