### PR TITLE
Improve for_each CR test

### DIFF
--- a/test/python/topology/test2_consistent.py
+++ b/test/python/topology/test2_consistent.py
@@ -213,9 +213,9 @@ class TestDistributedConsistentRegion(unittest.TestCase):
             
     # Test for_each.  This is a sink. 
     def test_for_each(self):
-        N = 300
+        N = 3000
         topo = Topology("test")
-        s = topo.source(TimeCounter(iterations=N, period=0.1))
+        s = topo.source(TimeCounter(iterations=N, period=0.01))
         s.set_consistent(ConsistentRegionConfig.periodic(1, drainTimeout=40, resetTimeout=40, maxConsecutiveAttempts=3))
 
         s.for_each(StatefulNothing())


### PR DESCRIPTION
In looking at the console while `test2_consistent` was running I saw that most of the time the jobs were resetting while no tuples were being processed. 

As an experiment I increased the run length to effectively around 30 seconds and added value verification within the for_each callable.