### PR TITLE
Added the pyStateful parameter to python topology operators.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate.xml
@@ -100,9 +100,9 @@
       <parameter>
         <name>pyStateful</name>
         <description>Whether the operator has state to be saved in checkpointing.</description>
-        <optional>true</optional>
+        <optional>false</optional>
         <rewriteAllowed>true</rewriteAllowed>
-        <expressionMode>AttributeFree</expressionMode>
+        <expressionMode>Constant</expressionMode>
         <type>boolean</type>
         <cardinality>1</cardinality>
       </parameter>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate.xml
@@ -97,6 +97,15 @@
         <type>int32</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>pyStateful</name>
+        <description>Whether the operator has state to be saved in checkpointing.</description>
+        <optional>true</optional>
+        <rewriteAllowed>true</rewriteAllowed>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter.xml
@@ -109,9 +109,9 @@
       <parameter>
        <name>pyStateful</name>
         <description>Whether the operator has state to be saved in checkpointing.</description>
-        <optional>true</optional>
+        <optional>false</optional>
         <rewriteAllowed>true</rewriteAllowed>
-        <expressionMode>AttributeFree</expressionMode>
+        <expressionMode>Constant</expressionMode>
         <type>boolean</type>
         <cardinality>1</cardinality>
       </parameter>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter.xml
@@ -106,6 +106,15 @@
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+       <name>pyStateful</name>
+        <description>Whether the operator has state to be saved in checkpointing.</description>
+        <optional>true</optional>
+        <rewriteAllowed>true</rewriteAllowed>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap.xml
@@ -109,9 +109,9 @@
       <parameter>
        <name>pyStateful</name>
         <description>Whether the operator has state to be saved in checkpointing.</description>
-         <optional>true</optional>
+        <optional>false</optional>
         <rewriteAllowed>true</rewriteAllowed>
-        <expressionMode>AttributeFree</expressionMode>
+        <expressionMode>Constant</expressionMode>
         <type>boolean</type>
         <cardinality>1</cardinality>
       </parameter>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap.xml
@@ -106,6 +106,15 @@
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+       <name>pyStateful</name>
+        <description>Whether the operator has state to be saved in checkpointing.</description>
+         <optional>true</optional>
+        <rewriteAllowed>true</rewriteAllowed>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach.xml
@@ -81,9 +81,9 @@
       <parameter>
        <name>pyStateful</name>
         <description>Whether the operator has state to be saved in checkpointing.</description>
-         <optional>true</optional>
+        <optional>false</optional>
         <rewriteAllowed>true</rewriteAllowed>
-        <expressionMode>AttributeFree</expressionMode>
+        <expressionMode>Constant</expressionMode>
         <type>boolean</type>
         <cardinality>1</cardinality>
       </parameter>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach.xml
@@ -79,6 +79,15 @@
         <cardinality>1</cardinality>
       </parameter>
       <parameter>
+       <name>pyStateful</name>
+        <description>Whether the operator has state to be saved in checkpointing.</description>
+         <optional>true</optional>
+        <rewriteAllowed>true</rewriteAllowed>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
         <name>submissionParamNames</name>
         <description>Submission parameter names</description>
         <optional>true</optional>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder.xml
@@ -84,9 +84,9 @@
       <parameter>
        <name>pyStateful</name>
         <description>Whether the operator has state to be saved in checkpointing.</description>
-         <optional>true</optional>
+        <optional>false</optional>
         <rewriteAllowed>true</rewriteAllowed>
-        <expressionMode>AttributeFree</expressionMode>
+        <expressionMode>Constant</expressionMode>
         <type>boolean</type>
         <cardinality>1</cardinality>
       </parameter>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder.xml
@@ -82,6 +82,15 @@
         <cardinality>1</cardinality>
       </parameter>
       <parameter>
+       <name>pyStateful</name>
+        <description>Whether the operator has state to be saved in checkpointing.</description>
+         <optional>true</optional>
+        <rewriteAllowed>true</rewriteAllowed>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
         <name>submissionParamNames</name>
         <description>Submission parameter names</description>
         <optional>true</optional>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map.xml
@@ -109,9 +109,9 @@
       <parameter>
        <name>pyStateful</name>
         <description>Whether the operator has state to be saved in checkpointing.</description>
-         <optional>true</optional>
+        <optional>false</optional>
         <rewriteAllowed>true</rewriteAllowed>
-        <expressionMode>AttributeFree</expressionMode>
+        <expressionMode>Constant</expressionMode>
         <type>boolean</type>
         <cardinality>1</cardinality>
       </parameter>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map.xml
@@ -106,6 +106,15 @@
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+       <name>pyStateful</name>
+        <description>Whether the operator has state to be saved in checkpointing.</description>
+         <optional>true</optional>
+        <rewriteAllowed>true</rewriteAllowed>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source.xml
@@ -72,9 +72,9 @@
       <parameter>
        <name>pyStateful</name>
         <description>Whether the operator has state to be saved in checkpointing.</description>
-         <optional>true</optional>
+        <optional>false</optional>
         <rewriteAllowed>true</rewriteAllowed>
-        <expressionMode>AttributeFree</expressionMode>
+        <expressionMode>Constant</expressionMode>
         <type>boolean</type>
         <cardinality>1</cardinality>
       </parameter>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source.xml
@@ -70,6 +70,15 @@
         <cardinality>1</cardinality>
       </parameter>
       <parameter>
+       <name>pyStateful</name>
+        <description>Whether the operator has state to be saved in checkpointing.</description>
+         <optional>true</optional>
+        <rewriteAllowed>true</rewriteAllowed>
+        <expressionMode>AttributeFree</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
         <name>submissionParamNames</name>
         <description>Submission parameter names</description>
         <optional>true</optional>

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -122,7 +122,7 @@ class SPLGraph(object):
         return self._requested_name(name)
 
 
-    def addOperator(self, kind, function=None, name=None, params=None, sl=None):
+    def addOperator(self, kind, function=None, name=None, params=None, sl=None, stateful=False):
         if(params is None):
             params = {}
 
@@ -134,7 +134,7 @@ class SPLGraph(object):
         else:
             if function is not None:
                 params['toolkitDir'] = streamsx.topology.param.toolkit_dir()
-            op = _SPLInvocation(len(self.operators), kind, function, name, params, self, sl=sl)
+            op = _SPLInvocation(len(self.operators), kind, function, name, params, self, sl=sl, stateful=stateful)
         self.operators.append(op)
         if not function is None:
             dep_instance = function
@@ -222,7 +222,7 @@ class SPLGraph(object):
         
 class _SPLInvocation(object):
 
-    def __init__(self, index, kind, function, name, params, graph, view_configs = None, sl=None):
+    def __init__(self, index, kind, function, name, params, graph, view_configs = None, sl=None, stateful = False):
         self.index = index
         self.kind = kind
         self.model = None
@@ -232,7 +232,7 @@ class _SPLInvocation(object):
         self.category = None
         self.params = {}
         self.setParameters(params)
-        self._addOperatorFunction(self.function)
+        self._addOperatorFunction(self.function, stateful)
         self.graph = graph
         self.viewable = True
         self.sl = sl
@@ -361,7 +361,7 @@ class _SPLInvocation(object):
             self._ex_op._generate(_op)
         return _op
 
-    def _addOperatorFunction(self, function):
+    def _addOperatorFunction(self, function, stateful=False):
         if (function is None):
             return None
         if not hasattr(function, "__call__"):

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -387,6 +387,8 @@ class _SPLInvocation(object):
             # dill format is binary; base64 encode so it is json serializable 
             self.params["pyCallable"] = base64.b64encode(dill.dumps(function)).decode("ascii")
 
+        self.params["pyStateful"] = bool(stateful)
+
         # note: functions in the __main__ module cannot be used as input to operations 
         # function.__module__ will be '__main__', so C++ operators cannot import the module
         self.params["pyModule"] = function.__module__

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -1645,7 +1645,7 @@ class Window(object):
         
         sl = _SourceLocation(_source_info(), "aggregate")
         name = self.topology.graph._requested_name(name, action="aggregate", func=function)
-        stateful = self._determine_statefulness(function)
+        stateful = self.stream._determine_statefulness(function)
         op = self.topology.graph.addOperator(self.topology.opnamespace+"::Aggregate", function, name=name, sl=sl, stateful=stateful)
         op.addInputPort(outputPort=self.stream.oport, name=self.stream.name, window_config=self._config)
         oport = op.addOutputPort(schema=schema, name=name)

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -454,7 +454,8 @@ class Topology(object):
 
         sl = _SourceLocation(_source_info(), "source")
         _name = self.graph._requested_name(_name, action='source', func=func)
-        op = self.graph.addOperator(self.opnamespace+"::Source", func, name=_name, sl=sl)
+        # source is always stateful
+        op = self.graph.addOperator(self.opnamespace+"::Source", func, name=_name, sl=sl, stateful=True)
         op._layout(kind='Source', name=_name, orig_name=name)
         oport = op.addOutputPort(name=_name)
         return Stream(self, oport)._make_placeable()
@@ -501,7 +502,8 @@ class Topology(object):
         """
         _name = self.graph._requested_name(name, 'subscribe')
         sl = _SourceLocation(_source_info(), "subscribe")
-        op = self.graph.addOperator(kind="com.ibm.streamsx.topology.topic::Subscribe", sl=sl, name=_name)
+        # subscribe is never stateful
+        op = self.graph.addOperator(kind="com.ibm.streamsx.topology.topic::Subscribe", sl=sl, name=_name, stateful=False)
         oport = op.addOutputPort(schema=schema, name=_name)
         params = {'topic': topic, 'streamType': schema}
         if connect is not None and connect != SubscribeConnection.Direct:
@@ -777,7 +779,8 @@ class Stream(_placement._Placement, object):
         """
         sl = _SourceLocation(_source_info(), 'for_each')
         _name = self.topology.graph._requested_name(name, action='for_each', func=func)
-        op = self.topology.graph.addOperator(self.topology.opnamespace+"::ForEach", func, name=_name, sl=sl)
+        stateful = self._determine_statefulness(func)
+        op = self.topology.graph.addOperator(self.topology.opnamespace+"::ForEach", func, name=_name, sl=sl, stateful=stateful)
         op.addInputPort(outputPort=self.oport, name=self.name)
         streamsx.topology.schema.StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')
         op._layout(kind='ForEach', name=_name, orig_name=name)
@@ -817,7 +820,8 @@ class Stream(_placement._Placement, object):
         """
         sl = _SourceLocation(_source_info(), 'filter')
         _name = self.topology.graph._requested_name(name, action="filter", func=func)
-        op = self.topology.graph.addOperator(self.topology.opnamespace+"::Filter", func, name=_name, sl=sl)
+        stateful = self._determine_statefulness(func)
+        op = self.topology.graph.addOperator(self.topology.opnamespace+"::Filter", func, name=_name, sl=sl, stateful=stateful)
         op.addInputPort(outputPort=self.oport, name=self.name)
         streamsx.topology.schema.StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')
         op._layout(kind='Filter', name=_name, orig_name=name)
@@ -826,7 +830,8 @@ class Stream(_placement._Placement, object):
 
     def _map(self, func, schema, name=None):
         _name = self.topology.graph._requested_name(name, action="map", func=func)
-        op = self.topology.graph.addOperator(self.topology.opnamespace+"::Map", func, name=_name)
+        stateful = self._determine_statefulness(func)
+        op = self.topology.graph.addOperator(self.topology.opnamespace+"::Map", func, name=_name, stateful=stateful)
         op.addInputPort(outputPort=self.oport, name=self.name)
         streamsx.topology.schema.StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')
         oport = op.addOutputPort(schema=schema, name=_name)
@@ -976,7 +981,8 @@ class Stream(_placement._Placement, object):
         """     
         sl = _SourceLocation(_source_info(), 'flat_map')
         _name = self.topology.graph._requested_name(name, action='flat_map', func=func)
-        op = self.topology.graph.addOperator(self.topology.opnamespace+"::FlatMap", func, name=_name, sl=sl)
+        stateful = self._determine_statefulness(func)
+        op = self.topology.graph.addOperator(self.topology.opnamespace+"::FlatMap", func, name=_name, sl=sl, stateful=stateful)
         op.addInputPort(outputPort=self.oport, name=self.name)
         streamsx.topology.schema.StreamSchema._fnop_style(self.oport.schema, op, 'pyStyle')
         oport = op.addOutputPort(name=_name)
@@ -1091,7 +1097,8 @@ class Stream(_placement._Placement, object):
 
             if func is not None:
                 keys = ['__spl_hash']
-                hash_adder = self.topology.graph.addOperator(self.topology.opnamespace+"::HashAdder", func)
+                stateful = self._determine_statefulness(func)
+                hash_adder = self.topology.graph.addOperator(self.topology.opnamespace+"::HashAdder", func, stateful=stateful)
                 hash_adder._layout(hidden=True)
                 hash_schema = self.oport.schema.extend(streamsx.topology.schema.StreamSchema("tuple<int64 __spl_hash>"))
                 hash_adder.addInputPort(outputPort=self.oport, name=self.name)
@@ -1286,7 +1293,8 @@ class Stream(_placement._Placement, object):
             return sp
 
         _name = self.topology.graph._requested_name(name, action="publish")
-        op = self.topology.graph.addOperator("com.ibm.streamsx.topology.topic::Publish", params={'topic': topic}, sl=sl, name=_name)
+        # publish is never stateful
+        op = self.topology.graph.addOperator("com.ibm.streamsx.topology.topic::Publish", params={'topic': topic}, sl=sl, name=_name, stateful=False)
         op.addInputPort(outputPort=self.oport)
         op._layout_group('Publish', name if name else _name)
         sink = Sink(op)
@@ -1406,6 +1414,13 @@ class Stream(_placement._Placement, object):
         self._op()._layout(kind, hidden, name, orig_name)
         return self
 
+    """
+    Determine whether a callable has state that needs to be saved during
+    checkpointing.  
+    """
+    def _determine_statefulness(self, _callable):
+        stateful = not inspect.isroutine(_callable)
+        return stateful
 
 class View(object):
     """
@@ -1630,7 +1645,8 @@ class Window(object):
         
         sl = _SourceLocation(_source_info(), "aggregate")
         name = self.topology.graph._requested_name(name, action="aggregate", func=function)
-        op = self.topology.graph.addOperator(self.topology.opnamespace+"::Aggregate", function, name=name, sl=sl)
+        stateful = self._determine_statefulness(function)
+        op = self.topology.graph.addOperator(self.topology.opnamespace+"::Aggregate", function, name=name, sl=sl, stateful=stateful)
         op.addInputPort(outputPort=self.stream.oport, name=self.stream.name, window_config=self._config)
         oport = op.addOutputPort(schema=schema, name=name)
 


### PR DESCRIPTION
I added a parameter, pyStateful, to the python topology operators.  It indicates whether on operator has state that needs to be saved when checkpointing.  All source operators are stateful, and other operators are stateful if their callable is not a function.