### PR TITLE
Ensure HashAdder has correct serializer.

### DIFF
--- a/java/execute/src/com/ibm/streamsx/topology/internal/functional/ops/HashAdder.java
+++ b/java/execute/src/com/ibm/streamsx/topology/internal/functional/ops/HashAdder.java
@@ -17,6 +17,7 @@ import com.ibm.streams.operator.model.InputPortSet;
 import com.ibm.streams.operator.model.InputPorts;
 import com.ibm.streams.operator.model.OutputPortSet;
 import com.ibm.streams.operator.model.OutputPorts;
+import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
 import com.ibm.streamsx.topology.function.ToIntFunction;
 import com.ibm.streamsx.topology.internal.spljava.SPLMapping;
@@ -35,6 +36,13 @@ public class HashAdder extends FunctionFunctor {
 
     protected SPLMapping<Object> mapping;
     protected StreamingOutput<OutputTuple> output;
+    
+    private String inputSerializer;
+    
+    @Parameter(optional=true)
+    public void setInputSerializer(String inputSerializer) {
+        this.inputSerializer = inputSerializer;
+    }
 
     @Override
     public void initialize(OperatorContext context)
@@ -44,7 +52,7 @@ public class HashAdder extends FunctionFunctor {
         hasher = getLogicObject(getFunctionalLogic());
 
         output = getOutput(0);
-        mapping = getInputMapping(this, 0);
+        mapping = getInputMapping(this, 0, inputSerializer);
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
+++ b/java/src/com/ibm/streamsx/topology/builder/BOperatorInvocation.java
@@ -182,6 +182,16 @@ public class BOperatorInvocation extends BOperator {
         
         jparams.add(name, param);
     }
+    
+    /**
+     * Get the raw value for a parameter for this operator invocation.
+     * @return Json representation of parameter or null if the parameter is not set.
+     */
+    public JsonObject getRawParameter(String name) {
+        if (jparams.has(name))
+            return jparams.getAsJsonObject(name);
+        return null;             
+    }
 
     public BOutputPort addOutput(String schema) {
         return addOutput(schema, Optional.empty());

--- a/java/src/com/ibm/streamsx/topology/internal/core/DependencyResolver.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/DependencyResolver.java
@@ -163,6 +163,19 @@ public class DependencyResolver {
             operatorToJarDependencies.get(op).add(absolutePath);
         }
     }
+
+    /**
+     * Copy dependencies from one operator to another.
+     */
+    public void copyDependencies(BOperatorInvocation source, BOperatorInvocation op) {
+        if (operatorToJarDependencies.containsKey(source)) {
+            Set<Path> sourceDeps = operatorToJarDependencies.get(source);
+            if (!operatorToJarDependencies.containsKey(op))
+               operatorToJarDependencies.put(op, new HashSet<>());
+                            
+            operatorToJarDependencies.get(op).addAll(sourceDeps);
+        }
+    }
     
     /**
      * Add a file dependency {@code location} to be 

--- a/java/src/com/ibm/streamsx/topology/internal/core/JavaFunctional.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/JavaFunctional.java
@@ -172,6 +172,15 @@ public class JavaFunctional {
     }
     
     /**
+     * Copy dependencies from one operator to another.
+     */
+    public static void copyDependencies(TopologyElement te,
+            BOperatorInvocation source,
+            BOperatorInvocation op) {
+        te.topology().getDependencyResolver().copyDependencies(source, op);
+    }
+    
+    /**
      * Simple check of the fields in the serializable logic
      * to ensure that all non-transient field are serializable. 
      * @param logic

--- a/java/src/com/ibm/streamsx/topology/spi/builder/Invoker.java
+++ b/java/src/com/ibm/streamsx/topology/spi/builder/Invoker.java
@@ -58,13 +58,18 @@ public interface Invoker {
         
         parameters = copyParameters(parameters);
 
-        if (outputSerializer != null)
+        if (outputSerializer != null) {
             parameters.put("outputSerializer", serializeLogic(outputSerializer));
+        }
 
         BOperatorInvocation source = JavaFunctional.addFunctionalOperator(topology,
                 jstring(invokeInfo, "name"),
                 kind,
                 logic, parameters);
+        
+        if (outputSerializer != null) {
+            JavaFunctional.addDependency(topology, source, outputSerializer.getClass());
+        }
 
         // Extract any source location information from the config.
         SourceInfo.setInvocationInfo(source, invokeInfo);
@@ -142,6 +147,13 @@ public interface Invoker {
                 jstring(invokeInfo, "name"),
                 kind,
                 logic, parameters);
+        
+        if (inputSerializer != null) {
+            JavaFunctional.addDependency(stream, pipe, inputSerializer.getClass());
+        }
+        if (outputSerializer != null) {
+            JavaFunctional.addDependency(stream, pipe, outputSerializer.getClass());
+        }
 
         // Extract any source location information from the config.
         SourceInfo.setInvocationInfo(pipe, invokeInfo);
@@ -211,6 +223,17 @@ public interface Invoker {
                 jstring(invokeInfo, "name"),
                 kind,
                 logic, parameters);
+        
+        if (inputSerializers != null) {
+            for (TupleSerializer serializer : inputSerializers)
+                if (serializer != null)
+                    JavaFunctional.addDependency(te, primitive, serializer.getClass());
+        }
+        if (outputSerializers != null) {
+            for (TupleSerializer serializer : outputSerializers)
+                if (serializer != null)
+                    JavaFunctional.addDependency(te, primitive, serializer.getClass());
+        }
 
         // Extract any source location information from the config.
         SourceInfo.setInvocationInfo(primitive, invokeInfo);

--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -107,6 +107,8 @@
 
   <target name="test.toolkit">
     <mkdir dir="${testtk.java}/bin"/>
+    <mkdir dir="${testtk.java}/lib"/>
+    <copy file="${topology.toolkit.jar}" todir="${testtk.java}/lib"/>
     <javac debug="true"
    	   srcdir="${testtk.java}/src"
    	   destdir="${testtk.java}/bin"

--- a/test/java/src/com/ibm/streamsx/topology/test/spi/InvokerTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/spi/InvokerTest.java
@@ -2,6 +2,7 @@ package com.ibm.streamsx.topology.test.spi;
 
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,6 +18,7 @@ import org.junit.Test;
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.TStream.Routing;
+import com.ibm.streamsx.topology.context.StreamsContext;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.function.Consumer;
 import com.ibm.streamsx.topology.function.Supplier;
@@ -30,6 +32,13 @@ import com.ibm.streamsx.topology.tester.Condition;
 import com.ibm.streamsx.topology.tester.Tester;
 
 public class InvokerTest extends TestTopology {
+    
+    // TEMP -  move to TestTopology
+    private void checkUdpSupported() {
+        assumeTrue(SC_OK);
+        assumeTrue(getTesterType() == StreamsContext.Type.STANDALONE_TESTER ||
+                getTesterType() == StreamsContext.Type.DISTRIBUTED_TESTER);
+    }
     
     public static class ByteSerializer implements TupleSerializer {
 
@@ -128,6 +137,8 @@ public class InvokerTest extends TestTopology {
     
     @Test
     public void testParallelHashSerializers() throws Exception {
+        
+        checkUdpSupported();
 
         Topology topology = newTopology();
         SPL.addToolkit(topology, new File(getTestRoot(), "spl/testtk"));

--- a/test/java/src/com/ibm/streamsx/topology/test/spi/InvokerTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/spi/InvokerTest.java
@@ -1,0 +1,181 @@
+package com.ibm.streamsx.topology.test.spi;
+
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+import com.ibm.streamsx.topology.TStream;
+import com.ibm.streamsx.topology.TStream.Routing;
+import com.ibm.streamsx.topology.Topology;
+import com.ibm.streamsx.topology.function.Consumer;
+import com.ibm.streamsx.topology.function.Supplier;
+import com.ibm.streamsx.topology.internal.core.JavaFunctionalOps;
+import com.ibm.streamsx.topology.spi.builder.Invoker;
+import com.ibm.streamsx.topology.spi.runtime.TupleSerializer;
+import com.ibm.streamsx.topology.spl.SPL;
+import com.ibm.streamsx.topology.streams.StringStreams;
+import com.ibm.streamsx.topology.test.TestTopology;
+import com.ibm.streamsx.topology.tester.Condition;
+import com.ibm.streamsx.topology.tester.Tester;
+
+public class InvokerTest extends TestTopology {
+    
+    public static class ByteSerializer implements TupleSerializer {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void serialize(Object tuple, OutputStream output) throws IOException {
+            output.write(((Byte) tuple).byteValue());       
+        }
+
+        @Override
+        public Object deserialize(InputStream input) throws IOException, ClassNotFoundException {
+            return Byte.valueOf((byte) input.read());
+        }    
+    }
+
+    public static class ByteData implements Supplier<Iterable<Byte>> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Iterable<Byte> get() {
+            List<Byte> data = new ArrayList<>();
+            data.add((byte) 1);
+            data.add((byte) 17);
+            data.add((byte) 93);
+            data.add((byte) -43);
+            return data;
+        }
+        
+    }
+    
+
+    public static class ByteAdder implements Consumer<Byte>, Function<Object,Object> {
+        private static final long serialVersionUID = 1L;
+        
+        private final int delta;
+        
+        public ByteAdder(int delta) {
+            this.delta = delta;
+        }
+        
+        private Consumer<Object> submitter;
+        @SuppressWarnings("unchecked")
+        @Override
+        public Object apply(Object submitter) {
+            this.submitter = (Consumer<Object>) submitter;
+            return this;
+        }   
+        
+        @Override
+        public void accept(Byte v) {
+            submitter.accept(new Byte((byte)(v + delta)));   
+        }      
+    }
+       
+    //@Test
+    public void testSource2PipeSerializers() throws Exception {
+
+        Topology topology = newTopology();
+        SPL.addToolkit(topology, new File(getTestRoot(), "spl/testtk"));
+        
+        JsonObject sname = new JsonObject();
+        sname.addProperty("name", "S");
+        TStream<Byte> s = Invoker.invokeSource(topology, JavaFunctionalOps.SOURCE_KIND,
+                sname,
+                new ByteData(), Byte.class, new ByteSerializer(), null);
+        
+        s = s.isolate();
+        
+        JsonObject pname = new JsonObject();
+        pname.addProperty("name", "P");
+        @SuppressWarnings("unchecked")
+        TStream<Byte> sp = (TStream<Byte>) Invoker.invokePipe(
+                "testjava::MyPipe",
+                s,
+                pname,
+                new ByteAdder(72), Byte.class,
+                new ByteSerializer(), null,
+                null);
+        
+        sp = sp.isolate();
+         
+        TStream<String> ss = StringStreams.toString(sp);
+        sp.print();
+        
+        Tester tester = topology.getTester();
+        
+        Condition<List<String>> contents = tester.stringContents(ss, "73", "89", "-91", "29");
+        
+        Condition<Long> count = tester.tupleCount(ss, 4);
+
+        complete(topology.getTester(), count, 10, TimeUnit.SECONDS);
+        assertTrue(count.valid());
+        assertTrue(contents.valid());
+    }
+    
+    @Test
+    public void testParallelHashSerializers() throws Exception {
+
+        Topology topology = newTopology();
+        SPL.addToolkit(topology, new File(getTestRoot(), "spl/testtk"));
+        
+        JsonObject sname = new JsonObject();
+        sname.addProperty("name", "S");
+        TStream<Byte> s = Invoker.invokeSource(topology, JavaFunctionalOps.SOURCE_KIND,
+                sname,
+                new ByteData(), Byte.class, new ByteSerializer(), null);
+             
+        s = s.parallel(() -> 3, Routing.HASH_PARTITIONED);
+        
+        JsonObject pname = new JsonObject();
+        pname.addProperty("name", "P");
+        @SuppressWarnings("unchecked")
+        TStream<Byte> sp = (TStream<Byte>) Invoker.invokePipe(
+                "testjava::MyPipe",
+                s,
+                pname,
+                new ByteAdder(32), Byte.class,
+                new ByteSerializer(), new ByteSerializer(),
+                null);
+         
+        
+        sp = sp.endParallel();
+        JsonObject fname = new JsonObject();
+        fname.addProperty("name", "F");
+        
+        @SuppressWarnings("unchecked")
+        TStream<Byte> fsp = (TStream<Byte>) Invoker.invokePipe(
+                "testjava::MyPipe",
+                sp,
+                pname,
+                new ByteAdder(0), Byte.class,
+                new ByteSerializer(), null,
+                null);
+        
+        TStream<String> ss = StringStreams.toString(fsp);
+        
+        Tester tester = topology.getTester();
+        
+        Condition<List<String>> contents = tester.stringContentsUnordered(ss, "33", "49", "125", "-11");
+        
+        Condition<Long> count = tester.tupleCount(ss, 4);
+
+        complete(topology.getTester(), count, 10, TimeUnit.SECONDS);
+        assertTrue(count.valid());
+        assertTrue(contents.valid());
+    }
+
+}


### PR DESCRIPTION
Copies the serializer and dependencies from the input to `parallel` to the `HashAdder`.
HashRemover does not need a serializer because it never accesses the Java value of the tuple, only passes it on.

Adds initial tests for Invoker including a `parallel` that has a serializer on input.

Ran the new test in main, distributed and standaloneand `ParallelTest` in standalone & distributed.