### PR TITLE
Add hashAdder property for Python HashAdder

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -239,6 +239,8 @@ class _SPLInvocation(object):
         self._placement = {}
         self._start_op = False
         self.config = {}
+        # Arbitrary JSON for operator
+        self._op_def = {}
 
         if view_configs is None:
             self.view_configs = []
@@ -298,7 +300,7 @@ class _SPLInvocation(object):
 
 
     def generateSPLOperator(self):
-        _op = {}
+        _op = dict(self._op_def)
         _op["name"] = self.name
         if self.category:
             _op["category"] = self.category

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -1121,6 +1121,7 @@ class Stream(_placement._Placement, object):
                 keys = ['__spl_hash']
                 stateful = self._determine_statefulness(func)
                 hash_adder = self.topology.graph.addOperator(self.topology.opnamespace+"::HashAdder", func, stateful=stateful)
+                hash_adder._op_def['hashAdder'] = True
                 hash_adder._layout(hidden=True)
                 hash_schema = self.oport.schema.extend(streamsx.topology.schema.StreamSchema("tuple<int64 __spl_hash>"))
                 hash_adder.addInputPort(outputPort=self.oport, name=self.name)


### PR DESCRIPTION
Verified manually that a partitioned parallel region following another region uses cat cradle rather than forcing through a single hash adder.