### PR TITLE
Support nested parallelism and BROADCAST routing in Python.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -855,10 +855,6 @@ class Stream(_placement._Placement, object):
         In other words, a parallel sink is created by calling parallel() and creating a sink operation.
         It is not necessary to invoke end_parallel() on parallel sinks.
         
-        Nested parallelism is not currently supported.
-        A call to parallel() should never be made immediately after another call to parallel() without 
-        having an end_parallel() in between.
-        
         Every call to end_parallel() must have a call to parallel() preceding it.
         
         Args:

--- a/java/src/com/ibm/streamsx/topology/TStream.java
+++ b/java/src/com/ibm/streamsx/topology/TStream.java
@@ -988,19 +988,6 @@ public interface TStream<T> extends TopologyElement, Placeable<TStream<T>>  {
      * It is not necessary to invoke {@link #endParallel()} on parallel sinks.</b>
      * <br><br>
      * Limitations of parallel() are as follows: <br>
-     * Nested parallelism is not currently supported. A call to {@code parallel(...)}
-     * should never be made immediately after another call to {@code parallel(...)} without
-     * having an {@code endParallel()} in between. <br>
-     * <br>
-     * {@code parallel()} should not be invoked immediately after another call to
-     * {@code parallel()}. The following is invalid:
-     * 
-     * <pre>
-     * <code>
-     * myStream.parallel(2).parallel(2);
-     * </pre>
-     * 
-     * </code>
      * 
      * Every call to {@code endParallel()} must have a call to {@code parallel(...)} preceding it. The
      * following is invalid:

--- a/test/python/topology/test2_udp.py
+++ b/test/python/topology/test2_udp.py
@@ -62,6 +62,21 @@ class TestUDP(unittest.TestCase):
   def setUp(self):
       Tester.setup_standalone(self)
 
+  def test_TopologyNestedParallel(self):
+      topo = Topology("test_TopologySetParallel")
+      s = topo.source([1])
+      s = s.parallel(5, routing=Routing.BROADCAST)
+      s = s.parallel(5, routing=Routing.BROADCAST)
+      s = s.map(lambda x: x)
+      s = s.end_parallel()
+      s = s.end_parallel()
+      s.print()
+      
+      tester = Tester(topo)
+      tester.contents(s, [1 for i in range(25)])
+      tester.test(self.test_ctxtype, self.test_config)
+      print(tester.result)
+
   def test_TopologySetParallel(self):
       topo = Topology("test_TopologySetParallel")
       s = topo.source([1])


### PR DESCRIPTION
Routing.broadcast was used to test nested parallelism in Python. I'm intentionally including both in this PR since they are related.