### PR TITLE
Patch 2

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -955,7 +955,6 @@ class Stream(_placement._Placement, object):
         """
         Equivalent to calling :py:meth:`map(func,name) <map>`.
 
-
         .. deprecated:: 1.7
             Replaced by :py:meth:`map`.
         """

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -953,7 +953,8 @@ class Stream(_placement._Placement, object):
 
     def transform(self, func, name=None):
         """
-        Equivalent to calling :py:meth:``map(func, name)``.
+        Equivalent to calling :py:meth:`map(func,name) <map>`.
+
 
         .. deprecated:: 1.7
             Replaced by :py:meth:`map`.


### PR DESCRIPTION
The generated documentation for Stream.transform is not correct.  It shows ':py:meth:' in the output and the link does not work.