### PR TITLE
Don't ignore testParallelPreFanOut in ParallelTest.java

### DIFF
--- a/test/java/src/com/ibm/streamsx/topology/test/api/ParallelTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/ParallelTest.java
@@ -684,7 +684,6 @@ public class ParallelTest extends TestTopology {
     }
 
     @Test
-    @Ignore("Issue #131")
     public void testParallelPreFanOut() throws Exception {
         Topology topology = newTopology();
         


### PR DESCRIPTION
#131 no longer causes this test to fail.