### PR TITLE
SelectCustomers python sample operator must derive from PrimitiveOperator

### DIFF
--- a/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_primitives.py
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/opt/python/streams/spl_primitives.py
@@ -13,7 +13,7 @@ def spl_namespace():
     return "com.ibm.streamsx.topology.pysamples.primitives"
 
 @spl.primitive_operator(output_ports=['MATCH', 'NEAR_MATCH'])
-class SelectCustomers(object):
+class SelectCustomers(spl.PrimitiveOperator):
     """Score customers using a model.
     Customers that are a good match are submitted to port 0 ('MATCH')
     while customers that are a near match are submitted to port 1 ('NEAR_MATCH').


### PR DESCRIPTION
The sample python primitive operator SelectCustomers has a output ports, so it needs to derive from PrimitiveOperator.