### PR TITLE
Low latency regions create a composite annotated with @threading

### DIFF
--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -63,6 +63,7 @@ class OperatorGenerator {
         noteAnnotations(_op, sb);
         categoryAnnotation(_op, sb);
         parallelAnnotation(_op, sb);
+        lowLatencyAnnotation(_op, sb);
         viewAnnotation(_op, sb);
         consistentAnnotation(_op, sb);
         AutonomousRegions.autonomousAnnotation(_op, sb);
@@ -209,6 +210,13 @@ class OperatorGenerator {
         });
     }
 
+    private void lowLatencyAnnotation(JsonObject op, StringBuilder sb){
+        boolean lowLatencyOperator = jboolean(op, "lowLatency");
+        if(lowLatencyOperator){
+            sb.append("@threading(model=manual)\n");
+        }
+    }
+    
     private void parallelAnnotation(JsonObject op, StringBuilder sb) {
         boolean parallel = jboolean(op, "parallelOperator");
         

--- a/java/src/com/ibm/streamsx/topology/generator/spl/PEPlacement.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/PEPlacement.java
@@ -208,10 +208,6 @@ class PEPlacement {
         for (JsonObject llStart : lowLatencyStartOperators) {
             assignLowLatency(llStart);
         }
-
-        // Remove all the markers
-        lowLatencyStartOperators.addAll(findOperatorByKind(END_LOW_LATENCY, graph));
-        GraphUtilities.removeOperators(lowLatencyStartOperators, graph);
     }
 
     @SuppressWarnings("serial")

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -437,6 +437,8 @@ public class SPLGenerator {
         unvisited.push(potentialStart);
         while(unvisited.size() > 0){
             JsonObject op = unvisited.pop();
+            System.out.println(op);
+            System.out.println();
             visited.add(op);
             Set<JsonObject> parents = new HashSet<>(), children = new HashSet<>();
             // Add the op to one of the lists containing the composite's operators
@@ -493,6 +495,8 @@ public class SPLGenerator {
                 // then it means that there are at least two inputs to the end
                 // of the composite.
                 if(kind(op).equals(endKind)){
+                    System.out.println("THE PARENTS ARE");
+                    System.out.println(parents);
                     throw new IllegalStateException("Cannot invoke union() before ending a region.");
                 }
                 

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -437,8 +437,6 @@ public class SPLGenerator {
         unvisited.push(potentialStart);
         while(unvisited.size() > 0){
             JsonObject op = unvisited.pop();
-            System.out.println(op);
-            System.out.println();
             visited.add(op);
             Set<JsonObject> parents = new HashSet<>(), children = new HashSet<>();
             // Add the op to one of the lists containing the composite's operators
@@ -495,8 +493,6 @@ public class SPLGenerator {
                 // then it means that there are at least two inputs to the end
                 // of the composite.
                 if(kind(op).equals(endKind)){
-                    System.out.println("THE PARENTS ARE");
-                    System.out.println(parents);
                     throw new IllegalStateException("Cannot invoke union() before ending a region.");
                 }
                 

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -105,10 +105,9 @@ public class SPLGenerator {
         compStarts.add(BVirtualMarker.PARALLEL.kind());
         compEnds.add(BVirtualMarker.END_PARALLEL.kind());
         
-        // TODO: add support for lowLatency
-        // compOperatorStarts.add(null);
-        // compStarts.add(BVirtualMarker.LOW_LATENCY.kind());
-        // compEnds.add(BVirtualMarker.END_LOW_LATENCY.kind());
+        compOperatorStarts.add(null);
+        compStarts.add(BVirtualMarker.LOW_LATENCY.kind());
+        compEnds.add(BVirtualMarker.END_LOW_LATENCY.kind());
         
 
         // Find composites until there are no more to find.
@@ -404,7 +403,7 @@ public class SPLGenerator {
 
     private JsonObject createLowLatencyCompositeInvocation(JsonObject opDefinition, List<List<JsonObject>> startsEndsAndOperators) {
         JsonObject compositeInvocation = createCompositeInvocation(opDefinition, startsEndsAndOperators);
-        
+        compositeInvocation.addProperty("lowLatency", true);
         return compositeInvocation;
     }
 

--- a/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
+++ b/java/src/com/ibm/streamsx/topology/internal/core/StreamImpl.java
@@ -665,6 +665,9 @@ public class StreamImpl<T> extends TupleContainer<T> implements TStream<T> {
     @Override
     public TStream<T> endLowLatency() {
         BOutput toEndLowLatency = output();
+        if(toEndLowLatency instanceof BUnionOutput){
+            toEndLowLatency = builder().addPassThroughOperator(toEndLowLatency);
+        }
         BOutput endedLowLatency = builder().endLowLatency(toEndLowLatency);
         return addMatchingStream(endedLowLatency);
 

--- a/test/java/src/com/ibm/streamsx/topology/test/api/LowLatencyTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/LowLatencyTest.java
@@ -45,7 +45,6 @@ public class LowLatencyTest extends TestTopology {
     @Test
     public void testSimpleLowLatency() throws Exception{
         assumeTrue(SC_OK);
-        assumeTrue(isMainRun());
         
         Topology topology = newTopology();
 
@@ -61,7 +60,6 @@ public class LowLatencyTest extends TestTopology {
     @Test
     public void testMultipleRegionLowLatency() throws Exception{
         assumeTrue(SC_OK);
-        assumeTrue(isMainRun());
         
         Topology topology = newTopology();
 
@@ -81,7 +79,7 @@ public class LowLatencyTest extends TestTopology {
     
     @Test
     public void testThreadedPort() throws Exception{
-        assumeTrue(isMainRun());
+        assumeTrue(SC_OK);
         
         Topology topology = newTopology();
 
@@ -242,6 +240,7 @@ public class LowLatencyTest extends TestTopology {
      */
     @Test
     public void testSameThread() throws Exception {
+        assumeTrue(SC_OK);
         final int tc = 2000;
         final Topology topology = newTopology("testSameThread");
         final Tester tester = topology.getTester();

--- a/test/java/src/com/ibm/streamsx/topology/test/api/LowLatencyTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/LowLatencyTest.java
@@ -130,7 +130,7 @@ public class LowLatencyTest extends TestTopology {
         
         // assume that if s1.modify and the split().[modify()] are
         // in the same PE, that s1.split() is in the same too
-        TStream<String> s2 = s1.modify(unaryGetPEId());
+        TStream<String> s2 = s1.modify(unaryGetPEId()).endLowLatency();
         
         List<TStream<String>> splits = s1
                 .split(splitWidth, roundRobinSplitter());
@@ -144,7 +144,7 @@ public class LowLatencyTest extends TestTopology {
                         new HashSet<>(splitChResults.subList(1, splitChResults.size())));
         
         /////////////////////////////////////
-        TStream<String> all = splitChFanin.endLowLatency();
+        TStream<String> all = splitChFanin.filter(tup -> true).endLowLatency();
 
         Tester tester = topology.getTester();
         

--- a/test/java/src/com/ibm/streamsx/topology/test/api/LowLatencyTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/LowLatencyTest.java
@@ -144,7 +144,7 @@ public class LowLatencyTest extends TestTopology {
                         new HashSet<>(splitChResults.subList(1, splitChResults.size())));
         
         /////////////////////////////////////
-        TStream<String> all = splitChFanin.filter(tup -> true).endLowLatency();
+        TStream<String> all = splitChFanin.endLowLatency();
 
         Tester tester = topology.getTester();
         


### PR DESCRIPTION
The operators in a low latency region will be added to an SPL composite that gets annotated with `@threading(mode=manual)` to ensure that scheduled ports are not inserted.