### PR TITLE
Hold permit and state lock across submit

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
@@ -69,9 +69,9 @@ void MY_OPERATOR::process(uint32_t idx)
    try {
     OPort0Type otuple;
 
+    AutoConsistentRegionPermit crp(crContext);
+    OptionalAutoLock stateLock(this);
     { // start lock
-      AutoConsistentRegionPermit crp(crContext);
-      OptionalAutoLock stateLock(this);
       SplpyGIL lock;
       if (pyReturnVar != NULL) {
           Py_DECREF(pyReturnVar);
@@ -110,6 +110,7 @@ void MY_OPERATOR::process(uint32_t idx)
     } // end lock
 
     submit(otuple, 0);
+
    } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
      SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
    }


### PR DESCRIPTION
The submit was being performed outside of the permit and the operator state being held.

This mean a reset just before the submit would lose tuples.

I would see `test2_consistent.TestDistributedConsistentRegion.test_flat_map` intermittently fail without this fix.

Could this be a reason for #1856 ?