### PR TITLE
Enable copying of doc-files.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -80,19 +80,17 @@
           failonerror="yes"
           additionalparam="-Xdoclint:none"
           >
-            <fileset dir="java/src">
-               <include name="com/ibm/streamsx/topology/**"/>
+            <packageset dir="java/src">
                <exclude name="com/ibm/streamsx/topology/context/remote/**"/>
                <exclude name="com/ibm/streamsx/topology/internal/**"/>
                <exclude name="com/ibm/streamsx/topology/builder/**"/>
                <exclude name="com/ibm/streamsx/topology/generator/**"/>
-               <include name="com/ibm/streamsx/rest/**"/>
-               <exclude name="**/*.properties"/>
-            </fileset>
-            <fileset dir="java/runtime/src">
+               
+            </packageset>
+            <packageset dir="java/runtime/src">
                <include name="com/ibm/streamsx/topology/**"/>
                <exclude name="com/ibm/streamsx/topology/internal/**"/>
-            </fileset>
+            </packageset>
        </javadoc>
        <ant dir="toolkit" target="spldoc"/>
        <ant dir="scala" target="scaladoc"/>


### PR DESCRIPTION
 If we use `fileset`, then javadoc will trip when it sees that `doc-files/Diagram1.jpg` is not a java file. If we exclude `doc-files`, then it will not be copied and the images will not be available in the javadoc.

Using `packageset` instead of `fileset` allows for `doc-files` to be copied automatically by javadoc. The downside is that we can not exclude individual files. There is only one case where we exclude a file:
```
<exclude name="**/*.properties"/>
```
But this line seems to be unnecessary since no `*.properties` files appear in the `doc` directory even when this line is removed.

If we feel strongly about being able to exclude individual files (by using `fileset`), then we will have to copy all `doc-files` directories manually to the target `doc` directory. This could be error prone, since it's easy to forget to add the additional ant target for every new `doc-files` directory that is added in the future. Therefore, at the expense of losing the ability to remove individual files with `fileset`, we gain the ability to copy all `doc-files` directories automatically with `packageset`.