### PR TITLE
Ensure sabs have different names.

### DIFF
--- a/test/python/spl/tests/test_exceptions.py
+++ b/test/python/spl/tests/test_exceptions.py
@@ -7,6 +7,7 @@ import sys
 import itertools
 import tempfile
 import os
+import uuid
 
 from streamsx.topology.topology import *
 from streamsx.topology.tester import Tester
@@ -27,7 +28,7 @@ def _create_tf():
 class TestBaseExceptions(unittest.TestCase):
     """ Test exceptions in callables
     """
-    _multiprocess_can_split_ = False
+    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):
@@ -57,7 +58,7 @@ class TestExceptions(TestBaseExceptions):
 
     def _run_app(self, kind, opi='M'):
         schema = 'tuple<rstring a, int32 b>'
-        topo = Topology()
+        topo = Topology('TESPL' + str(uuid.uuid4().hex))
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
         if opi == 'M':
             data = [1,2,3]
@@ -155,7 +156,7 @@ class TestSuppressExceptions(TestBaseExceptions):
 
     def _run_app(self, kind, e, opi='M'):
         schema = 'tuple<rstring a, int32 b>'
-        topo = Topology()
+        topo = Topology('TSESPL' + str(uuid.uuid4().hex))
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
 
         if opi == 'M':

--- a/test/python/topology/test2_exception.py
+++ b/test/python/topology/test2_exception.py
@@ -7,6 +7,7 @@ import sys
 import itertools
 import tempfile
 import os
+import uuid
 
 if sys.version_info.major == 3:
     unicode = str
@@ -87,7 +88,7 @@ class BadSourceNext(EnterExit):
 class TestBaseExceptions(unittest.TestCase):
     """ Test exceptions in callables
     """
-    _multiprocess_can_split_ = False
+    _multiprocess_can_split_ = True
 
     def setUp(self):
         self.tf = _create_tf()
@@ -137,7 +138,7 @@ class TestExceptions(TestBaseExceptions):
         self.assertEqual('TypeError\n', content[4])
 
     def _run_app(self, fn=None, data=None):
-        topo = Topology()
+        topo = Topology('TE' + str(uuid.uuid4().hex))
         if data is None:
             data = [1,2,3]
         se = topo.source(data)
@@ -401,7 +402,7 @@ class TestSuppressExceptions(TestBaseExceptions):
     """ Test exception suppression in callables
     """
     def _run_app(self, fn=None, data=None, n=None, e=None):
-        topo = Topology()
+        topo = Topology('TSE' + str(uuid.uuid4().hex))
         if data is None:
             data = [1,2,3]
         se = topo.source(data)


### PR DESCRIPTION
Duplicate names from invoking `Topology()` in a common method led to issues when test fixtures are run concurrently.