### PR TITLE
Ordre locking within Python operators

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -105,7 +105,6 @@ MY_OPERATOR::~MY_OPERATOR()
 // Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
     funcop_->prepareToShutdown();
 }
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -35,31 +35,31 @@ MY_OPERATOR::~MY_OPERATOR()
     delete funcop_;
 }
 
-// Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
+    SPLPY_AUTO_OP_LOCK();
     funcop_->prepareToShutdown();
 }
 
-// Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-try {
+    bool passed = false;
+    SPLPY_AUTO_OP_LOCK();
+    try {
+
 @include "../pyspltuple2value.cgt"
 
-  OptionalAutoLock stateLock(this);
-  if (streamsx::topology::Splpy::pyTupleFilter(funcop_->callable(), value)) {
-      submit(tuple, 0);
-  }
-} catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
-    SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
-}
+        passed = streamsx::topology::Splpy::pyTupleFilter(funcop_->callable(), value);
+    } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
+        SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
+        return;
+    }
+    if (passed)
+         submit(tuple, 0);
 }
 
 void MY_OPERATOR::process(Punctuation const & punct, uint32_t port)
 {
-   OptionalAutoLock stateLock(this);
    forwardWindowPunctuation(punct);
 }
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -37,22 +37,23 @@ MY_OPERATOR::~MY_OPERATOR()
 
 void MY_OPERATOR::prepareToShutdown() 
 {
-    SPLPY_AUTO_OP_LOCK();
     funcop_->prepareToShutdown();
 }
 
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
     bool passed = false;
-    SPLPY_AUTO_OP_LOCK();
-    try {
+    {
+         OptionalAutoLock stateLock(this);
+         try {
 
 @include "../pyspltuple2value.cgt"
 
-        passed = streamsx::topology::Splpy::pyTupleFilter(funcop_->callable(), value);
-    } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
-        SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
-        return;
+             passed = streamsx::topology::Splpy::pyTupleFilter(funcop_->callable(), value);
+         } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
+             SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
+             return;
+         }
     }
     if (passed)
          submit(tuple, 0);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
@@ -75,21 +75,19 @@ MY_OPERATOR::~MY_OPERATOR()
   delete funcop_;
 }
 
-// Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
     funcop_->prepareToShutdown();
 }
 
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-@include "../pyspltuple2value.cgt"
-  
   std::vector<OPort0Type> output_tuples; 
   
+ {
   OptionalAutoLock stateLock(this);
+@include "../pyspltuple2value.cgt"
   try {
     SplpyGIL lock;
 
@@ -121,7 +119,9 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
     Py_DECREF(pyIterator);
   } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
     SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
+    return;
   }
+ }
 
   // submit tuples
   for(int i = 0; i < output_tuples.size() && !getPE().getShutdownRequested(); i++) {
@@ -131,7 +131,6 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 
 void MY_OPERATOR::process(Punctuation const & punct, uint32_t port)
 {
-   OptionalAutoLock lock(this);
    forwardWindowPunctuation(punct);
 }
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -37,17 +37,17 @@ MY_OPERATOR::~MY_OPERATOR()
 // Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
+    SPLPY_AUTO_OP_LOCK();
     funcop_->prepareToShutdown();
 }
 
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
+SPLPY_AUTO_OP_LOCK();
 try {
 @include "../pyspltuple2value.cgt"
 
-  OptionalAutoLock stateLock(this);
   streamsx::topology::Splpy::pyTupleForEach(funcop_->callable(), value);
 } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
   SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -37,22 +37,20 @@ MY_OPERATOR::~MY_OPERATOR()
 // Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    SPLPY_AUTO_OP_LOCK();
     funcop_->prepareToShutdown();
 }
 
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-SPLPY_AUTO_OP_LOCK();
-try {
+    OptionalAutoLock stateLock(this);
+    try {
 @include "../pyspltuple2value.cgt"
 
-  streamsx::topology::Splpy::pyTupleForEach(funcop_->callable(), value);
-} catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
-  SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
-}
- 
+        streamsx::topology::Splpy::pyTupleForEach(funcop_->callable(), value);
+    } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
+       SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
+    }
 }
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -1,5 +1,3 @@
-/* Additional includes go here */
-
 #include "splpy.h"
 #include "splpy_funcop.h"
 
@@ -13,7 +11,6 @@ using namespace streamsx::topology;
  my $pywrapfunc= $pystyle_fn . '_in';
 %>
 
-// Constructor
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
    pyInStyleObj_(NULL),
@@ -25,7 +22,6 @@ MY_OPERATOR::MY_OPERATOR() :
 }
 
 
-// Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {
     if (pyInStyleObj_) {
@@ -36,43 +32,35 @@ MY_OPERATOR::~MY_OPERATOR()
     delete funcop_;
 }
 
-// Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock lock(this);
     funcop_->prepareToShutdown();
 }
 
-// Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
-try {
+    SPL::int32 _hash = 0;
+    {
+        OptionalAutoLock stateLock(this);
+        try {
 @include "../pyspltuple2value.cgt"
 
-  OptionalAutoLock stateLock(this);
-<%if ($pystyle_fn eq 'dict' || $pystyle_fn eq 'tuple') {%>
+            _hash = streamsx::topology::Splpy::pyTupleHash(funcop_->callable(), value);
 
-  OPort0Type otuple;
-  otuple.assignFrom(<%=$iport->getCppTupleName()%>, false);
-  otuple.set___spl_hash(streamsx::topology::Splpy::pyTupleHash(funcop_->callable(), value));
+        } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
+            SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
+            return;
+        }
+    }
 
-<%} else { %>
-
-  // value is the first matching attribute and an SPL:: reference
-  OPort0Type otuple(value,
-       streamsx::topology::Splpy::pyTupleHash(funcop_->callable(), value));
-<%}%>
-
-  // submit tuple
-  submit(otuple, 0);
-} catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
-  SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
-}
+    OPort0Type otuple;
+    otuple.assignFrom(tuple, false);
+    otuple.set___spl_hash(_hash);
+    submit(otuple, 0);
 }
 
 void MY_OPERATOR::process(Punctuation const & punct, uint32_t port)
 {
-   OptionalAutoLock stateLock(this);
    forwardWindowPunctuation(punct);
 }
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -80,10 +80,8 @@ MY_OPERATOR::~MY_OPERATOR()
   delete funcop_;
 }
 
-// Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
     funcop_->prepareToShutdown();
 }
 
@@ -128,7 +126,6 @@ try {
 
 void MY_OPERATOR::process(Punctuation const & punct, uint32_t port)
 {
-   OptionalAutoLock stateLock(this);
    forwardWindowPunctuation(punct);
 }
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
@@ -56,7 +56,6 @@ void MY_OPERATOR::allPortsReady()
 // Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock lock(this);
     funcop_->prepareToShutdown();
 }
 

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
@@ -26,12 +26,6 @@
  }
 
  my $isCheckpointing = $stateful && ($isInConsistentRegion or $ckptKind ne "none");
-
- if ($isCheckpointing) {
-%>
-#define SPLPYOP_STATE_HANDLER
-<%
-}
 %>
   // True if this operator is in a consistent region.
   static const bool isInConsistentRegion = <%= $isInConsistentRegion ? "true" :" false" %>;
@@ -42,11 +36,5 @@
   typedef OptionalConsistentRegionContextImpl<isInConsistentRegion> OptionalConsistentRegionContext;
   typedef OptionalConsistentRegionContext::Permit AutoConsistentRegionPermit;
   typedef OptionalAutoLockImpl<isCheckpointing> OptionalAutoLock;
-
-#ifdef SPLPYOP_STATE_HANDLER
-#define SPLPY_AUTO_OP_LOCK() OptionalAutoLock stateLock(this)
-#else
-#define SPLPY_AUTO_OP_LOCK()
-#endif
 
 

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
@@ -26,6 +26,12 @@
  }
 
  my $isCheckpointing = $stateful && ($isInConsistentRegion or $ckptKind ne "none");
+
+ if ($isCheckpointing) {
+%>
+#define SPLPYOP_STATE_HANDLER
+<%
+}
 %>
   // True if this operator is in a consistent region.
   static const bool isInConsistentRegion = <%= $isInConsistentRegion ? "true" :" false" %>;
@@ -36,5 +42,11 @@
   typedef OptionalConsistentRegionContextImpl<isInConsistentRegion> OptionalConsistentRegionContext;
   typedef OptionalConsistentRegionContext::Permit AutoConsistentRegionPermit;
   typedef OptionalAutoLockImpl<isCheckpointing> OptionalAutoLock;
+
+#ifdef SPLPYOP_STATE_HANDLER
+#define SPLPY_AUTO_OP_LOCK() OptionalAutoLock stateLock(this)
+#else
+#define SPLPY_AUTO_OP_LOCK()
+#endif
 
 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
@@ -146,6 +146,12 @@ class SplpyOp {
       /**
        * Actions for a Python operator on prepareToShutdown
        * Flush any pending output.
+       * Note we do not interact with the callable here
+       * as it may still be needed for concurrent tuple
+       * processing. The callable is shutdown and its __exit__
+       * method called when this object's destructor is called.
+       * This means the mutex in the operator is not required
+       * when calling this function.
       */
       void prepareToShutdown() {
           SplpyGIL lock;

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
@@ -57,7 +57,6 @@ using namespace streamsx::topology;
   my $skip_set_callable = 0;
 %>
 
-// Constructor
 MY_OPERATOR::MY_OPERATOR() :
    pyop_(NULL),
    pyInNames_(NULL)
@@ -74,7 +73,6 @@ MY_OPERATOR::MY_OPERATOR() :
 <% } %>
 }
 
-// Destructor
 MY_OPERATOR::~MY_OPERATOR() 
 {
    {
@@ -85,20 +83,18 @@ MY_OPERATOR::~MY_OPERATOR()
    delete pyop_;
 }
 
-// Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
     pyop_->prepareToShutdown();
 }
 
-// Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
  @include  "../../opt/.__splpy/common/py_splTupleCheckForBlobs.cgt"
 
-   OptionalAutoLock stateLock(this);
    int ret = 0;
+ {
+   OptionalAutoLock stateLock(this);
    try {
      SplpyGIL lock;
 
@@ -116,6 +112,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
        SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
        return;
    }
+ }
 
    if (ret)
        submit(tuple, 0);   
@@ -125,10 +122,8 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 <%}%>
 }
 
-// Punctuation processing
 void MY_OPERATOR::process(Punctuation const & punct, uint32_t port)
 {
-    OptionalAutoLock stateLock(this);
     forwardWindowPunctuation(punct);
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -81,7 +81,6 @@ MY_OPERATOR::~MY_OPERATOR()
 // Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
     pyop_->prepareToShutdown();
 }
 
@@ -114,7 +113,6 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 // Punctuation processing
 void MY_OPERATOR::process(Punctuation const & punct, uint32_t port)
 {
-    OptionalAutoLock stateLock(this);
     forwardWindowPunctuation(punct);
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
@@ -70,10 +70,8 @@ MY_OPERATOR::~MY_OPERATOR()
    delete pyop_;
 }
 
-// Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
     pyop_->prepareToShutdown();
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -76,7 +76,6 @@ void MY_OPERATOR::allPortsReady()
 // Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
-    OptionalAutoLock stateLock(this);
     pyop_->prepareToShutdown();
 }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -166,7 +166,6 @@ MY_OPERATOR::~MY_OPERATOR()
 <%}%>
 }
 
-// Notify pending shutdown
 void MY_OPERATOR::prepareToShutdown() 
 {
     pyop_->prepareToShutdown();


### PR DESCRIPTION
Locking associated with the Python callable:

- Lock whenever the code calls into the callable including when __exit__ is called after an error in tuple conversion or the callable itself.
- Don't lock during `prepareToShutdown` or `processPunctuation` as the callable is not invoked.
- Avoid holding the lock across the tuple submission from the operator.