### PR TITLE
Checkpoint 1698

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
@@ -175,7 +175,7 @@ class SplpyFuncOp : public SplpyOp {
                   // state handler to be created.
                   // Effectively, checkpointing will not be enabled for
                   // this operator even though it is stateful.
-                  SPLAPPTRC(L_WARN, "Proceeding with no checkpointing for this operator", "python");
+                  SPLAPPTRC(L_WARN, "Proceeding with no checkpointing for the " << op()->getContext().getName() << " operator", "python");
                 }
               }
               else {

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
@@ -170,8 +170,8 @@ class SplpyFuncOp : public SplpyOp {
                     throw exceptionInfo.exception();
                   }
                   exceptionInfo.clear();
-                  // The exception was suppressed.  Continue with 
-                  // pickledCallable == NULL, which will cause a do-nothing 
+                  // The exception was suppressed.  Continue with
+                  // pickledCallable == NULL, which will cause a do-nothing
                   // state handler to be created.
                   // Effectively, checkpointing will not be enabled for
                   // this operator even though it is stateful.

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
@@ -151,34 +151,42 @@ class SplpyFuncOp : public SplpyOp {
 	    
 	    if (!pickledCallable) {
 	      // The callable cannot be pickled.  Throw an exception that
-	      // shuts down the operator.
-	      // (TODO: enable the exception optionally to be suppressed.
+              // shuts down the operator, unless it is supressed.
 	      // If it is suppressed, this operator will continue to run, but
 	      // with no checkpointing enabled.)
 	      if (PyErr_Occurred()) {
-		PyObject * type = NULL;
-		PyObject * value = NULL;
-		PyObject * traceback = NULL;
-		
-		PyErr_Fetch(&type, &value, &traceback);
-		if (value) {
+                SplpyExceptionInfo exceptionInfo = SplpyExceptionInfo::pythonError("setup");
+                if (exceptionInfo.pyValue_) {
 		  SPL::rstring text;
 		  // note pyRStringFromPyObject returns zero on success
-		  if (!pyRStringFromPyObject(text, value)) {
+                  if (pyRStringFromPyObject(text, exceptionInfo.pyValue_) == 0) {
 		    msg << " because of python error " << text;
 		  }
-		}
-		
-		Py_XDECREF(type);
-		Py_XDECREF(value);
-		Py_XDECREF(traceback);
+
+                  SPLAPPTRC(L_WARN, msg.str(), "python");
+                  // Offer the exception to the operator, so the operator
+                  // can suppress it.
+                  if (exceptionRaised(exceptionInfo) == 0) {
+                    throw exceptionInfo.exception();
+                  }
+                  exceptionInfo.clear();
+                  // The exception was suppressed.  Continue with 
+                  // pickledCallable == NULL, which will cause a do-nothing 
+                  // state handler to be created.
+                  // Effectively, checkpointing will not be enabled for
+                  // this operator even though it is stateful.
+                  SPLAPPTRC(L_WARN, "Proceeding with no checkpointing for this operator", "python");
+                }
+              }
+              else {
+                // This is probably unreachable.  PyObject_CallObject
+                // returned NULL, but there was no python exception.
+		throw SplpyGeneral::generalException("setup", msg.str());
 	      }
-	      
-	      throw SplpyGeneral::generalException("setup", msg.str());
-	    }
+            }
 	  }
 	  assert(!stateHandler);
-	  stateHandler = (stateful) ? new SplPyFuncOpStateHandler(this, pickledCallable) : new SPL::StateHandler;
+          stateHandler = (stateful && pickledCallable) ? new SplPyFuncOpStateHandler(this, pickledCallable) : new SPL::StateHandler;
 	  SPLAPPTRC(L_DEBUG, "registerStateHandler", "python");
 	  op()->getContext().registerStateHandler(*stateHandler);
 	}

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -677,23 +677,6 @@ class Topology(object):
 
     @property
     def checkpoint_period(self):
-        """Enable checkpointing for the topology, and define the checkpoint 
-        period.
-
-        When checkpointing is enabled, the state of all stateful operators
-        is saved periodically.  If the operator restarts, its state is
-        restored from the most recent checkpoint.  
-
-        The checkpoint period is the frequency at which checkpoints will
-        be taken.  It can either be a :py:class:`~datetime.timedelta` value 
-        or a floating point value in seconds.
-
-        Stateful operators are those whose callable is an instance of a
-        Python callable class.
-
-        Returns:
-            The checkpoint period.
-        """
         return self._checkpoint_period
 
     @checkpoint_period.setter

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -677,6 +677,23 @@ class Topology(object):
 
     @property
     def checkpoint_period(self):
+        """Enable checkpointing for the topology, and define the checkpoint 
+        period.
+
+        When checkpointing is enabled, the state of all stateful operators
+        is saved periodically.  If the operator restarts, its state is
+        restored from the most recent checkpoint.  
+
+        The checkpoint period is the frequency at which checkpoints will
+        be taken.  It can either be a :py:class:`~datetime.timedelta` value 
+        or a floating point value in seconds.
+
+        Stateful operators are those whose callable is an instance of a
+        Python callable class.
+
+        Returns:
+            The checkpoint period.
+        """
         return self._checkpoint_period
 
     @checkpoint_period.setter


### PR DESCRIPTION
Enable the user's class to suppress the exception thrown when the user's callable object cannot be dilled.  When this happens, processing continues with no checkpoint support for the operator using the callable that cannot be dilled.