### PR TITLE
Update Unparallel's output port schema after relocating HashAdder

### DIFF
--- a/java/src/com/ibm/streamsx/topology/generator/spl/GraphUtilities.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/GraphUtilities.java
@@ -513,7 +513,26 @@ public class GraphUtilities {
         JsonObject output = outputs.get(index).getAsJsonObject();
         return jstring(output, "name");
 
-    }  
+    }
+
+    /**
+     * @return the output port schema type
+     */
+    static String getOutputPortType(JsonObject op, int index) {
+        JsonArray outputs = op.get("outputs").getAsJsonArray();
+        JsonObject output = outputs.get(index).getAsJsonObject();
+        return jstring(output, "type");
+    }
+
+    /**
+     * set the output port schema type to the given value
+     */
+    static void setOutputPortType(JsonObject op, int index, String schema) {
+        JsonArray outputs = op.get("outputs").getAsJsonArray();
+        JsonObject output = outputs.get(index).getAsJsonObject();
+        output.remove("type");
+        output.addProperty("type", schema);
+    }
     
     /**
      * Add an operator before another operator.

--- a/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/Preprocessor.java
@@ -106,10 +106,15 @@ class Preprocessor {
         // has only one child
         if (GraphUtilities.isKind(parent, BVirtualMarker.END_PARALLEL.kind()) &&
                 GraphUtilities.getDownstream(parent, graph).size() == 1) {
+            // retrieve HashAdder's output port schema
+            String schema = GraphUtilities.getOutputPortType(hashAdder, 0);
+            // insert a copy of HashAdder to the front of Unparallel
             JsonObject hashAdderCopy = GraphUtilities.copyOperatorNewName(
                     hashAdder, jstring(hashAdder, "name"));
             GraphUtilities.removeOperator(hashAdder, graph);
             GraphUtilities.addBefore(parent, hashAdderCopy, graph);
+            // set Unparallel's output port schema using HashAdder's schema
+            GraphUtilities.setOutputPortType(parent, 0, schema);
         }
     }
 }

--- a/test/java/src/com/ibm/streamsx/topology/test/api/ParallelTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/api/ParallelTest.java
@@ -152,7 +152,7 @@ public class ParallelTest extends TestTopology {
 
         Tester tester = topology.getTester();
 
-        Condition<List<String>> assertFinished = tester.stringContentsUnordered(numRegions, "20", "5");
+        Condition<List<String>> assertFinished = tester.stringContentsUnordered(numRegions, "3", "5");
 
         Condition<Long> expectedCount = tester.tupleCount(out2, 800);
 


### PR DESCRIPTION
#1738 introduced a bug. Partitioned Parallel operators expect tuples with a `__spl_hash` field. After relocating `HashAdder` to the front of Unparallel, Unparallel immediately connects to Parallel but Unparallel's output tuple does not contain a `__spl_hash` field.