### PR TITLE
Exception safety fix in Source_cpp.cgt.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
@@ -70,8 +70,10 @@ void MY_OPERATOR::process(uint32_t idx)
 
     { // start lock
       SplpyGIL lock;
-      if (pyReturnVar != NULL)
+      if (pyReturnVar != NULL) {
           Py_DECREF(pyReturnVar);
+          pyReturnVar = NULL;
+      }
 
       pyReturnVar = PyObject_CallObject(funcop_->callable(), NULL);
 


### PR DESCRIPTION
In the main tuple-generation loop in Source_cpp.cgt, there is a potential exception safety issue.  The call to Python_CallObject can throw an exception.  In that case, the value of pyReturnVar will not be changed.  There is an exception handler that I think in some cases will handle the exception and allow the while loop to continue.  The next time around the while loop, pyReturnVar will have its reference count decremented a second time.  To prevent this I zero the value of pyReturnVar after the first time it it is DECREFed.