### PR TITLE
Fix samples property for test with changed toolkit version

### DIFF
--- a/test/java/build.xml
+++ b/test/java/build.xml
@@ -159,12 +159,14 @@
   <target name="unittest.main" depends="jar">
      <antcall target="unittest.base" inheritAll="no">
        <param name="topology.test.type" value="EMBEDDED_TESTER"/>
+       <param name="topology.samples.jar" value="${topology.samples.jar}"/>
      </antcall>
   </target>
 
   <target name="unittest.standalone" depends="jar,test.python.toolkit">
      <antcall target="unittest.base" inheritAll="no">
        <param name="topology.test.type" value="STANDALONE_TESTER"/>
+       <param name="topology.samples.jar" value="${topology.samples.jar}"/>
      </antcall>
   </target>
 
@@ -204,6 +206,7 @@
   <property name="topology.test.base.pattern" value="**/*Test.java"/>
 
   <target name="unittest.base" depends="unittest.base.scala">
+    <echo message="topology.samples.jar=${topology.samples.jar}"/>
      <mkdir dir="${test.dir}"/>
      <tempfile property="topology.test.dir" prefix="testrun" destDir="${test.dir}"/>
      <mkdir dir="${topology.test.dir}"/>


### PR DESCRIPTION
If the test is called with a changed toolkit release (e.g. from Streams installation) the samples have a different location. Thus it must be possible to setup the samples-jar independent from toolkit release.