### PR TITLE
Test fixes.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -187,7 +187,10 @@ class Tester(object):
             raise unittest.SkipTest("Skipped due to STREAMS_DOMAIN_ID environment variable not set")
 
         test.test_ctxtype = stc.ContextTypes.DISTRIBUTED
-        test.test_config = {}
+        if hasattr(test, "username") and hasattr(test, "password"):
+            test.test_config = {'username' : test.username, 'password' : test.password}
+        else:
+            test.test_config = {}
 
     @staticmethod
     def setup_streaming_analytics(test, service_name=None, force_remote_build=False):
@@ -484,7 +487,10 @@ class Tester(object):
         if stc.ContextTypes.STANDALONE == ctxtype:
             passed = self._standalone_test(config)
         elif stc.ContextTypes.DISTRIBUTED == ctxtype:
-            passed = self._distributed_test(config, username, password)
+            if 'username' in config and 'password' in config:
+                passed = self._distributed_test(config, config['username'], config['password'])
+            else:
+                passed = self._distributed_test(config, username, password)
         elif stc.ContextTypes.STREAMING_ANALYTICS_SERVICE == ctxtype or stc.ContextTypes.ANALYTICS_SERVICE == ctxtype:
             passed = self._streaming_analytics_test(ctxtype, config)
         else:

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTopicNames.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/PublishSubscribeTopicNames.java
@@ -24,7 +24,7 @@ public class PublishSubscribeTopicNames extends TestTopology {
        
         t.strings().publish((String) null, true);
     }
-    @Test(expected=NullPointerException.class)
+    @Test(expected=IllegalStateException.class)
     public void testNullTopicNameParam() throws Exception {
         final Topology t = new Topology();
        
@@ -77,7 +77,7 @@ public class PublishSubscribeTopicNames extends TestTopology {
     public void testNullTopicFilter() throws Exception {
         new Topology().subscribe((String) null, String.class);
     }
-    @Test(expected=NullPointerException.class)
+    @Test(expected=IllegalStateException.class)
     public void testNullTopicFilterParam() throws Exception {
         new Topology().subscribe((Supplier<String>) null, String.class);
     }

--- a/test/python/pubsub/json_filter_json.py
+++ b/test/python/pubsub/json_filter_json.py
@@ -19,6 +19,9 @@ def main():
   # Verify that autonomous can be called from Python
   ts = ts.autonomous()
 
+  # stream must be placeable
+  ts = ts.filter(lambda x: True)
+
   ts.publish("pytest/json/filter/result", schema=CommonSchema.Json)
 
   config = {}

--- a/test/python/pubsub/spl_map_json.py
+++ b/test/python/pubsub/spl_map_json.py
@@ -20,6 +20,9 @@ def main():
 
   ts = ts.isolate().map(pytest_funcs.remove_complex).isolate()
   ts = ts.map(pytest_funcs.change_set_to_list).isolate()
+  
+  # stream must be placeable to publish
+  ts = ts.filter(lambda x: True)
 
   ts.publish("pytest/spl/map/result", schema=CommonSchema.Json)
 


### PR DESCRIPTION
This PR contains 3 fixes to our unit tests:

1) We were incorrectly checking to see whether the `username` and `password` were set in a test class.

2) Two tests in `publishSubscibeTopicNames` were throwing IllegalStateExceptions instead of NullPointerExceptions.

3) The PublishSubscribeTopicNames tests were failing because the python apps they use were attempting to publish streams that were non-placeable.