### PR TITLE
Update types.py

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/types.py
@@ -63,6 +63,7 @@ class Timestamp(streamsx.spl.runtime._Timestamp):
     def from_datetime(dt, machine_id=0):
         """
         Convert a datetime to an SPL `Timestamp`.
+        
         Args:
            dt(datetime.datetime): Datetime to be converted.
            machine_id(int): Machine identifier.


### PR DESCRIPTION
The parameters section of the docs for from_datetime in streamsx.spl.types is not displayed correctly.