### PR TITLE
Some safety fixes to SplpyExceptionInfo

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
@@ -447,7 +447,7 @@ class SplpyExceptionInfo {
       }
 
       PyObject * asTuple() const {
-  	  PyObject *info = PyTuple_New(pyTraceback_ ? 3 : pyValue_ ? 2 : 1);
+          PyObject *info = PyTuple_New(pyTraceback_ ? 3 : pyValue_ ? 2 : 1);
           Py_INCREF(pyType_);
           PyTuple_SET_ITEM(info, 0, pyType_);
           if (pyValue_) {

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_general.h
@@ -412,14 +412,14 @@ class SplpyGeneral {
  * it into __exit__.
  */
 class SplpyExceptionInfo {
-    public:
-      SplpyExceptionInfo() {
+    private:
+      SplpyExceptionInfo() : et_(), location_() {
          PyErr_Fetch(&pyType_, &pyValue_, &pyTraceback_);
          PyErr_NormalizeException(&pyType_, &pyValue_, &pyTraceback_);
-         // At this point we hold refrences to the objects
+         // At this point we hold references to the objects
          // and the error indicator is cleared.
       }
-
+    public:
       /*
        * Returns a SplpyExceptionInfo instance that can be thrown
        * when a Python error is raised through the Python C-API,
@@ -447,7 +447,7 @@ class SplpyExceptionInfo {
       }
 
       PyObject * asTuple() const {
-          PyObject *info = PyTuple_New(pyValue_ ? (pyTraceback_ ? 3 : 2) : 1);
+  	  PyObject *info = PyTuple_New(pyTraceback_ ? 3 : pyValue_ ? 2 : 1);
           Py_INCREF(pyType_);
           PyTuple_SET_ITEM(info, 0, pyType_);
           if (pyValue_) {


### PR DESCRIPTION
The default constructor for SplpyExceptionInfo leaves et_ and location_ uninitialized, potentially leading to undefined behaviour if the uninitialized values are used.  It appears that the intent of this class is that the default constructor is not to be used to construct an instance of the class, but instead the static methods exception and dataConversion, so I made the default constructor private.  asTuple had a potential buffer overrun if pyTraceback_ is set but not pyValue_, which I think is possible.  