### PR TITLE
Remove type information from composite invocation output port.

### DIFF
--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -264,9 +264,6 @@ public class SPLGenerator {
             String inputPortName = GsonUtilities.jstring(end.get("inputs").getAsJsonArray().get(0).getAsJsonObject(), "name");
             
             for(JsonObject parent : getUpstream(end, graph)){
-		String endType = jstring(array(end, "outputs").get(0).getAsJsonObject(), "type");
-		array(opInvocation, "outputs").get(i[0]).getAsJsonObject().addProperty("type", endType);
-
                 
                 GraphUtilities.outputs(parent, output -> {
                     JsonArray conns = array(output, "connections");


### PR DESCRIPTION
This should have been done in #1588, but was accidentally merged before the changes were pushed. 