### PR TITLE
Mark tests which can be split

### DIFF
--- a/test/python/spl/tests/test2_checkpointing.py
+++ b/test/python/spl/tests/test2_checkpointing.py
@@ -18,6 +18,8 @@ import spl_tests_utils as stu
 # operators: source, map, filter, for_each, primitive_operator
 
 class TestCheckpointing(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Extract Python operators in toolkit"""

--- a/test/python/spl/tests/test_exceptions.py
+++ b/test/python/spl/tests/test_exceptions.py
@@ -27,6 +27,8 @@ def _create_tf():
 class TestBaseExceptions(unittest.TestCase):
     """ Test exceptions in callables
     """
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Extract Python operators in toolkit"""
@@ -51,6 +53,7 @@ class TestBaseExceptions(unittest.TestCase):
         return content
 
 class TestExceptions(TestBaseExceptions):
+    _multiprocess_can_split_ = True
 
     def _run_app(self, kind, opi='M'):
         schema = 'tuple<rstring a, int32 b>'
@@ -152,6 +155,7 @@ class TestExceptions(TestBaseExceptions):
         self.assertEqual('KeyError\n', content[4])
 
 class TestSuppressExceptions(TestBaseExceptions):
+    _multiprocess_can_split_ = True
 
     def _run_app(self, kind, e, opi='M'):
         schema = 'tuple<rstring a, int32 b>'

--- a/test/python/spl/tests/test_kwargs.py
+++ b/test/python/spl/tests/test_kwargs.py
@@ -18,6 +18,8 @@ import streamsx.scripts.extract
 import spl_tests_utils as stu
 
 class TestKWArgs(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     """ 
     Test decorated operators with **kwargs
     """

--- a/test/python/spl/tests/test_pip.py
+++ b/test/python/spl/tests/test_pip.py
@@ -32,6 +32,9 @@ class TestLocal(unittest.TestCase):
 class TestPipInstalls(unittest.TestCase):
     """ Test remote pip install of packages.
     """
+
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Extract Python operators in toolkit"""

--- a/test/python/spl/tests/test_primitives.py
+++ b/test/python/spl/tests/test_primitives.py
@@ -20,6 +20,9 @@ class TestPrimitives(unittest.TestCase):
     """ 
     Test @spl.primitive_operator decorated operators
     """
+
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Extract Python operators in toolkit"""
@@ -145,6 +148,8 @@ class TestPrimitives(unittest.TestCase):
 # With output ports it's easier to test thus can use standalone.
 #
 class TestPrimitivesOutputs(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Extract Python operators in toolkit"""

--- a/test/python/spl/tests/test_sources.py
+++ b/test/python/spl/tests/test_sources.py
@@ -20,6 +20,9 @@ class TestSources(unittest.TestCase):
     """ 
     Test @spl.source decorated operators
     """
+
+    _multiprocess_can_split_ = True
+
     @classmethod
     def setUpClass(cls):
         """Extract Python operators in toolkit"""

--- a/test/python/spl/tests/test_types.py
+++ b/test/python/spl/tests/test_types.py
@@ -20,6 +20,8 @@ import streamsx.scripts.extract
 import spl_tests_utils as stu
 
 class TestTypes(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     """ Type tests.
     """
     @classmethod

--- a/test/python/topology/test2_byref.py
+++ b/test/python/topology/test2_byref.py
@@ -23,6 +23,7 @@ class CheckForEach(object):
         self.count += 1
 
 class TestByRef(unittest.TestCase):
+    _multiprocess_can_split_ = True
 
     def setUp(self):
         Tester.setup_standalone(self)

--- a/test/python/topology/test2_checkpoint.py
+++ b/test/python/topology/test2_checkpoint.py
@@ -120,6 +120,8 @@ class ListIterator(object):
     
 
 class TestCheckpointing(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_ec.py
+++ b/test/python/topology/test2_ec.py
@@ -112,6 +112,7 @@ def get_sys_argv():
     return sys_ec_test.argv
 
 class TestEc(unittest.TestCase):
+  _multiprocess_can_split_ = True
 
   def setUp(self):
       Tester.setup_standalone(self)

--- a/test/python/topology/test2_enter_exit.py
+++ b/test/python/topology/test2_enter_exit.py
@@ -106,6 +106,7 @@ def EEMSFunc(x):
     return None
 
 class TestSuppressMetricDistributed(unittest.TestCase):
+    _multiprocess_can_split_ = True
     def setUp(self):
         Tester.setup_distributed(self)
 

--- a/test/python/topology/test2_exception.py
+++ b/test/python/topology/test2_exception.py
@@ -87,6 +87,8 @@ class BadSourceNext(EnterExit):
 class TestBaseExceptions(unittest.TestCase):
     """ Test exceptions in callables
     """
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         self.tf = _create_tf()
         Tester.setup_standalone(self)

--- a/test/python/topology/test2_job_config.py
+++ b/test/python/topology/test2_job_config.py
@@ -14,6 +14,8 @@ from streamsx import rest
 from streamsx.rest_primitives import _IAMConstants
 
 class TestJobConfig(unittest.TestCase):
+  _multiprocess_can_split_ = True
+
   def setUp(self):
       Tester.setup_streaming_analytics(self, force_remote_build=True)
       sc = rest.StreamingAnalyticsConnection()

--- a/test/python/topology/test2_json.py
+++ b/test/python/topology/test2_json.py
@@ -23,6 +23,7 @@ class CheckForEach(object):
         self.count += 1
 
 class TestJson(unittest.TestCase):
+    _multiprocess_can_split_ = True
 
     def setUp(self):
         Tester.setup_standalone(self)

--- a/test/python/topology/test2_names.py
+++ b/test/python/topology/test2_names.py
@@ -10,6 +10,7 @@ from streamsx.topology.tester import Tester
 import streamsx.topology.context as stc
 
 class TestNames(unittest.TestCase):
+  _multiprocess_can_split_ = True
 
   def setUp(self):
       Tester.setup_standalone(self)

--- a/test/python/topology/test2_pending.py
+++ b/test/python/topology/test2_pending.py
@@ -15,6 +15,8 @@ import streamsx.spl.op as op
 
 
 class TestPending(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     """ Test pending connections.
     """
     def setUp(self):

--- a/test/python/topology/test2_pkg.py
+++ b/test/python/topology/test2_pkg.py
@@ -16,6 +16,8 @@ import test_package.test_subpackage.test_module
 import test2_pkg_helpers
 
 class TestPackages(unittest.TestCase):
+  _multiprocess_can_split_ = True
+
   def setUp(self):
       Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_placement.py
+++ b/test/python/topology/test2_placement.py
@@ -35,6 +35,8 @@ class RemoveDup(object):
 
 
 class TestPlacement(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_streaming_analytics(self, force_remote_build=True)
         

--- a/test/python/topology/test2_pubsub.py
+++ b/test/python/topology/test2_pubsub.py
@@ -19,6 +19,8 @@ import uuid
 class TestPubSub(unittest.TestCase):
     """ Test publish/subscribe
     """
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_distributed(self)
 

--- a/test/python/topology/test2_python2spl.py
+++ b/test/python/topology/test2_python2spl.py
@@ -16,6 +16,8 @@ Test that we can covert Python streams to SPL tuples.
 class TestPython2SPL(unittest.TestCase):
     """ Test invocations handling of SPL schemas in Python ops.
     """
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_python_window.py
+++ b/test/python/topology/test2_python_window.py
@@ -115,6 +115,8 @@ class TupleTimespanCheck(object):
 within_tolerance = lambda val, tol, exp: val < exp + (tol*exp) and val > exp - (tol*exp)
 
 class TestPythonWindowing(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_schema_tuple.py
+++ b/test/python/topology/test2_schema_tuple.py
@@ -79,6 +79,8 @@ class check_is_tuple_map_to_json(check_for_tuple_type):
 class TestSchemaTuple(unittest.TestCase):
     """ Test invocations handling of SPL schemas in Python ops.
     """
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_spl.py
+++ b/test/python/topology/test2_spl.py
@@ -37,6 +37,8 @@ class TestParseOption(IntEnum):
 class TestSPL(unittest.TestCase):
     """ Test invocations of SPL operators from Python topology.
     """
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 
@@ -256,6 +258,8 @@ GOOD_DATA = {
 class TestConversion(unittest.TestCase):
     """ Test conversions of Python values to SPL attributes/types.
     """
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_spl2python.py
+++ b/test/python/topology/test2_spl2python.py
@@ -28,6 +28,8 @@ schemas = [
 class TestSPL2Python(unittest.TestCase):
     """ Test invocations handling of SPL schemas in Python ops.
     """
+    _multiprocess_can_split_ = True
+
     # Fake out subTest
     if sys.version_info.major == 2:
         def subTest(self, **args): return threading.Lock()

--- a/test/python/topology/test2_spl_window.py
+++ b/test/python/topology/test2_spl_window.py
@@ -15,6 +15,8 @@ import streamsx.spl.op as op
 class TestSPLWindow(unittest.TestCase):
     """ Test invocations of SPL operators from Python topology.
     """
+    _multiprocess_can_split_ = True
+
     # Fake out subTest
     if sys.version_info.major == 2:
         def subTest(self, **args): return threading.Lock()

--- a/test/python/topology/test2_submission_params.py
+++ b/test/python/topology/test2_submission_params.py
@@ -29,6 +29,8 @@ class AddIt(object):
 class TestSubmissionParams(unittest.TestCase):
     """ Test submission params (distributed).
     """
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_submission_result.py
+++ b/test/python/topology/test2_submission_result.py
@@ -7,6 +7,8 @@ import os
 import fnmatch
 
 class TestSubmissionResult(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_distributed(self)
         self.username = os.getenv("STREAMS_USERNAME", "streamsadmin")

--- a/test/python/topology/test2_test.py
+++ b/test/python/topology/test2_test.py
@@ -16,6 +16,8 @@ def rands():
        yield r.random()
 
 class TestTester(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_udp.py
+++ b/test/python/topology/test2_udp.py
@@ -51,6 +51,7 @@ def s2_hash(t):
     return hash(t['s2'])
 
 class TestUDP(unittest.TestCase):
+  _multiprocess_can_split_ = True
 
   # Fake out subTest
   if sys.version_info.major == 2:

--- a/test/python/topology/test2_unicode.py
+++ b/test/python/topology/test2_unicode.py
@@ -13,6 +13,8 @@ import streamsx.ec as ec
 
 
 class TestUnicode(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_standalone(self)
 

--- a/test/python/topology/test2_views.py
+++ b/test/python/topology/test2_views.py
@@ -18,6 +18,8 @@ def rands():
        yield r.random()
 
 class TestViews(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     def setUp(self):
         Tester.setup_distributed(self)
 


### PR DESCRIPTION
See https://nose.readthedocs.io/en/latest/doc_tests/test_multiprocess/multiprocess.html

Preparation for running nosetests in parallel to reduce CI test elapsed time.