### PR TITLE
Make the SplpyOp destructor virtual.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
@@ -35,7 +35,7 @@ class SplpyFuncOp : public SplpyOp {
          loadAndWrapCallable(wrapfn);
       }
 
-      ~SplpyFuncOp() {
+      virtual ~SplpyFuncOp() {
       }
 
 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
@@ -54,7 +54,7 @@ class SplpyOp {
 #endif
       }
 
-      ~SplpyOp()
+      virtual ~SplpyOp()
       {
         {
           SplpyGIL lock;


### PR DESCRIPTION
The destructor in SplpyOp should be virtual, because it has derived classes, and it is important for the destructors of derived classes to call the SplpyOp destructor.  