### PR TITLE
Add buffered options to Topology.subscribe

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester_runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester_runtime.py
@@ -29,9 +29,6 @@ import unittest
 import logging
 import collections
 import threading
-from streamsx.rest import StreamsConnection
-from streamsx.rest import StreamingAnalyticsConnection
-from streamsx.topology.context import ConfigParams
 import time
 
 class Condition(object):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -201,6 +201,8 @@ except (ImportError,NameError):
 import copy
 import random
 import streamsx._streams._placement as _placement
+import streamsx.spl.op
+import streamsx.spl.types
 import streamsx.topology.graph
 import streamsx.topology.schema
 import streamsx.topology.functions
@@ -291,6 +293,38 @@ class Routing(Enum):
         hash value to other channels and the execution that routed the tuple due to
         being in different processing elements.
     """
+
+class SubscribeConnection(Enum):
+    """Connection mode between a subscriber and matching publishers.
+
+    .. versionadded:: 1.9
+    .. seealso:: :py:meth:`~Topology.subscribe`
+    """
+    Direct = 0
+    """Direct connection between a subscriber and and matching publishers.
+    
+    When connected directly a slow subscriber will cause back-pressure
+    against the publishers, forcing them to slow tuple processing to
+    the slowest publisher.
+    """
+
+    Buffered = 1
+    """Buffered connection between a subscriber and and matching publishers.
+   
+    With a buffered connection tuples from publishers are placed in
+    a single queue owned by the subscriber. This allows a slower
+    subscriber to handle brief spikes in tuples from publishers.
+
+    A subscriber can fully isolate itself from matching publishers
+    by adding a :py:class:`CongestionPolicy` that drops tuples
+    when the queue is full. In this case when the subscriber is
+    not able to keep up with the tuple rate from all matching subscribers
+    it will have a minimal effect on matching publishers.
+    """
+
+    def spl_json(self):
+        """Internal method."""
+        return streamsx.spl.op.Expression.expression('com.ibm.streamsx.topology.topic::' + self.name).spl_json()
 
 class Topology(object):
     """The Topology class is used to define data sources, and is passed as a parameter when submitting an application.
@@ -424,7 +458,7 @@ class Topology(object):
         oport = op.addOutputPort(name=_name)
         return Stream(self, oport)._make_placeable()
 
-    def subscribe(self, topic, schema=streamsx.topology.schema.CommonSchema.Python, name=None):
+    def subscribe(self, topic, schema=streamsx.topology.schema.CommonSchema.Python, name=None, connect=None, buffer_capacity=None, buffer_full_policy=None):
         """
         Subscribe to a topic published by other Streams applications.
         A Streams application may publish a stream to allow other
@@ -445,20 +479,38 @@ class Topology(object):
         A Streams application publishing JSON streams may have been implemented in any programming language
         supported by Streams.
 
+        Subscribers can ensure they do not slow down matching publishers
+        by using a buffered connection with a buffer full policy
+        that drops tuples.
+
         Args:
             topic(str): Topic to subscribe to.
             schema(~streamsx.topology.schema.StreamSchema): schema to subscribe to.
             name(str): Name of the subscribed stream, defaults to a generated name.
+            connect(SubscribeConnection): How subscriber will be connected to matching publishers. Defaults to :py:const:`~SubscribeConnection.Direct` connection.
+            buffer_capacity(int): Buffer capacity in tuples when `connect` is set to :py:const:`~SubscribeConnection.Buffered`. Defaults to 1000 when `connect` is `Buffered`. Ignored when `connect` is `None` or `Direct`.
+            buffer_full_policy(~streamsx.types.CongestionPolicy): Policy when a pulished tuple arrives and the subscriber's buffer is full. Defaults to `Wait` when `connect` is `Buffered`. Ignored when `connect` is `None` or `Direct`.
 
         Returns:
             Stream:  A stream whose tuples have been published to the topic by other Streams applications.
+
+        .. versionchanged:: 1.9 `connect`, `buffer_capacity` and `buffer_full_policy` parameters added.
+
+        .. seealso:`SubscribeConnection`
         """
         _name = self.graph._requested_name(name, 'subscribe')
         sl = _SourceLocation(_source_info(), "subscribe")
         op = self.graph.addOperator(kind="com.ibm.streamsx.topology.topic::Subscribe", sl=sl, name=_name)
         oport = op.addOutputPort(schema=schema, name=_name)
-        subscribeParams = {'topic': topic, 'streamType': schema}
-        op.setParameters(subscribeParams)
+        params = {'topic': topic, 'streamType': schema}
+        if connect is not None and connect != SubscribeConnection.Direct:
+            params['connect'] = connect
+            if buffer_capacity:
+                params['bufferCapacity'] = int(buffer_capacity)
+            if buffer_full_policy:
+                params['bufferFullPolicy'] = buffer_full_policy
+            
+        op.setParameters(params)
         op._layout_group('Subscribe', name if name else _name)
         return Stream(self, oport)._make_placeable()
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.pyi
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.pyi
@@ -7,6 +7,7 @@ from enum import Enum
 import datetime
 
 from streamsx.topology.schema import _AnySchema
+import streamsx.types
 
 _StreamWindow = Union[Stream, Window]
 
@@ -16,12 +17,17 @@ class Routing(Enum):
     HASH_PARTITIONED=3
 
 
+class SubscribeConnection(Enum):
+    Direct = 0
+    Buffered = 1
+
+
 class Topology(object):
     def __init__(self, name: str=None, namespace: str=None, files: Any=None) -> None: ...
     def source(self, func : Union[Callable[[], Any],Iterable[Any]], name: str =None) -> Stream: ...
     def name(self) -> str: ...
     def namespace(self) -> str: ...
-    def subscribe(self, topic: str, schema: _AnySchema=None, name: str=None) -> Stream: ...
+    def subscribe(self, topic: str, schema: _AnySchema=None, name: str=None, connect: SubscribeConnection=None, buffer_capacity: int=None, buffer_full_policy: streamsx.types.CongestionPolicy=None) -> Stream: ...
     def add_file_dependency(self, path: str, location: str) -> str: ...
     def add_pip_package(self, requirement: str) -> None: ...
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/types.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/types.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2018
+"""
+Types used within IBM Streams and Streaming Analytics service.
+"""
+
+from enum import Enum
+
+import streamsx.spl.op
+
+class _SysEnum(Enum):
+    """Super class for an Enum that maps to a enum in the
+    spl.Sys composite from the standard toolkit.
+    """
+    def spl_json(self):
+        return streamsx.spl.op.Expression.expression('Sys.' + self.name).spl_json()
+
+class CongestionPolicy(_SysEnum):
+    """Congestion policy for a threaded port's queue.
+
+    .. versionadded:: 1.9
+    """
+    Wait = 0
+    """When a tuple is to be added into a full queue the thread
+    waits until space exists in the queue.
+    """
+    DropFirst = 1
+    """When a tuple is to be added into a full queue the oldest tuple
+    (first inserted) is dropped (discarded) and the newly arrived
+    tuple inserted into the queue.
+    """
+    DropLast = 2
+    """When a tuple is to be added into a queue and it is full
+    the tuple is dropped (discarded).
+    """
+


### PR DESCRIPTION
Part of #529 

Passed all Python topology tests and python tests under test/java.