### PR TITLE
Consistent tests

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/tester.py
@@ -704,6 +704,7 @@ class Tester(object):
             if self.local_check is not None:
                 self._local_thread.join()
         else:
+            _logger.error ("wait for healthy failed")
             self.result = cc._end(False, _ConditionChecker._UNHEALTHY)
 
         self.result['submission_result'] = self.submission_result
@@ -770,7 +771,7 @@ class _ConditionChecker(object):
         for cn in tester._conditions:
             self._sequences[cn] = -1
         self.delay = 1.0 
-        self.timeout = 20.0
+        self.timeout = 30.0
         self.waits = 0
         self.additional_checks = 2
 
@@ -786,6 +787,7 @@ class _ConditionChecker(object):
                 self.waits = 0
                 return True
             if ok_ is False: # actually failed
+                _logger.error ("wait for healthy actually failed")
                 return False
 
             # ok_ is number of ok PEs
@@ -887,8 +889,10 @@ class _ConditionChecker(object):
                 return False
         ok_pes = 0
         for pe in self.job.get_pes():
-            if pe.launchCount != 1:
-                if verbose:
+            if pe.launchCount == 0:
+                continue # not a test failure, but not an ok_pe either
+            if pe.launchCount > 1:
+                if verbose or start:
                     _logger.error("PE %s launch count > 1: %s", pe.id, pe.launchCount)
                 return False
             if pe.health != 'healthy':

--- a/test/python/spl/tests/test2_checkpointing.py
+++ b/test/python/spl/tests/test2_checkpointing.py
@@ -30,21 +30,21 @@ class TestCheckpointing(unittest.TestCase):
 
     # Source operator
     def test_source(self):
-        topo = Topology("test")
+        topo = Topology()
         topo.checkpoint_period = timedelta(seconds=1)
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
         bop = op.Source(topo, "com.ibm.streamsx.topology.pytest.checkpoint::TimeCounter", schema.StreamSchema('tuple<int32 f>').as_tuple(), params={'iterations':30,'period':0.1})
+#        streamsx.topology.context.submit('TOOLKIT', topo)
         s = bop.stream
         tester = Tester(topo)
         tester.tuple_count(s, 30)
-        #tester.contents(s, range(0,30))  # why doesn't this work?
         tester.contents(s, list(zip(range(0,30))))
 
-        tester.test(self.test_ctxtype, self.test_config, always_collect_logs=True)
+        tester.test(self.test_ctxtype, self.test_config)
 
     # Source, filter, and map operators
     def test_filter_map(self):
-        topo = Topology("test")
+        topo = Topology()
         topo.checkpoint_period = timedelta(seconds=1)
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
         timeCounter = op.Source(topo, "com.ibm.streamsx.topology.pytest.checkpoint::TimeCounter", schema.StreamSchema('tuple<int32 f>').as_tuple(), params={'iterations':30,'period':0.1})
@@ -55,14 +55,14 @@ class TestCheckpointing(unittest.TestCase):
         tester.tuple_count(s, 15)
         tester.contents(s, list(zip(range(1,16))))
 
-        tester.test(self.test_ctxtype, self.test_config, always_collect_logs=True)
+        tester.test(self.test_ctxtype, self.test_config)
 
     # source, primitive, and for_each operators
     # this will fail to compile because checkpointing is not supported
     # for python primitive operators.
     @unittest.expectedFailure
     def test_primitive_foreach(self):
-        topo = Topology("test")
+        topo = Topology()
         topo.checkpoint_period = timedelta(seconds=1)
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
         timeCounter = op.Source(topo, "com.ibm.streamsx.topology.pytest.checkpoint::TimeCounter", schema.StreamSchema('tuple<int32 f>').as_tuple(), params={'iterations':30,'period':0.1})
@@ -75,7 +75,7 @@ class TestCheckpointing(unittest.TestCase):
 
     # source, map, and for_each operators
     def test_map_foreach(self):
-        topo = Topology("test")
+        topo = Topology()
         topo.checkpoint_period = timedelta(seconds=1)
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
         timeCounter = op.Source(topo, "com.ibm.streamsx.topology.pytest.checkpoint::TimeCounter", schema.StreamSchema('tuple<int32 f>').as_tuple(), params={'iterations':30,'period':0.1})

--- a/test/python/spl/tests/test2_consistent.py
+++ b/test/python/spl/tests/test2_consistent.py
@@ -35,12 +35,16 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         bop = op.Source(topo, "com.ibm.streamsx.topology.pytest.checkpoint::TimeCounter", schema.StreamSchema('tuple<int32 f>').as_tuple(), params={'iterations':iterations,'period':0.01})
 
         s = bop.stream
-        s.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        s.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
         
         tester = Tester(topo)
         tester.resets()
         tester.tuple_count(s, iterations)
         tester.contents(s, list(zip(range(0,iterations))))
+
+        # cfg={}
+        # job_config = streamsx.topology.context.JobConfig(tracing='debug')
+        # job_config.add(self.test_config)
 
         tester.test(self.test_ctxtype, self.test_config)
 
@@ -51,18 +55,13 @@ class TestDistributedConsistentRegion(unittest.TestCase):
 
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
         timeCounter = op.Source(topo, "com.ibm.streamsx.topology.pytest.checkpoint::TimeCounter", schema.StreamSchema('tuple<int32 f>').as_tuple(), params={'iterations':iterations,'period':0.01})
-        timeCounter.stream.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        timeCounter.stream.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
  
         evenFilter = op.Map("com.ibm.streamsx.topology.pytest.checkpoint::StatefulEvenFilter", timeCounter.stream, None, params={})
         hpo = op.Map("com.ibm.streamsx.topology.pytest.checkpoint::StatefulHalfPlusOne", evenFilter.stream, None, params={})
         s = hpo.stream
         tester = Tester(topo)
         tester.resets()
-
-#        cfg={}
-#        job_config = streamsx.topology.context.JobConfig(tracing='debug')
-#        job_config.add(self.test_config)
-
         tester.tuple_count(s, iterations/2)
         tester.contents(s, list(zip(range(1,int((iterations/2)+1)))))
 
@@ -79,7 +78,7 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         topo.checkpoint_period = timedelta(seconds=1)
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
         timeCounter = op.Source(topo, "com.ibm.streamsx.topology.pytest.checkpoint::TimeCounter", schema.StreamSchema('tuple<int32 f>').as_tuple(), params={'iterations':iterations,'period':0.01})
-        timeCounter.stream.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        timeCounter.stream.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
 
         fizzbuzz = op.Map("com.ibm.streamsx.topology.pytest.checkpoint::FizzBuzzPrimitive", timeCounter.stream, schema.StreamSchema('tuple<int32 f, rstring c>').as_tuple())
         verify = op.Sink("com.ibm.streamsx.topology.pytest.checkpoint::Verify", fizzbuzz.stream)
@@ -87,6 +86,7 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         tester = Tester(topo)
         tester.resets()
         tester.tuple_count(s, iterations)
+
         tester.test(self.test_ctxtype, self.test_config)
 
     # source, map, and for_each operators
@@ -96,7 +96,7 @@ class TestDistributedConsistentRegion(unittest.TestCase):
 
         streamsx.spl.toolkit.add_toolkit(topo, stu._tk_dir('testtkpy'))
         timeCounter = op.Source(topo, "com.ibm.streamsx.topology.pytest.checkpoint::TimeCounter", schema.StreamSchema('tuple<int32 f>').as_tuple(), params={'iterations':iterations,'period':0.01})
-        timeCounter.stream.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        timeCounter.stream.set_consistent(ConsistentRegionConfig.periodic(5 , drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
 
         fizzbuzz = op.Map("com.ibm.streamsx.topology.pytest.checkpoint::FizzBuzzMap", timeCounter.stream, schema.StreamSchema('tuple<int32 f, rstring c>').as_tuple())
         verify = op.Sink("com.ibm.streamsx.topology.pytest.checkpoint::Verify", fizzbuzz.stream)
@@ -110,8 +110,8 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         buzz=lambda x: (x[0], x[1]+'buzz' if x[0] % 5 == 0 else x[1])
         expected = list (map (buzz, (map (fizz, (map (lambda x: (x,''), range(iterations)))))))
         tester.contents(s, expected)
-        tester.test(self.test_ctxtype, self.test_config)
 
+        tester.test(self.test_ctxtype, self.test_config)
 
 class TestSasConsistentRegion(TestDistributedConsistentRegion):
     def setUp(self):

--- a/test/python/topology/test2_checkpoint.py
+++ b/test/python/topology/test2_checkpoint.py
@@ -127,13 +127,19 @@ class TestCheckpointing(unittest.TestCase):
 
     # Source operator
     def test_source(self):
-        topo = Topology("test")
+        topo = Topology()
         topo.checkpoint_period = timedelta(seconds=1)
         s = topo.source(TimeCounter(iterations=30, period=0.1))
         tester = Tester(topo)
         tester.contents(s, range(0,30))
 
-        tester.test(self.test_ctxtype, self.test_config, always_collect_logs=True)
+        # streamsx.topology.context.submit('TOOLKIT', topo)
+
+#        cfg={}
+#        job_config = streamsx.topology.context.JobConfig(tracing='debug')
+#        job_config.add(self.test_config)
+
+        tester.test(self.test_ctxtype, self.test_config)
 
     # Source, ForEach, Filter, Aggregate operators
     # (based on test2_python_window.TestPythonWindowing.test_basicCountCountWindow)
@@ -161,14 +167,16 @@ class TestCheckpointing(unittest.TestCase):
         # slow things down so checkpoints can be taken.
         lines = lines.filter(StatefulDelay(0.5)) 
         words = lines.flat_map(StatefulSplit())
+
         tester = Tester(topo)
         tester.contents(words, ["mary","had","a","little","lamb","its","fleece","was","white","as","snow"])
+
         tester.test(self.test_ctxtype, self.test_config)
 
     # Test hash adder.  This requires parallel with a hash router.
     # (based on test2_udp.TestUDP.test_TopologyParallelHash)
     def test_hash_adder(self):
-        topo = Topology("test_hash_adder")
+        topo = Topology()
         topo.checkpoint_period = timedelta(seconds=1)
         s = topo.source(TimeCounter(iterations=30, period=0.1))
         width =  3
@@ -186,11 +194,12 @@ class TestCheckpointing(unittest.TestCase):
             
     # Test for_each.  This is a sink. 
     def test_for_each(self):
-        topo = Topology("test")
+        topo = Topology()
         topo.checkpoint_period = timedelta(seconds=1)
         s = topo.source(TimeCounter(iterations=30, period=0.1))
         s.for_each(StatefulNothing())
         tester = Tester(topo)
+
         tester.test(self.test_ctxtype, self.test_config)
 
 class TestDistributedCheckpointing(TestCheckpointing):

--- a/test/python/topology/test2_consistent.py
+++ b/test/python/topology/test2_consistent.py
@@ -181,18 +181,19 @@ class TestDistributedConsistentRegion(unittest.TestCase):
     # Source operator
     def test_source(self):
         iterations=3000
+        reset_count=5
         topo = Topology()
         
         s = topo.source(TimeCounter(iterations=iterations, period=0.01))
-        s.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        s.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
 
         tester = Tester(topo)
         tester.contents(s, range(0,iterations))
-        tester.resets()
+        tester.resets(reset_count)
 
-#        cfg={}
-#        job_config = streamsx.topology.context.JobConfig(tracing='debug')
-#        job_config.add(self.test_config)
+        # cfg={}
+        # job_config = streamsx.topology.context.JobConfig(tracing='debug')
+        # job_config.add(self.test_config)
 
         tester.test(self.test_ctxtype, self.test_config)
 
@@ -202,10 +203,11 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         # If the number of iterations is changed, keep it a multiple of six,
         # or improve the expected results generation below.
         iterations = 3000
+        reset_count = 5
         topo = Topology()
         # Generate integers from [0,3000)
         s = topo.source(TimeCounter(iterations=iterations, period=0.01))
-        s.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        s.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
 
         # Filter the odd ones 
         s = s.filter(StatefulEvenFilter())
@@ -214,7 +216,7 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         s = s.last(10).trigger(3).aggregate(StatefulAverage())
 
         tester = Tester(topo)
-        tester.resets()
+        tester.resets(reset_count)
 
         # Find the expected results.
         # The first three values (until the window fills) are special.
@@ -234,15 +236,16 @@ class TestDistributedConsistentRegion(unittest.TestCase):
     # Test flat map (based on a sample)
     def test_flat_map(self):
         count = 1000
+        reset_count = 5
         topo = Topology();
 
         lines = topo.source(ListIterator(["All work","and no play","makes Jack","a dull boy"], period=0.01, count=count))
 
-        lines.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        lines.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
 
         words = lines.flat_map(StatefulSplit())
         tester = Tester(topo)
-        tester.resets()
+        tester.resets(reset_count)
 
         # Find the expected results.
         flat_contents = ["All","work","and","no","play","makes","Jack","a","dull","boy"]
@@ -257,9 +260,10 @@ class TestDistributedConsistentRegion(unittest.TestCase):
     # (based on test2_udp.TestUDP.test_TopologyParallelHash)
     def test_hash_adder(self):
         iterations=3000
+        reset_count=5
         topo = Topology()
         s = topo.source(TimeCounter(iterations=iterations, period=0.01))
-        s.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        s.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
 
         width = 3
         s = s.parallel(width, Routing.HASH_PARTITIONED, StatefulStupidHash())
@@ -269,30 +273,31 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         expected = [v + 23 for v in range(iterations)]
 
         tester = Tester(topo)
-        tester.resets()
+        tester.resets(reset_count)
         tester.contents(s, expected, ordered=width==1)
         tester.test(self.test_ctxtype, self.test_config)
 
     # Test for_each.  This is a sink. 
     def test_for_each(self):
         iterations = 3000
+        reset_count = 5
         topo = Topology()
         s = topo.source(TimeCounter(iterations=iterations, period=0.01))
-        s.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        s.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
 
         s.for_each(VerifyNumericOrder())
 
         tester = Tester(topo)
         tester.contents(s, range(0,iterations))
-        tester.resets()
+        tester.resets(reset_count)
         tester.test(self.test_ctxtype, self.test_config)
 
     def test_enter_exit(self):
         iterations = 3000
-        reset_count = 10
+        reset_count = 5
         topo = Topology()
         s = topo.source(TimeCounter(iterations=iterations, period=0.01))
-        s.set_consistent(ConsistentRegionConfig.periodic(1, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
+        s.set_consistent(ConsistentRegionConfig.periodic(5, drain_timeout=40, reset_timeout=40, max_consecutive_attempts=6))
         
         v = VerifyEnterExit(reset_count + 1, "VerifyEnterExit")
         tester = Tester(topo)


### PR DESCRIPTION
Updates to the checkpointing and consistent region tests to make them pass more consistently in the Cloud.  The main fixes were: 

Sometimes during startup, the launch count of a PE was 0.  The tester treated launch count != 1 as an error.  Now it is treated as an error only if launch count > 1.

The period for the consistent regions was 1 second in most of the tests.  The consistent region resetter does resets at a small multiple of the period, and with the period only one second, sometimes the resets were not complete before another was triggered.  This led to frequent test failures when the max consecutive resets were reached.  The fix was to increase the period and decrease the number of resets performed.

Also, on the cloud, the 20 second limit for a job to become healthy was sometimes a cause of a test failure, so it has been increased to 30 second.