### PR TITLE
Pass in tuple reference to be submitted.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -88,6 +88,7 @@ void MY_OPERATOR::prepareToShutdown()
 // Tuple processing for non-mutating ports
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 {
+  OPort0Type otuple;
 try {
 @include "../pyspltuple2value.cgt"
 
@@ -100,10 +101,10 @@ try {
   if (ret == NULL)
      return;
   if (PyTuple_Check(ret)) {
-      fromPythonToPort0(ret);
+      fromPythonToPort0(ret, otuple);
       Py_DECREF(ret);
   } else if (PyDict_Check(ret)) {
-      fromPythonDictToPort0(ret);
+      fromPythonDictToPort0(ret, otuple);
       Py_DECREF(ret);
   } else {
           throw SplpyGeneral::generalException("submit",
@@ -112,7 +113,6 @@ try {
   }
   
 <% } else { %>
-  OPort0Type otuple;
 
   if (SPLPY_TUPLE_MAP(funcop_->callable(), value,
        otuple.get_<%=$model->getOutputPortAt(0)->getAttributeAt(0)->getName()%>(), occ_))

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
@@ -33,10 +33,10 @@ private:
 <%
 if ($pyoutstyle eq 'dict') {
 %>
-    void fromPythonToPort0(PyObject * pyTuple);
-    void fromPythonDictToPort0(PyObject * pyDict);
-    void fromPyTupleToSPLTuple(PyObject *pyDict, <%=$oport->getCppTupleType()%> & otuple);
-    void fromPyDictToSPLTuple(PyObject *pyTuple, <%=$oport->getCppTupleType()%> & otuple);
+    void fromPythonToPort0(PyObject * pyTuple, OPort0Type & otuple);
+    void fromPythonDictToPort0(PyObject * pyDict, OPort0Type & otuple);
+    void fromPyTupleToSPLTuple(PyObject *pyDict, OPort0Type & otuple);
+    void fromPyDictToSPLTuple(PyObject *pyTuple, OPort0Type & otuple);
 <%}%>
 
     SplpyOp * op() { return funcop_; }

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_pyTupleTosplTuple.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_pyTupleTosplTuple.cgt
@@ -15,9 +15,8 @@
 %>
  
 // Python tuple to SPL tuple with submission to a port
-void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple <%=$itypeparam%>) {
+void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=$oport->getCppTupleType()%> & otuple <%=$itypeparam%>) {
 
-  <%=$oport->getCppTupleType()%> otuple;
   try {
     MY_OPERATOR::fromPyTupleToSPLTuple(pyTuple, otuple <%=$itypearg%>);
   } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
@@ -29,9 +28,7 @@ void MY_OPERATOR::fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple <%=$
 }
 
 // Python dict to SPL tuple with submission to a port.
-void MY_OPERATOR::fromPythonDictToPort<%=$oport->getIndex()%>(PyObject *pyDict <%=$itypeparam%>) {
-
-  <%=$oport->getCppTupleType()%> otuple;
+void MY_OPERATOR::fromPythonDictToPort<%=$oport->getIndex()%>(PyObject *pyDict, <%=$oport->getCppTupleType()%> & otuple <%=$itypeparam%>) {
 
   try {
     MY_OPERATOR::fromPyDictToSPLTuple(pyDict, otuple <%=$itypearg%>);

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_valueToTuples.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_valueToTuples.cgt
@@ -19,12 +19,15 @@
 
 void MY_OPERATOR::pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject *value <%=$itypeparam%>) {
 
+
   if (PyTuple_Check(value))
   {
-    fromPythonToPort<%=$oport->getIndex()%>(value <%=$ituplearg%>);
+    <%=$oport->getCppTupleType()%> otuple;
+    fromPythonToPort<%=$oport->getIndex()%>(value, otuple <%=$ituplearg%>);
   }
   else if (PyDict_Check(value)) {
-    fromPythonDictToPort<%=$oport->getIndex()%>(value <%=$ituplearg%>);
+    <%=$oport->getCppTupleType()%> otuple;
+    fromPythonDictToPort<%=$oport->getIndex()%>(value, otuple <%=$ituplearg%>);
   }
   else if (PyList_Check(value))
   {
@@ -35,10 +38,11 @@ void MY_OPERATOR::pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject *value <%=$
        PyObject *ltuple = PyList_GET_ITEM(value, k);
        if (SplpyGeneral::isNone(ltuple))
            continue;
+       <%=$oport->getCppTupleType()%> otuple;
        if (PyTuple_Check(ltuple)) {    
-           fromPythonToPort<%=$oport->getIndex()%>(ltuple <%=$ituplearg%>);
+           fromPythonToPort<%=$oport->getIndex()%>(ltuple, otuple <%=$ituplearg%>);
        } else if (PyDict_Check(ltuple)) {
-           fromPythonDictToPort<%=$oport->getIndex()%>(ltuple <%=$ituplearg%>);
+           fromPythonDictToPort<%=$oport->getIndex()%>(ltuple, otuple <%=$ituplearg%>);
        } else {
           throw SplpyGeneral::generalException("submit",
              "Fatal error: Value submitted must be a Python tuple, dict or list of tuples or dicts: Port <%=$oport->getIndex()%>");

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
@@ -45,10 +45,10 @@ private:
     PyObject *pyOutNames_0;
 
     void pySubmitTuplesPort0(PyObject * value, <%=$iport->getCppTupleType()%> const & ituple);
-    void fromPythonToPort0(PyObject * pyTuple, <%=$iport->getCppTupleType()%> const & ituple);
-    void fromPythonDictToPort0(PyObject * pyDict, <%=$iport->getCppTupleType()%> const & ituple);
-    void fromPyTupleToSPLTuple(PyObject *pyDict, <%=$oport->getCppTupleType()%> & otuple, <%=$iport->getCppTupleType()%> const & ituple);
-    void fromPyDictToSPLTuple(PyObject *pyTuple, <%=$oport->getCppTupleType()%> & otuple, <%=$iport->getCppTupleType()%> const & ituple);
+    void fromPythonToPort0(PyObject * pyTuple, OPort0Type & otuple, IPort0Type const & ituple);
+    void fromPythonDictToPort0(PyObject * pyDict, OPort0Type & otuple, IPort0Type const & ituple);
+    void fromPyTupleToSPLTuple(PyObject *pyDict, OPort0Type & otuple, IPort0Type const & ituple);
+    void fromPyDictToSPLTuple(PyObject *pyTuple, OPort0Type & otuple, IPort0Type const & ituple);
 
 @include "../../opt/.__splpy/common/py_enable_cr.cgt"
 }; 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
@@ -44,10 +44,10 @@ private:
 
     SplpyOp *op() { return pyop_; }
     void pySubmitTuplesPort0(PyObject * value);
-    void fromPythonToPort0(PyObject * pyTuple);
-    void fromPythonDictToPort0(PyObject * pyDict);
-    void fromPyTupleToSPLTuple(PyObject *pyDict, <%=$oport->getCppTupleType()%> & otuple);
-    void fromPyDictToSPLTuple(PyObject *pyTuple, <%=$oport->getCppTupleType()%> & otuple);
+    void fromPythonToPort0(PyObject * pyTuple, OPort0Type & otuple);
+    void fromPythonDictToPort0(PyObject * pyDict, OPort0Type & otuple);
+    void fromPyTupleToSPLTuple(PyObject *pyDict, OPort0Type & otuple);
+    void fromPyDictToSPLTuple(PyObject *pyTuple, OPort0Type & otuple);
 
 @include "../../opt/.__splpy/common/py_enable_cr.cgt"
     OptionalConsistentRegionContext crContext;

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -49,8 +49,8 @@ private:
 %>
   PyObject *pyOutNames_<%=$oport->getIndex()%>;
   void pySubmitTuplesPort<%=$oport->getIndex()%>(PyObject * value);
-  void fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple);
-  void fromPythonDictToPort<%=$oport->getIndex()%>(PyObject *pyDict);
+  void fromPythonToPort<%=$oport->getIndex()%>(PyObject *pyTuple, <%=$oport->getCppTupleType()%> &otuple);
+  void fromPythonDictToPort<%=$oport->getIndex()%>(PyObject *pyDict, <%=$oport->getCppTupleType()%> &otuple);
 
   <%
      my $otype = $oport->getCppTupleType();


### PR DESCRIPTION
Step in ensuring where possible operators such as `Map` do not hold the lock over submission.