### PR TITLE
Convert dict tuples directly to SPL tuples for spl.map and spl.source.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/codegen/py_pyTupleTosplTuple.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_pyTupleTosplTuple.cgt
@@ -12,6 +12,7 @@
   }
 %>
  
+// Python tuple to SPL tuple
 void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple <%=$itypeparam%>) {
 
   <%=$oport->getCppTupleType()%> otuple;
@@ -73,3 +74,80 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple <%=$
   submit(otuple, <%=$oport->getIndex()%>);
   Py_END_ALLOW_THREADS
 }
+
+<%
+{
+no strict 'vars';
+if (defined $FROM_DICT_TMP) {
+%>
+
+// Python dict to SPL tuple
+void MY_OPERATOR::fromPythonDictToPort<%=$oport->getIndex()%>(PyObject *pyDict <%=$itypeparam%>) {
+
+  <%=$oport->getCppTupleType()%> otuple;
+
+  Py_ssize_t available = PyDict_Size(pyDict); 
+    
+<%
+  if (defined $iport) {
+    print 'bool setAttr = false;';
+  }
+
+  for (my $ai = $oport->getNumberOfAttributes() - 1; $ai >= 0; --$ai) {
+    
+    my $attribute = $oport->getAttributeAt($ai);
+    my $name = $attribute->getName();
+    my $atype = $attribute->getSPLType();
+    splToPythonConversionCheck($atype);
+    
+    if (defined $iport) {
+             print 'setAttr = false;';
+    }
+%>
+    if (available > 0) {
+         // Value from the Python function
+         PyObject *pyAttrValue = PyDict_GetItem(pyDict, PyTuple_GET_ITEM(pyOutNames_<%=$oport->getIndex()%>, <%=$ai%>));
+         if (pyAttrValue != NULL) {
+             --available;
+             if (!SplpyGeneral::isNone(pyAttrValue)) {
+                  streamsx::topology::pySplValueFromPyObject(
+                               otuple.get_<%=$name%>(), pyAttrValue);
+<%
+    if (defined $iport) {
+             print 'setAttr = true;';
+    }
+%>
+           }
+        }
+   }
+<%
+    if (defined $iport) {
+    
+    # Only copy attributes across if they match on name and type
+    my $matchInputAttr = $iport->getAttributeByName($name);
+    if (defined $matchInputAttr) {
+       if ($matchInputAttr->getSPLType() eq $attribute->getSPLType()) {
+%>
+    if (!setAttr) {
+      // value from the input attribute
+      otuple.set_<%=$name%>(ituple.get_<%=$name%>());
+    }
+<%
+      }
+    }
+   }
+%>
+         
+<%
+}
+ %>
+
+  Py_BEGIN_ALLOW_THREADS
+  submit(otuple, <%=$oport->getIndex()%>);
+  Py_END_ALLOW_THREADS
+}
+
+<%
+}
+}
+%>

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_sym.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_sym.h
@@ -275,7 +275,9 @@ extern "C" {
   static __splpy_p_s_fp __spl_fp_PyTuple_New;
   static __splpy_p_p_fp __spl_fp_PyIter_Next;
   static __splpy_v_p_fp __spl_fp_PyDict_New;
+  static __splpy_s_p_fp __spl_fp_PyDict_Size;
   static __splpy_i_ppp_fp __spl_fp_PyDict_SetItem;
+  static __splpy_p_pp_fp __spl_fp_PyDict_GetItem;
   static __splpy_dn_fp __spl_fp_PyDict_Next;
   static __splpy_p_s_fp __spl_fp_PyList_New;
   static __splpy_s_p_fp __spl_fp_PyList_Size;
@@ -293,8 +295,14 @@ extern "C" {
   static PyObject * __spl_fi_PyDict_New() {
      return __spl_fp_PyDict_New();
   }
+  static Py_ssize_t __spl_fi_PyDict_Size(PyObject *d) {
+     return __spl_fp_PyDict_Size(d);
+  }
   static int __spl_fi_PyDict_SetItem(PyObject *d, PyObject *k, PyObject *v) {
      return __spl_fp_PyDict_SetItem(d, k, v);
+  }
+  static PyObject * __spl_fi_PyDict_GetItem(PyObject *d, PyObject *k) {
+     return __spl_fp_PyDict_GetItem(d, k);
   }
   static int __spl_fi_PyDict_Next(PyObject *d, Py_ssize_t *o,PyObject **k, PyObject **v) {
      return __spl_fp_PyDict_Next(d, o, k, v);
@@ -321,7 +329,9 @@ extern "C" {
 #pragma weak PyTuple_New = __spl_fi_PyTuple_New
 #pragma weak PyIter_Next = __spl_fi_PyIter_Next
 #pragma weak PyDict_New = __spl_fi_PyDict_New
+#pragma weak PyDict_Size = __spl_fi_PyDict_Size
 #pragma weak PyDict_SetItem = __spl_fi_PyDict_SetItem
+#pragma weak PyDict_GetItem = __spl_fi_PyDict_GetItem
 #pragma weak PyDict_Next = __spl_fi_PyDict_Next
 #pragma weak PyList_New = __spl_fi_PyList_New
 #pragma weak PyList_Size = __spl_fi_PyList_Size
@@ -518,7 +528,9 @@ class SplpySym {
      __SPLFIX(PyTuple_New, __splpy_p_s_fp);
      __SPLFIX(PyIter_Next, __splpy_p_p_fp);
      __SPLFIX(PyDict_New, __splpy_v_p_fp);
+     __SPLFIX(PyDict_Size, __splpy_s_p_fp);
      __SPLFIX(PyDict_SetItem, __splpy_i_ppp_fp);
+     __SPLFIX(PyDict_GetItem, __splpy_p_pp_fp);
      __SPLFIX(PyDict_Next, __splpy_dn_fp);
      __SPLFIX(PyList_New, __splpy_p_s_fp);
      __SPLFIX(PyList_Size, __splpy_s_p_fp);

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_valueToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_valueToTuples.cgt
@@ -23,6 +23,9 @@ void MY_OPERATOR::pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject *value <%=$
   {
     fromPythonToPort<%=$oport->getIndex()%>(value <%=$ituplearg%>);
   }
+  else if (PyDict_Check(value)) {
+    fromPythonDictToPort<%=$oport->getIndex()%>(value <%=$ituplearg%>);
+  }
   else if (PyList_Check(value))
   {
 
@@ -32,12 +35,15 @@ void MY_OPERATOR::pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject *value <%=$
        PyObject *ltuple = PyList_GET_ITEM(value, k);
        if (SplpyGeneral::isNone(ltuple))
            continue;
-       if (!PyTuple_Check(ltuple)) {    
+       if (PyTuple_Check(ltuple)) {    
+           fromPythonToPort<%=$oport->getIndex()%>(ltuple <%=$ituplearg%>);
+       } else if (PyDict_Check(ltuple)) {
+           fromPythonDictToPort<%=$oport->getIndex()%>(ltuple <%=$ituplearg%>);
+       } else {
           throw SplpyGeneral::generalException("submit",
-             "Fatal error: Value submitted must be a Python tuple or a Python list of tuples: Port <%=$oport->getIndex()%>");
+             "Fatal error: Value submitted must be a Python tuple, dict or list of tuples or dicts: Port <%=$oport->getIndex()%>");
        }
      
-      fromPythonToPort<%=$oport->getIndex()%>(ltuple <%=$ituplearg%>);
      }
   }
   else {

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -25,6 +25,8 @@ using namespace streamsx::topology;
  
  my $iport = $model->getInputPortAt(0);
 
+ my $FROM_DICT_TMP = 1;
+
  my $inputAttrs2Py = $iport->getNumberOfAttributes();
  if ($fixedParam != -1) {
     $inputAttrs2Py = $fixedParam;
@@ -45,14 +47,17 @@ using namespace streamsx::topology;
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
    pyop_(NULL),
-   pyInNames_(NULL)
+   pyInNames_(NULL),
+   pyOutNames_0(NULL)
 {
    PyObject * callable;
 @include  "../../opt/.__splpy/common/py_constructor.cgt"
    
    {
       SplpyGIL lock;
-      PyObject * pyOutNames = Splpy::pyAttributeNames(getOutputPortAt(0));
+      pyOutNames_0 = Splpy::pyAttributeNames(getOutputPortAt(0));
+
+#if 0
 
      // Now create the wrapper function that converts
      // other types returned by the user's function
@@ -61,7 +66,8 @@ MY_OPERATOR::MY_OPERATOR() :
      // simplify the generated code.
      callable = SplpyGeneral::callFunction(
              "streamsx.spl.runtime", "_splpy_to_tuples",
-             callable, pyOutNames);   
+             callable, pyOutNames_0);   
+#endif
 
 <% if ($paramStyle eq 'dictionary') { %>
       pyInNames_ = Splpy::pyAttributeNames(
@@ -79,6 +85,8 @@ MY_OPERATOR::~MY_OPERATOR()
    SplpyGIL lock;
    if (pyInNames_)
       Py_DECREF(pyInNames_);
+   if (pyOutNames_0)
+      Py_DECREF(pyOutNames_0);
    }
 
    delete pyop_;

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
@@ -36,9 +36,11 @@ private:
     SplpyPyOp *pyop_;
 
     PyObject *pyInNames_;
+    PyObject *pyOutNames_0;
 
     void pySubmitTuplesPort0(PyObject * value, <%=$iport->getCppTupleType()%> const & ituple);
     void fromPythonToPort0(PyObject * pyTuple, <%=$iport->getCppTupleType()%> const & ituple);
+    void fromPythonDictToPort0(PyObject * pyDict, <%=$iport->getCppTupleType()%> const & ituple);
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -22,6 +22,7 @@ using namespace streamsx::topology;
  spl_pip_packages($model, \@packages);
 
  my $iport;
+ my $FROM_DICT_TMP = 1;
  
   my $oport = $model->getOutputPortAt(0);
   my $otupleType = $oport->getSPLTupleType();
@@ -31,7 +32,8 @@ using namespace streamsx::topology;
 
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
-   pyop_(NULL)
+   pyop_(NULL),
+   pyOutNames_0(NULL)
 {
    PyObject * callable;
 @include  "../../opt/.__splpy/common/py_constructor.cgt"
@@ -45,8 +47,9 @@ MY_OPERATOR::MY_OPERATOR() :
              "streamsx.spl.runtime", "_splpy_iter_source",
              callable, NULL);   
 
-     PyObject *pyOutNames = Splpy::pyAttributeNames(getOutputPortAt(0));
+     pyOutNames_0 = Splpy::pyAttributeNames(getOutputPortAt(0));
 
+#if 0
      // Now create the wrapper function that converts
      // other types returned by the user's function
      // (e.g. dictionaries) to Python tuples as the
@@ -55,6 +58,7 @@ MY_OPERATOR::MY_OPERATOR() :
      callable = SplpyGeneral::callFunction(
              "streamsx.spl.runtime", "_splpy_to_tuples",
              callable, pyOutNames);   
+#endif
 
      pyop_->setCallable(callable);
    }
@@ -63,6 +67,11 @@ MY_OPERATOR::MY_OPERATOR() :
 // Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {
+   {
+   SplpyGIL lock;
+   if (pyOutNames_0)
+      Py_DECREF(pyOutNames_0);
+   }
    delete pyop_;
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
@@ -34,9 +34,11 @@ public:
 private:
   // Members
     SplpyPyOp *pyop_;
+    PyObject *pyOutNames_0;
 
     void pySubmitTuplesPort0(PyObject * value);
     void fromPythonToPort0(PyObject * pyTuple);
+    void fromPythonDictToPort0(PyObject * pyDict);
 
 }; 
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -20,6 +20,8 @@ using namespace streamsx::topology;
 
  my $module = splpy_Module();
  my $functionName = splpy_FunctionName();
+
+ my $FROM_DICT_TMP = 1;
 %>
 
 // Constructor
@@ -31,6 +33,9 @@ MY_OPERATOR::MY_OPERATOR() :
 <%  for (my $p = 1; $p < $model->getNumberOfInputPorts(); $p++) { %>
     , pyInNames_<%=$p%>(NULL)
 <%}}%>
+<%  for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) { %>
+    , pyOutNames_<%=$p%>(NULL)
+<%}%>
 {
    PyObject * callable;
 @include  "../../opt/.__splpy/common/py_constructor.cgt"
@@ -68,6 +73,11 @@ if ($paramStyle eq 'dictionary') { %>
       pyInNames_<%=$ppn%> = streamsx::topology::Splpy::pyAttributeNames(
                getInputPortAt(<%=$p%>));
 <%}}%>
+
+<% for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) { %>
+    pyOutNames_<%=$p%> = streamsx::topology::Splpy::pyAttributeNames(
+               getOutputPortAt(<%=$p%>));
+<%}%>
 
    // callFunction takes a reference.
    Py_INCREF(callable);

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -28,12 +28,6 @@ public:
 private:
     SplpyPyOp *pyop_;
 
-<% for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) {
-    my $oport = $model->getOutputPortAt($p);
-%>
-  void pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject * value);
-  void fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple);
-<%}%>
 
 
 <%if ($model->getNumberOfInputPorts() != 0) {%>
@@ -42,6 +36,15 @@ private:
 <%  for (my $p = 1; $p < $model->getNumberOfInputPorts(); $p++) { %>
     PyObject *pyInNames_<%=$p%>;
 <%}}%>
+
+<% for (my $p = 0; $p < $model->getNumberOfOutputPorts(); $p++) {
+    my $oport = $model->getOutputPortAt($p);
+%>
+  PyObject *pyOutNames_<%=$oport->getIndex()%>;
+  void pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject * value);
+  void fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple);
+  void fromPythonDictToPort<%=$oport->getIndex()%>(PyObject *pyDict);
+<%}%>
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/test/python/spl/tests/test_types.py
+++ b/test/python/spl/tests/test_types.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 from builtins import *
 
+import copy
 import unittest
 import sys
 import itertools
@@ -108,20 +109,52 @@ class TestTypes(unittest.TestCase):
         """Simple test of returning values from a map."""
         topo = Topology()
         streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
-        s = topo.source(itertools.range(5))
+        s = topo.source(range(20))
         s = s.map(lambda v : (v,), schema='tuple<int32 val>')
 
         values = op.Map(
             "com.ibm.streamsx.topology.pytest.pytypes::MapReturnValues",
             s, 'tuple<rstring how, int32 val>')
 
-        expected = [
-            {'how': 'astuple', 'val':823},
-            {'how': 'aspartialtuple', 'val':2},
-            {'how': '', 'val':3},
-            {'how': 'asdict', 'val':234},
-            ]
+
+        tester = Tester(topo)
+        tester.contents(values.stream, MRV_EXPECTED)
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_source_return(self):
+        """Simple test of returning values from a source operator."""
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+
+        values = op.Source(
+            topo,
+            kind="com.ibm.streamsx.topology.pytest.pytypes::SourceReturnValues",
+            schema='tuple<rstring how, int32 val>')
+
+        expected = copy.deepcopy(MRV_EXPECTED)
+        # no assignment from input tuple so all automatically
+        # assigned values will be zero
+        for d in expected:
+            if d['val'] < 100:
+                d['val'] = 0
 
         tester = Tester(topo)
         tester.contents(values.stream, expected)
         tester.test(self.test_ctxtype, self.test_config)
+
+MRV_EXPECTED = [
+    {'how': 'astuple', 'val':823},
+    {'how': 'aspartialtuple', 'val':2},
+    {'how': '', 'val':3},
+    {'how': 'asdict', 'val':234},
+    {'how': 'aspartialdict1', 'val':5},
+    {'how': 'aspartialdict2', 'val':6},
+    {'how': '', 'val':7},
+    {'how': '', 'val':10},
+    {'how': '', 'val':10},
+    {'how': '', 'val':10},
+    {'how': 'listtuple', 'val':494},
+    {'how': 'listdict', 'val':863},
+    {'how': 'listpartialtuple', 'val':12},
+    {'how': 'listpartialdict', 'val':12},
+    ]

--- a/test/python/spl/tests/test_types.py
+++ b/test/python/spl/tests/test_types.py
@@ -16,8 +16,8 @@ import streamsx.spl.op as op
 import streamsx.spl.toolkit
 import streamsx.scripts.extract
 
-class TestBlobs(unittest.TestCase):
-    """ Test blobs in decorated operators.
+class TestTypes(unittest.TestCase):
+    """ Type tests.
     """
     @classmethod
     def setUpClass(cls):
@@ -101,4 +101,27 @@ class TestBlobs(unittest.TestCase):
          
         tester = Tester(topo)
         tester.contents(bt.stream, data)
+        tester.test(self.test_ctxtype, self.test_config)
+
+
+    def test_map_return(self):
+        """Simple test of returning values from a map."""
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, '../testtkpy')
+        s = topo.source(itertools.range(5))
+        s = s.map(lambda v : (v,), schema='tuple<int32 val>')
+
+        values = op.Map(
+            "com.ibm.streamsx.topology.pytest.pytypes::MapReturnValues",
+            s, 'tuple<rstring how, int32 val>')
+
+        expected = [
+            {'how': 'astuple', 'val':823},
+            {'how': 'aspartialtuple', 'val':2},
+            {'how': '', 'val':3},
+            {'how': 'asdict', 'val':234},
+            ]
+
+        tester = Tester(topo)
+        tester.contents(values.stream, expected)
         tester.test(self.test_ctxtype, self.test_config)

--- a/test/python/spl/testtkpy/opt/python/streams/test_types.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_types.py
@@ -127,3 +127,19 @@ class MapBlobTest(object):
         if sys.version_info.major == 2:
             v = v.tobytes()
         return str(v, encoding='utf-8'),
+
+
+@spl.map()
+def MapReturnValues(*t):
+    """Simple test of returning values from a map."""
+    if t[0] == 0:
+        return None
+    if t[0] == 1:
+        return 'astuple', 823
+    if t[0] == 2:
+        return 'aspartialtuple', None
+    if t[0] == 3:
+        return ()
+    if t[0] == 4:
+        return {'how': 'asdict', 'val':234}
+    return None

--- a/test/python/spl/testtkpy/opt/python/streams/test_types.py
+++ b/test/python/spl/testtkpy/opt/python/streams/test_types.py
@@ -128,18 +128,28 @@ class MapBlobTest(object):
             v = v.tobytes()
         return str(v, encoding='utf-8'),
 
+MRV = [
+    None,
+    ('astuple', 823),
+    ('aspartialtuple', None),
+    (),
+    {'how': 'asdict', 'val':234},
+    {'how': 'aspartialdict1', 'val':None},
+    {'how': 'aspartialdict2'},
+    {},
+    [],
+    [None,None,None],
+    [(), None, {}, {}],
+    [('listtuple', 494), {'how':'listdict', 'val':863}],
+    [('listpartialtuple',None), {'how':'listpartialdict'}],
+    ]
 
 @spl.map()
 def MapReturnValues(*t):
     """Simple test of returning values from a map."""
-    if t[0] == 0:
-        return None
-    if t[0] == 1:
-        return 'astuple', 823
-    if t[0] == 2:
-        return 'aspartialtuple', None
-    if t[0] == 3:
-        return ()
-    if t[0] == 4:
-        return {'how': 'asdict', 'val':234}
-    return None
+    idx = t[0]
+    return MRV[idx] if idx < len(MRV) else None
+
+@spl.source()
+def SourceReturnValues():
+    return iter(MRV)


### PR DESCRIPTION
See #1543 

For `@spl.map` and `@spl.source` the decorated callable is now called directly and all conversion of the Python object representing the tuple is handled in CCGT/C++ code.

Previously the CGT/C++ code only supported `tuple` or `list[tuple]` so any `dict` object was first converted to a `tuple` using a wrapper function.

Now a `fromPythonDictToSPLTupleN` method is created in the operator and used when the returned value is a `dict` or the value in the returned `list` is a `dict`.

A minor optimization is handled for `dict` to try avoid the cost of too many dict lookups, basically once N items have been taken from the `dict` where N is the size of the `dict` then no more lookups are performed as we have taken all the values.