### PR TITLE
Add dependencies in hash adder key function

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -518,6 +518,9 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
             String hashSchema = ObjectSchemas.schemaWithHash(ip._schema());
             toBeParallelized = hashAdder.addOutput(hashSchema);
             isPartitioned = true;
+            
+            // Add dependencies in the hashAdder function
+            JavaFunctional.addDependency(this, hashAdder, TypeDiscoverer.determineStreamType(keyer, null));
         }
                 
         BOutput parallelOutput = builder().parallel(toBeParallelized, routing.name(), width);


### PR DESCRIPTION
Currently, if the hashadder uses a third party library, the dependency will not be included automatically.