### PR TITLE
Fix distributed tests

### DIFF
--- a/test/python/topology/test2_test.py
+++ b/test/python/topology/test2_test.py
@@ -122,7 +122,7 @@ class TestTester(unittest.TestCase):
 
 
 @unittest.skipIf(not test_vers.tester_supported() , "Tester not supported")
-class TestDistributedTester(unittest.TestCase):
+class TestDistributedTester(TestTester):
     def setUp(self):
         Tester.setup_distributed(self)
 


### PR DESCRIPTION
test2_test.py had incorrect super-class for the distributed test class.