### PR TITLE
Convert float to decimal through string

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
@@ -1,6 +1,6 @@
 /*
 # Licensed Materials - Property of IBM
-# Copyright IBM Corp. 2015,2016
+# Copyright IBM Corp. 2015,2018
 */
 
 /*
@@ -676,13 +676,12 @@ class SplpyExceptionInfo {
         Py_DECREF(tst);
     }
 
+// A float to decimal is coverted through a string which
+// has the nice property of maintaining the expected
+// value rather than the precise value, for example
+// 993.335 is converted as 993.335 rather than
+// 993.3350000000000363797880709171295166015625
 #define SPLPY_PY2DECIMAL(T) \
-    if (PyFloat_Check(value)) { \
-        SPL::float64 f64; \
-        pySplValueFromPyObject(f64, value); \
-        splv = (T) f64; \
-        return; \
-    } \
     if (PyLong_Check(value)) { \
         SPL::int64 i64; \
         pySplValueFromPyObject(i64, value); \

--- a/test/python/topology/test2_spl.py
+++ b/test/python/topology/test2_spl.py
@@ -246,13 +246,13 @@ class TestConversion(unittest.TestCase):
                     expected = [{'a':int(d)} for d in data]
                 elif dt == 'decimal32':
                     ctx = decimal.Context(prec=7, rounding=decimal.ROUND_HALF_EVEN)
-                    expected = [{'a':decimal.Decimal(d).normalize(ctx)} for d in data]
+                    expected = [{'a':decimal.Decimal(str(d)).normalize(ctx)} for d in data]
                 elif dt == 'decimal64':
                     ctx = decimal.Context(prec=16, rounding=decimal.ROUND_HALF_EVEN)
-                    expected = [{'a':decimal.Decimal(d).normalize(ctx)} for d in data]
+                    expected = [{'a':decimal.Decimal(str(d)).normalize(ctx)} for d in data]
                 elif dt == 'decimal128':
                     ctx = decimal.Context(prec=34, rounding=decimal.ROUND_HALF_EVEN)
-                    expected = [{'a':decimal.Decimal(d).normalize(ctx)} for d in data]
+                    expected = [{'a':decimal.Decimal(str(d)).normalize(ctx)} for d in data]
                 elif dt.startswith('complex'):
                     expected = [{'a':complex(d)} for d in data]
                 elif dt == 'timestamp':


### PR DESCRIPTION
`PyFloat_Type` was an undeclared symbol with Python when using decimal SPL types.

Tested with `test2_spl.py` and `PythonFunctionalOperatorsTest.java` which were failing.