### PR TITLE
Checkpoint 1711

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -220,26 +220,15 @@ class SPLGraph(object):
             params[name] = sp.spl_json()
 
     def _add_checkpoint(self, _graph):
-        # TODO there seems to be a minimum value below which
-        # the period gets set to zero.  What is that value?
-        # should it be an error or warning if the value is 
-        # not exceeded?  Is there also a max?
 
         if self.topology.checkpoint_period is None:
             pass
-        else:
-            if (isinstance (self.topology.checkpoint_period, float)):
-                seconds = self.topology.checkpoint_period
-            elif (isinstance (self.topology.checkpoint_period, datetime.timedelta)):
-                seconds = self.topology.checkpoint_period.total_seconds()
-            else:
-                raise TypeError("Unsupported type for checkpoint_period");
-            period = seconds * 1000 * 1000
+        else:            
             unit = "MICROSECONDS"
 
             _graph["config"]["checkpoint"] = {}
             _graph["config"]["checkpoint"]["mode"] = "periodic"
-            _graph["config"]["checkpoint"]["period"] = period
+            _graph["config"]["checkpoint"]["period"] = self.topology.checkpoint_period * 1000 * 1000 # Seconds to microseconds
             _graph["config"]["checkpoint"]["unit"] = unit
 
 

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -686,7 +686,8 @@ class Topology(object):
 
         The checkpoint period is the frequency at which checkpoints will
         be taken.  It can either be a :py:class:`~datetime.timedelta` value
-        or a floating point value in seconds.
+        or a floating point value in seconds.  It must be at 0.001
+        seconds or greater.
 
         A stateful operator is an operator whose callable is an instance of a
         Python callable class.
@@ -698,10 +699,14 @@ class Topology(object):
 
     @checkpoint_period.setter
     def checkpoint_period(self, period):
-        if (isinstance(period, datetime.timedelta) or isinstance(period, float)):
-            self._checkpoint_period = period
+        if (isinstance(period, datetime.timedelta)):
+            self._checkpoint_period = period.total_seconds()
         else:
-            raise TypeError("Unsupported type for checkpoint_period")
+            self._checkpoint_period = float (period)
+
+        # checkpoint period must be greater or equal to 0.001
+        if self._checkpoint_period < 0.001:
+            raise ValueError("checkpoint_period must be 0.001 or greater")
 
     def _prepare(self):
         """Prepare object prior to SPL generation."""

--- a/test/python/topology/test2_enable_checkpoint.py
+++ b/test/python/topology/test2_enable_checkpoint.py
@@ -139,3 +139,98 @@ class test_distributed_undillable_class_suppress(test_undillable_class_suppress)
 class test_sas_undillable_class_suppress(test_undillable_class_suppress):
     def setUp(self):
         Tester.setup_streaming_analytics(self, force_remote_build=True)
+
+# checkpoint_period can be either a datetime.timedelta value, or
+# any type that can be cast to float.  Here we verify timedelta,
+# float, int, string, bool, as well as some negative tests.
+# This test is standalone only because the deployment type is
+# irrelevant.
+class CheckpointPeriodTypes(unittest.TestCase):
+    def setUp(self):
+        Tester.setup_standalone(self)
+
+    def test_timedelta(self):
+        topo = Topology("test")
+        topo.checkpoint_period = timedelta(seconds=1)
+        s = topo.source(undillable_source(3, True))
+        tester = Tester(topo)
+        tester.contents(s, [1, 2, 3])
+
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_float(self):
+        topo = Topology("test")
+        topo.checkpoint_period = 1.0
+        s = topo.source(undillable_source(3, True))
+        tester = Tester(topo)
+        tester.contents(s, [1, 2, 3])
+
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_int(self):
+        topo = Topology("test")
+        topo.checkpoint_period = 1
+        s = topo.source(undillable_source(3, True))
+        tester = Tester(topo)
+        tester.contents(s, [1, 2, 3])
+
+        tester.test(self.test_ctxtype, self.test_config)
+
+    # bool can be cast to float
+    def test_bool(self):
+        topo = Topology("test")
+        topo.checkpoint_period = True
+        # If no exception, the test passes.
+
+    # imaginary literal cannot be cast to float.
+    def test_imaginary(self):
+        topo = Topology("test")
+        with self.assertRaises(TypeError):
+            topo.checkpoint_period = 1j
+
+    # None cannot be cast to float
+    def test_none(self):
+        topo = Topology("test")
+        with self.assertRaises(TypeError):
+            topo.checkpoint_period = None
+
+    # test a string that can be cast to float
+    def test_string_valid(self):
+        topo = Topology("test")
+        topo.checkpoint_period = "42.0"
+        # if no exception, the test passed
+
+    # test a string that cannnot be cast to float
+    def test_string_invalid(self):
+        topo = Topology("test")
+        with self.assertRaises(ValueError):
+            topo.checkpoint_period = "Forty-two"
+
+    # Negative period should raise ValueError
+    def test_float_negative(self):
+        topo = Topology("test")
+        with self.assertRaises(ValueError):
+             topo.checkpoint_period = -0.1
+
+    # False is zero, so should raise ValueError
+    def test_bool_false(self):
+        topo = Topology("test")
+        with self.assertRaises(ValueError):
+            topo.checkpoint_period = False
+
+
+    # Less than 0.001 is not allowed, but exactly 0.001 is.
+    def test_float_low(self):
+        topo = Topology("test")
+
+        with self.assertRaises(ValueError):
+            topo.checkpoint_period = 0.0009
+
+        # Try again with 0.001
+        topo.checkpoint_period = 0.001
+
+        s = topo.source(undillable_source(3, True))
+        tester = Tester(topo)
+        tester.contents(s, [1, 2, 3])
+
+        tester.test(self.test_ctxtype, self.test_config)


### PR DESCRIPTION
Allow checkpoint_period to be either a datetime.timedelta, or any value that can be converted to a float.  Also enforce a minimum checkpoint_period of 0.001 seconds, which is the lowest value supported by
the runtime.  This  is related to issue #1711 