### PR TITLE
Fix Python includes for primitive operators

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyversion.sh
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/pyversion.sh
@@ -15,5 +15,5 @@ then
     echo
 elif [ $action = "includePath" ]
 then
-    python3-config --includes
+    python3-config --includes | /bin/sed -e 's/-I//;s/[[space]]+-I/\n/'
 fi

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/pyversion.sh
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python2/pyversion.sh
@@ -15,5 +15,5 @@ then
     echo
 elif [ $action = "includePath" ]
 then
-    python-config --includes
+    python-config --includes | /bin/sed -e 's/-I//;s/[[space]]+-I/\n/'
 fi


### PR DESCRIPTION
Previously the includes were working by chance as `python-config -includes` returned duplicated paths like:

`-I/python3/include -I/python/include`

which was then handled by the SPL compile system as two tokens, the first an **relative** include path and the second just a flag to the compiler, resulting in C++ flags like (simplified):

`-I/topology_tk_path/.../Map/-I/python3/include -I/python/include`

The script that produces the paths is expected to have one path per-line of output.