### PR TITLE
Aggregate does not support structured schema output type

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -19,8 +19,8 @@ using namespace streamsx::topology;
  # Select the Python wrapper function
  my $pyoutstyle = splpy_tuplestyle($model->getOutputPortAt(0));
 
- if (($pystyle eq 'dict') || ($pyoutstyle eq 'dict') || ($pystyle eq 'tuple')) {
-    SPL::CodeGen::exitln("Dictionary input and output not supported.");
+ if (($pystyle eq 'dict') || ($pystyle eq 'tuple')) {
+    SPL::CodeGen::exitln("Dictionary input not supported.");
  }
  
  my $out_pywrapfunc=  'object_in__' . $pyoutstyle . '_out';

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -7,10 +7,6 @@ using namespace streamsx::topology;
 <%SPL::CodeGen::headerPrologue($model);%>
 
 @include "../pyspltuple.cgt"
-<%
- my $pyoutstyle = splpy_tuplestyle($model->getOutputPortAt(0));
- my $oport = $model->getOutputPortAt(0);
-%>
 
 class MY_OPERATOR : public MY_BASE_OPERATOR,
       public WindowEvent<PyObject *>
@@ -37,12 +33,6 @@ void afterTupleEvictionEvent(
      Window<PyObject *>::PartitionType const & partition);
 
 private:
-<%
-if ($pyoutstyle eq 'dict') {
-%>
-    void fromPythonToPort0(PyObject * pyTuple, <%=$oport->getCppTupleType()%> & otuple);
-<%}%>
-
     SplpyOp * op() { return funcop_; }
 
     // Members


### PR DESCRIPTION
Code that was copied from the `Map` operator but is not required since output of an aggregate is always a Python object. Only `Stream.map` supports changing the schema to a structured schema.