### PR TITLE
Link analytics service to connection.

### DIFF
--- a/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsConnection.java
@@ -33,7 +33,7 @@ abstract class AbstractStreamingAnalyticsConnection
     AbstractStreamingAnalyticsConnection(
     		AbstractStreamingAnalyticsService service,
             String resourcesUrl, boolean allowInsecure)
-            throws IOException {
+            {
         super(resourcesUrl, allowInsecure);
         this.service = service;
     }
@@ -95,7 +95,7 @@ abstract class AbstractStreamingAnalyticsConnection
     }
 
     @Override
-    Result<Job, JsonObject> submitJob(ApplicationBundle bundle, JsonObject jco) throws IOException {
-    	throw new UnsupportedOperationException();
+    Result<Job, JsonObject> submitJob(ApplicationBundle bundle, JsonObject jco) throws IOException {    	
+    	return service.submitJob(((FileBundle) bundle).bundleFile(), jco);
     }
 }

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsConnection.java
@@ -17,8 +17,6 @@ import org.apache.http.client.fluent.Response;
 import org.apache.http.util.EntityUtils;
 
 import com.google.gson.JsonObject;
-import com.ibm.streamsx.rest.StreamsRestUtils.StreamingAnalyticsServiceVersion;
-import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
 
 /**
  * Common code for implementations of {@link IStreamingAnalyticsConnection}
@@ -28,15 +26,25 @@ abstract class AbstractStreamingAnalyticsConnection
 
     private static final Logger traceLog = Logger.getLogger("com.ibm.streamsx.rest.AbstractStreamingAnalyticsConnection");
 
-    JsonObject credentials;
+    private final AbstractStreamingAnalyticsService service;
     private Instance instance;
     String baseConsoleURL;
 
-    AbstractStreamingAnalyticsConnection(String authorization,
-            String resourcesUrl, JsonObject credentials, boolean allowInsecure)
+    AbstractStreamingAnalyticsConnection(
+    		AbstractStreamingAnalyticsService service,
+            String resourcesUrl, boolean allowInsecure)
             throws IOException {
-        super(authorization, resourcesUrl, allowInsecure);
-        this.credentials = credentials;
+        super(resourcesUrl, allowInsecure);
+        this.service = service;
+    }
+    
+    final JsonObject credentials() {
+    	return service.credentials();
+    }
+    
+    @Override
+    final String getAuthorization() {
+    	return service.getAuthorization();
     }
 
     /**
@@ -48,7 +56,7 @@ abstract class AbstractStreamingAnalyticsConnection
      *
      * @throws IOException
      */
-    public Instance getInstance() throws IOException {
+    Instance getInstance() throws IOException {
         if (instance != null)
             return instance;
         List<Instance> instances = getInstances();
@@ -84,39 +92,6 @@ abstract class AbstractStreamingAnalyticsConnection
         traceLog.finest("Request: [" + deleteJobUrl + "]");
         traceLog.finest(rcResponse + ": " + sReturn);
         return rc;
-    }
-
-    static AbstractStreamingAnalyticsConnection of(JsonObject config,
-            boolean allowInsecure) throws IOException {
-
-        // Get the VCAP service based on the config, and extract credentials
-        JsonObject service = VcapServices.getVCAPService(config);
-
-        JsonObject credentials = service.get("credentials").getAsJsonObject();
-
-        StreamingAnalyticsServiceVersion version = 
-                StreamsRestUtils.getStreamingAnalyticsServiceVersion(credentials);
-        switch (version) {
-        case V1:
-            return StreamingAnalyticsConnectionV1.of(service, allowInsecure);
-        case V2:
-        {
-            // V2: authorization is constructed with IAM and must be renewed
-            String tokenUrl = StreamsRestUtils.getTokenUrl(credentials);
-            String apiKey = StreamsRestUtils.getServiceApiKey(credentials);
-            JsonObject response = StreamsRestUtils.getTokenResponse(tokenUrl, apiKey);
-            String accessToken = StreamsRestUtils.getToken(response);
-            if (null != accessToken) {
-                String authorization = StreamsRestUtils.createBearerAuth(accessToken);
-                long authExpiryMillis = StreamsRestUtils.getTokenExpiryMillis(response);
-                return StreamingAnalyticsConnectionV2.of(service, authorization,
-                        authExpiryMillis, allowInsecure);
-            }
-            throw new IllegalStateException("Unable to authenticate Streaming Analytics Service");
-        }
-        default:
-            throw new IllegalStateException("Unknown Streaming Analytics Service version");
-        }
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
@@ -107,19 +107,17 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
             throws IOException;
     /** Version-specific to submit a build. */
     protected abstract JsonObject submitBuild(CloseableHttpClient httpclient,
-            String authorization, File archive, String buildName) throws IOException;
+            File archive, String buildName) throws IOException;
     /** Version-specific to get build info. */
     protected abstract JsonObject getBuild(String buildId,
-            CloseableHttpClient httpclient,
-            String authorization) throws IOException;
+            CloseableHttpClient httpclient) throws IOException;
     /** Version-specific to submit build artifact as job. */
     protected abstract JsonObject submitBuildArtifact(CloseableHttpClient httpclient,
-            JsonObject deploy, String authorization, String submitUrl)
+            JsonObject deploy, String submitUrl)
             throws IOException;
     /** Version-specific to get build info that includes output. */
     protected abstract JsonObject getBuildOutput(String buildId, String outputId,
-            CloseableHttpClient httpclient,
-            String authorization) throws IOException;
+            CloseableHttpClient httpclient) throws IOException;
     /** Version-specific mechanism to get AbstractStreamsConnection. */
     abstract AbstractStreamingAnalyticsConnection createStreamsConnection()
             throws IOException;
@@ -189,7 +187,7 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
             // Perform initial post of the archive
             TRACE.info("Streaming Analytics service (" + serviceName + "): submitting build " + buildName);
             final long startUploadTime = System.currentTimeMillis();
-            JsonObject buildSubmission = submitBuild(httpclient, getAuthorization(), archive, buildName);
+            JsonObject buildSubmission = submitBuild(httpclient, archive, buildName);
             final long endUploadTime = System.currentTimeMillis();
             metrics.addProperty(SubmissionResultsKeys.SUBMIT_UPLOAD_TIME, (endUploadTime - startUploadTime));
             
@@ -199,7 +197,7 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
             // Loop until built
             final long startBuildTime = endUploadTime;
             long lastCheckTime = endUploadTime;
-            JsonObject buildStatus = getBuild(buildId, httpclient, getAuthorization());  
+            JsonObject buildStatus = getBuild(buildId, httpclient);  
             String status = jstring(buildStatus, "status");
             while (!"built".equals(status)) {
                 String mkey = SubmissionResultsKeys.buildStateMetricKey(status);
@@ -222,14 +220,14 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                     }
-                    buildStatus = getBuild(buildId, httpclient, getAuthorization()); 
+                    buildStatus = getBuild(buildId, httpclient); 
                     status = jstring(buildStatus, "status");
                     continue;
                 } 
                 // The remaining possible states are 'failed', 'timeout', 'canceled', 'canceling', and 'unknown', none of which can lead to a state of 'built', so we throw an error.
                 else {
                     TRACE.severe("Streaming Analytics service (" + serviceName + "): The submitted archive " + archive.getName() + " failed to build with status " + status + ".");
-                    JsonObject output = getBuildOutput(buildId, outputId, httpclient, getAuthorization());
+                    JsonObject output = getBuildOutput(buildId, outputId, httpclient);
                     String strOutput = "";
                     if (output != null)
                         strOutput = prettyPrintOutput(output);
@@ -251,8 +249,7 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
 
             TRACE.info("Streaming Analytics service (" + serviceName + "): submitting job request.");
             final long startSubmitTime = System.currentTimeMillis();
-            JsonObject response = submitBuildArtifact(httpclient, jco,
-                    getAuthorization(), submitUrl);
+            JsonObject response = submitBuildArtifact(httpclient, jco, submitUrl);
             final long endSubmitTime = System.currentTimeMillis();
             metrics.addProperty(SubmissionResultsKeys.SUBMIT_JOB_TIME, (endSubmitTime - startSubmitTime));
             

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
@@ -49,12 +49,9 @@ import com.ibm.streamsx.topology.internal.streams.Util;
  */
 abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsService {
 
-    final protected JsonObject credentials;
+    private final JsonObject credentials;
     final protected JsonObject service;
     private final String serviceName;
-
-    // Current value for the authorization header
-    protected String authorization;
 
     // Connection to Streams REST API
     AbstractStreamingAnalyticsConnection streamsConnection;
@@ -64,6 +61,10 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
         this.credentials = credentials;
         this.service = service;
         this.serviceName = jstring(service, "name");
+    }
+    
+    final JsonObject credentials() {
+    	return credentials;
     }
     
     @Override
@@ -122,13 +123,6 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
     /** Version-specific mechanism to get AbstractStreamsConnection. */
     abstract AbstractStreamingAnalyticsConnection createStreamsConnection()
             throws IOException;
-
-    /**
-     * Set the current authorization header contents.
-     */
-    protected void setAuthorization(String authorization) {
-        this.authorization = authorization;
-    }
 
     @Override
     public Result<Job, JsonObject> submitJob(File bundle, JsonObject jco) throws IOException {

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
@@ -26,7 +26,6 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
     private final String resourcesUrl;
 
     protected Executor executor;
-    protected String authorization;
     protected String instancesUrl;
     
     /**
@@ -61,9 +60,8 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
      *            String representing the root url to the REST API resources,
      *            for example: https://server:port/streams/rest/resources
      */
-    AbstractStreamsConnection(String authorization, String resourcesUrl,
+    AbstractStreamsConnection(String resourcesUrl,
             boolean allowInsecure) throws IOException {
-        this.authorization = authorization;
         this.resourcesUrl = resourcesUrl;
         this.executor = StreamsRestUtils.createExecutor(allowInsecure);
     }
@@ -96,13 +94,6 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
      */
     Executor getExecutor() {
         return executor;
-    }
-
-    /**
-     * Set the contents of the authorization header
-     */
-    protected void setAuthorization(String authorization) {
-        this.authorization = authorization;
     }
 
     /**

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
@@ -13,7 +13,6 @@ import org.apache.http.client.fluent.Executor;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.Expose;
 
 /**
@@ -26,7 +25,7 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
     private final String resourcesUrl;
 
     protected Executor executor;
-    protected String instancesUrl;
+    private String instancesUrl;
     
     /**
      * Cancel a job.
@@ -61,32 +60,15 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
      *            for example: https://server:port/streams/rest/resources
      */
     AbstractStreamsConnection(String resourcesUrl,
-            boolean allowInsecure) throws IOException {
+            boolean allowInsecure) {
         this.resourcesUrl = resourcesUrl;
         this.executor = StreamsRestUtils.createExecutor(allowInsecure);
     }
-
-    /**
-     * Must be called after construction once to initialize the connection.
-     */
-    synchronized void init() throws IOException, JsonSyntaxException {
-        if (null == instancesUrl) {
-            // Query the resourcesUrl to find the instances URL
-            String response = getResponseString(resourcesUrl);
-            ResourcesArray resources = new GsonBuilder()
-                    .excludeFieldsWithoutExposeAnnotation()
-                    .create().fromJson(response, ResourcesArray.class);
-            for (Resource resource : resources.resources) {
-                if (INSTANCES_RESOURCE_NAME.equals(resource.name)) {
-                    instancesUrl = resource.resource;
-                    break;
-                }
-            }
-            if (null == instancesUrl) {
-                // If we couldn't find instances something is wrong
-                throw new RESTException("Unable to find instances resource from resources URL: " + resourcesUrl);
-            }
-        }
+    
+    @Override
+    public boolean allowInsecureHosts(boolean allowInsecure) {
+    	this.executor = StreamsRestUtils.createExecutor(allowInsecure);
+    	return allowInsecure;
     }
 
     /**
@@ -113,7 +95,7 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
      */
     @Override
     public List<Instance> getInstances() throws IOException {
-        return Instance.createInstanceList(this, instancesUrl);
+        return Instance.createInstanceList(this, getInstancesURL());
     }
 
     /* (non-Javadoc)
@@ -126,7 +108,7 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
             // should add some fallback code to see if there's only one instance
             throw new IllegalArgumentException("Missing instance id");
         } else {
-            String query = instancesUrl + "?id=" + instanceId;
+            String query = getInstancesURL() + "?id=" + instanceId;
 
             List<Instance> instances = Instance.createInstanceList(this, query);
             if (instances.size() == 1) {
@@ -138,6 +120,27 @@ abstract class AbstractStreamsConnection implements IStreamsConnection {
 
         }
         return si;
+    }
+    
+    private String getInstancesURL() throws IOException {
+    	if (instancesUrl == null) {
+            // Query the resourcesUrl to find the instances URL
+            String response = getResponseString(resourcesUrl);
+            ResourcesArray resources = new GsonBuilder()
+                    .excludeFieldsWithoutExposeAnnotation()
+                    .create().fromJson(response, ResourcesArray.class);
+            for (Resource resource : resources.resources) {
+                if (INSTANCES_RESOURCE_NAME.equals(resource.name)) {
+                    instancesUrl = resource.resource;
+                    break;
+                }
+            }
+            if (null == instancesUrl) {
+                // If we couldn't find instances something is wrong
+                throw new RESTException("Unable to find instances resource from resources URL: " + resourcesUrl);
+            }
+    	}
+    	return instancesUrl;
     }
 
     private static class Resource {

--- a/java/src/com/ibm/streamsx/rest/IStreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/IStreamsConnection.java
@@ -13,6 +13,8 @@ import java.util.List;
  * {@link StreamsRestFactory}
  */
 interface IStreamsConnection {
+		
+	public boolean allowInsecureHosts(boolean allowInsecure);
 
     /**
      * Gets a list of {@link Instance instances} that are available to this IBM

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV1.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV1.java
@@ -16,7 +16,7 @@ import com.google.gson.JsonObject;
  *
  */
 class StreamingAnalyticsConnectionV1 extends AbstractStreamingAnalyticsConnection {
-
+	
     /**
      * Connection to IBM Streaming Analytics service
      *
@@ -33,11 +33,11 @@ class StreamingAnalyticsConnectionV1 extends AbstractStreamingAnalyticsConnectio
      *            Service jobs REST API.
      * @throws IOException
      */
-    StreamingAnalyticsConnectionV1(String userName, String authToken,
-            String resourcesUrl, JsonObject credentials, boolean allowInsecure)
+    StreamingAnalyticsConnectionV1(
+    		StreamingAnalyticsServiceV1 service,
+            String resourcesUrl, boolean allowInsecure)
             throws IOException {
-        super(StreamsRestUtils.createBasicAuth(userName, authToken),
-                resourcesUrl, credentials, allowInsecure);
+        super(service, resourcesUrl, allowInsecure);
     }
 
     /**
@@ -54,32 +54,27 @@ class StreamingAnalyticsConnectionV1 extends AbstractStreamingAnalyticsConnectio
      */
     @Override
     boolean cancelJob(Instance instance, String jobId) throws IOException {
-        String restUrl = StreamsRestUtils.getRequiredMember(credentials, "rest_url");
-        String jobsUrl = restUrl + StreamsRestUtils.getRequiredMember(credentials, "jobs_path");
+        String restUrl = StreamsRestUtils.getRequiredMember(credentials(), "rest_url");
+        String jobsUrl = restUrl + StreamsRestUtils.getRequiredMember(credentials(), "jobs_path");
         return delete(jobsUrl + "?job_id=" + jobId);
     }
 
-    @Override
-    String getAuthorization() {
-        return authorization;
-    }
-
-    static StreamingAnalyticsConnectionV1 of(JsonObject service,
+    static StreamingAnalyticsConnectionV1 of(
+    		StreamingAnalyticsServiceV1 actualService,
+    		JsonObject service,
             boolean allowInsecure) throws IOException {
         JsonObject credentials = service.get("credentials").getAsJsonObject();
         String userId = StreamsRestUtils.getRequiredMember(credentials, MEMBER_USERID);
-        String authToken = StreamsRestUtils.getRequiredMember(credentials, MEMBER_PASSWORD);
-        String authorization = StreamsRestUtils.createBasicAuth(userId, authToken);
         String restUrl = StreamsRestUtils.getRequiredMember(credentials, "rest_url");
         String sasResourcesUrl = restUrl + StreamsRestUtils.getRequiredMember(credentials, "resources_path");
-        JsonObject sasResources = StreamsRestUtils.getServiceResources(authorization, sasResourcesUrl);
+        JsonObject sasResources = StreamsRestUtils.getServiceResources(actualService.getAuthorization(), sasResourcesUrl);
         String streamsBaseUrl = StreamsRestUtils.getRequiredMember(sasResources, "streams_rest_url");
         // In V1, streams_rest_url is missing /resources
         String streamsResourcesUrl = StreamsRestUtils.fixStreamsRestUrl(streamsBaseUrl);
 
         StreamingAnalyticsConnectionV1 connection =
-                new StreamingAnalyticsConnectionV1(userId, authToken,
-                streamsResourcesUrl, credentials, allowInsecure);
+                new StreamingAnalyticsConnectionV1(actualService,
+                streamsResourcesUrl, allowInsecure);
         connection.baseConsoleURL = StreamsRestUtils.getRequiredMember(sasResources, "streams_console_url");
         connection.init();
         return connection;

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV1.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV1.java
@@ -4,7 +4,6 @@
  */
 package com.ibm.streamsx.rest;
 
-import static com.ibm.streamsx.rest.StreamsRestUtils.MEMBER_PASSWORD;
 import static com.ibm.streamsx.rest.StreamsRestUtils.MEMBER_USERID;
 
 import java.io.IOException;
@@ -36,7 +35,7 @@ class StreamingAnalyticsConnectionV1 extends AbstractStreamingAnalyticsConnectio
     StreamingAnalyticsConnectionV1(
     		StreamingAnalyticsServiceV1 service,
             String resourcesUrl, boolean allowInsecure)
-            throws IOException {
+             {
         super(service, resourcesUrl, allowInsecure);
     }
 
@@ -76,7 +75,6 @@ class StreamingAnalyticsConnectionV1 extends AbstractStreamingAnalyticsConnectio
                 new StreamingAnalyticsConnectionV1(actualService,
                 streamsResourcesUrl, allowInsecure);
         connection.baseConsoleURL = StreamsRestUtils.getRequiredMember(sasResources, "streams_console_url");
-        connection.init();
         return connection;
     }
 }

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV2.java
@@ -19,7 +19,7 @@ class StreamingAnalyticsConnectionV2 extends AbstractStreamingAnalyticsConnectio
     StreamingAnalyticsConnectionV2(
     		StreamingAnalyticsServiceV2 service,
             String resourcesUrl, boolean allowInsecure)
-            throws IOException {
+            {
         super(service, resourcesUrl, allowInsecure);
     }
 
@@ -74,7 +74,6 @@ class StreamingAnalyticsConnectionV2 extends AbstractStreamingAnalyticsConnectio
                         streamsResourcesUrl,
                         allowInsecure);
         connection.baseConsoleURL = StreamsRestUtils.getRequiredMember(sasResources, "streams_console");
-        connection.init();
         return connection;
     }
 

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsConnectionV2.java
@@ -14,43 +14,13 @@ import com.google.gson.JsonObject;
 
 class StreamingAnalyticsConnectionV2 extends AbstractStreamingAnalyticsConnection {
 
-    private long authExpiryTime;
     private String jobsUrl;
-    private final String tokenUrl;
-    private final String apiKey;
 
-    StreamingAnalyticsConnectionV2(String authorization, long authExpiryTime,
-            String resourcesUrl, JsonObject credentials, boolean allowInsecure)
+    StreamingAnalyticsConnectionV2(
+    		StreamingAnalyticsServiceV2 service,
+            String resourcesUrl, boolean allowInsecure)
             throws IOException {
-        super(authorization, resourcesUrl, credentials, allowInsecure);
-        this.authExpiryTime = authExpiryTime;
-        this.tokenUrl = StreamsRestUtils.getTokenUrl(credentials);
-        this.apiKey = StreamsRestUtils.getServiceApiKey(credentials);
-    }
-
-    // Synchronized because it needs to read and possibly write two members
-    // that are interdependent: authExpiryTime and authorization. Should be
-    // fast enough without getting tricky: contention should be rare because
-    // of the way we use this, and this should be fast compared to the network
-    // I/O that typically follows using the returned authorization.
-    @Override
-    synchronized String getAuthorization() {
-        if (authorization == null ||
-                System.currentTimeMillis() > authExpiryTime) {
-            refreshAuthorization();
-        }
-        return authorization;
-    }
-
-    private void refreshAuthorization() {
-        JsonObject response = StreamsRestUtils.getTokenResponse(tokenUrl, apiKey);
-        if (null != response) {
-            String accessToken = StreamsRestUtils.getToken(response);
-            if (null != accessToken) {
-                setAuthorization(StreamsRestUtils.createBearerAuth(accessToken));
-                authExpiryTime = StreamsRestUtils.getTokenExpiryMillis(response);
-            }
-        }
+        super(service, resourcesUrl, allowInsecure);
     }
 
     /**
@@ -70,7 +40,7 @@ class StreamingAnalyticsConnectionV2 extends AbstractStreamingAnalyticsConnectio
     @Override
     boolean cancelJob(Instance instance, String jobId) throws IOException {
         if (null == jobsUrl) {
-            String restUrl = jstring(credentials, "v2_rest_url");
+            String restUrl = jstring(credentials(), "v2_rest_url");
             JsonObject response = StreamsRestUtils.getGsonResponse(executor,
                     getAuthorization(), restUrl);
             JsonElement element = response.get("jobs");
@@ -84,13 +54,15 @@ class StreamingAnalyticsConnectionV2 extends AbstractStreamingAnalyticsConnectio
         return delete(jobsUrl + "/" + jobId);
     }
 
-    static StreamingAnalyticsConnectionV2 of(JsonObject service,
-            String authorization, long authExpiryMillis, boolean allowInsecure)
+    static StreamingAnalyticsConnectionV2 of(
+    		StreamingAnalyticsServiceV2 actualService,
+    		JsonObject service,
+            boolean allowInsecure)
             throws IOException {
         JsonObject credentials = service.get("credentials").getAsJsonObject();
         String sasResourcesUrl = StreamsRestUtils.getRequiredMember(credentials,
                 StreamsRestUtils.MEMBER_V2_REST_URL);
-        JsonObject sasResources = StreamsRestUtils.getServiceResources(authorization, sasResourcesUrl);
+        JsonObject sasResources = StreamsRestUtils.getServiceResources(actualService.getAuthorization(), sasResourcesUrl);
         String instanceUrl = StreamsRestUtils.getRequiredMember(sasResources,
                 "streams_self");
         // Find root URL. V2 starts at the instance, we want resources
@@ -98,8 +70,8 @@ class StreamingAnalyticsConnectionV2 extends AbstractStreamingAnalyticsConnectio
         String streamsResourcesUrl = StreamsRestUtils.fixStreamsRestUrl(baseUrl);
 
         StreamingAnalyticsConnectionV2 connection =
-                new StreamingAnalyticsConnectionV2(authorization,
-                        authExpiryMillis, streamsResourcesUrl, credentials,
+                new StreamingAnalyticsConnectionV2(actualService, 
+                        streamsResourcesUrl,
                         allowInsecure);
         connection.baseConsoleURL = StreamsRestUtils.getRequiredMember(sasResources, "streams_console");
         connection.init();

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
@@ -36,17 +36,20 @@ import com.google.gson.JsonObject;
  * This is cut & paste of the code from the original uses. 
  */
 class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
+	
+	private final String authorization;
+	
     StreamingAnalyticsServiceV1(JsonObject service) {
         super(service);
         // Authorization header never changes in V1 once set
-        setAuthorization(StreamsRestUtils.createBasicAuth(credentials));
+        authorization = StreamsRestUtils.createBasicAuth(credentials());
     }
 
     @Override
     protected String getStatusUrl(CloseableHttpClient httpClient) {
         StringBuilder sb = new StringBuilder(500);
-        sb.append(jstring(credentials, "rest_url"));
-        sb.append(jstring(credentials, "status_path"));
+        sb.append(jstring(credentials(), "rest_url"));
+        sb.append(jstring(credentials(), "status_path"));
         return sb.toString();
     }
 
@@ -54,8 +57,8 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
     protected String getJobSubmitUrl(CloseableHttpClient httpClient, File bundle)
             throws UnsupportedEncodingException {
         StringBuilder sb = new StringBuilder(500);
-        sb.append(jstring(credentials, "rest_url"));
-        sb.append(jstring(credentials, "jobs_path"));
+        sb.append(jstring(credentials(), "rest_url"));
+        sb.append(jstring(credentials(), "jobs_path"));
         sb.append("?");
         sb.append("bundle_id=");
         sb.append(URLEncoder.encode(bundle.getName(), StandardCharsets.UTF_8.name()));
@@ -67,8 +70,8 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
             throws UnsupportedEncodingException {
         String artifactId = jstring(artifact, "id");
         StringBuilder sb = new StringBuilder(500);
-        sb.append(jstring(credentials, "rest_url"));
-        sb.append(jstring(credentials, "jobs_path").replace("jobs", "builds"));
+        sb.append(jstring(credentials(), "rest_url"));
+        sb.append(jstring(credentials(), "jobs_path").replace("jobs", "builds"));
         sb.append("?");
         sb.append("artifact_id=");
         sb.append(URLEncoder.encode(artifactId, StandardCharsets.UTF_8.name()));
@@ -77,8 +80,8 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
 
     @Override
     protected String getBuildsUrl(CloseableHttpClient httpClient){
-        String buildURL = jstring(credentials, "jobs_path").replace("jobs", "builds");
-        return jstring(credentials, "rest_url") + buildURL;
+        String buildURL = jstring(credentials(), "jobs_path").replace("jobs", "builds");
+        return jstring(credentials(), "rest_url") + buildURL;
     }
 
     @Override
@@ -176,6 +179,6 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
 
     @Override
     AbstractStreamingAnalyticsConnection createStreamsConnection() throws IOException {
-        return StreamingAnalyticsConnectionV1.of(service, false);
+        return StreamingAnalyticsConnectionV1.of(this, service, false);
     }
 }

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
@@ -95,12 +95,11 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
     }
 
     @Override
-    protected JsonObject getBuild(String buildId, CloseableHttpClient httpclient,
-            String authorization) throws IOException {
+    protected JsonObject getBuild(String buildId, CloseableHttpClient httpclient) throws IOException {
         String buildURL = getBuildsUrl(httpclient) + "?build_id="
             + URLEncoder.encode(buildId, StandardCharsets.UTF_8.name());
         HttpGet httpget = new HttpGet(buildURL);
-        httpget.addHeader("Authorization", authorization);
+        httpget.addHeader("Authorization", getAuthorization());
 
         JsonObject response = StreamsRestUtils.getGsonResponse(httpclient, httpget);
         // Get the correct build
@@ -116,14 +115,14 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
 
     @Override
     protected JsonObject getBuildOutput(String buildId, String outputId,
-            CloseableHttpClient httpclient, String authorization)
+            CloseableHttpClient httpclient)
             throws IOException {
         String buildOutputURL = getBuildsUrl(httpclient) + "?build_id="
                 + URLEncoder.encode(buildId, StandardCharsets.UTF_8.name())
                 + "&output_id="
                 + URLEncoder.encode(outputId, StandardCharsets.UTF_8.name());
         HttpGet httpget = new HttpGet(buildOutputURL);
-        httpget.addHeader("Authorization", authorization);
+        httpget.addHeader("Authorization", getAuthorization());
 
         JsonObject response = StreamsRestUtils.getGsonResponse(httpclient, httpget);
         for(JsonElement outputElem : array(response, "builds")){
@@ -137,12 +136,12 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
 
     @Override
     protected JsonObject submitBuild(CloseableHttpClient httpclient,
-            String authorization, File archive, String buildName)
+            File archive, String buildName)
             throws IOException {
         String newBuildURL = getBuildsUrl(httpclient) + "?build_name=" +
                 URLEncoder.encode(buildName, StandardCharsets.UTF_8.name());
         HttpPost httppost = new HttpPost(newBuildURL);
-        httppost.addHeader("Authorization", authorization);
+        httppost.addHeader("Authorization", getAuthorization());
 
         FileBody archiveBody = new FileBody(archive,
                 ContentType.create("application/zip"));
@@ -159,11 +158,12 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
     /**
      * Submit the job from the built artifact.
      */
+    @Override
     protected JsonObject submitBuildArtifact(CloseableHttpClient httpclient,
-            JsonObject jobConfigOverlays, String authorization, String submitUrl)
+            JsonObject jobConfigOverlays, String submitUrl)
             throws IOException {
         HttpPut httpput = new HttpPut(submitUrl);
-        httpput.addHeader("Authorization", authorization);
+        httpput.addHeader("Authorization", getAuthorization());
         httpput.addHeader("content-type", ContentType.APPLICATION_JSON.getMimeType());
 
         StringEntity params = new StringEntity(jobConfigOverlays.toString(),

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
@@ -123,37 +123,36 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
     }
 
     @Override
-    protected JsonObject getBuild(String buildId, CloseableHttpClient httpclient,
-            String authorization) throws IOException {
+    protected JsonObject getBuild(String buildId, CloseableHttpClient httpclient) throws IOException {
         String buildURL = getBuildsUrl(httpclient) + "/"
             + URLEncoder.encode(buildId, StandardCharsets.UTF_8.name());
         HttpGet httpget = new HttpGet(buildURL);
-        httpget.addHeader("Authorization", authorization);
+        httpget.addHeader("Authorization", getAuthorization());
 
         return StreamsRestUtils.getGsonResponse(httpclient, httpget);
     }
 
     @Override
     protected JsonObject getBuildOutput(String buildId, String outputId,
-            CloseableHttpClient httpclient, String authorization)
+            CloseableHttpClient httpclient)
             throws IOException {
         String buildOutputURL = getBuildsUrl(httpclient) + "/"
                 + URLEncoder.encode(buildId, StandardCharsets.UTF_8.name())
                 + "?output_id="
                 + URLEncoder.encode(outputId, StandardCharsets.UTF_8.name());
         HttpGet httpget = new HttpGet(buildOutputURL);
-        httpget.addHeader("Authorization", authorization);
+        httpget.addHeader("Authorization", getAuthorization());
 
         return StreamsRestUtils.getGsonResponse(httpclient, httpget);
     }
 
     @Override
     protected JsonObject submitBuild(CloseableHttpClient httpclient,
-            String authorization, File archive, String buildName)
+            File archive, String buildName)
             throws IOException {
         String newBuildURL = getBuildsUrl(httpclient);
         HttpPost httppost = new HttpPost(newBuildURL);
-        httppost.addHeader("Authorization", authorization);
+        httppost.addHeader("Authorization", getAuthorization());
 
         JsonObject buildParams = new JsonObject();
         buildParams.addProperty("buildName", buildName);
@@ -176,11 +175,12 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
     /**
      * Submit the job from the built artifact.
      */
+    @Override
     protected JsonObject submitBuildArtifact(CloseableHttpClient httpclient,
-            JsonObject jobConfigOverlays, String authorization, String submitUrl)
+            JsonObject jobConfigOverlays, String submitUrl)
             throws IOException {
         HttpPost postArtifact = new HttpPost(submitUrl);
-        postArtifact.addHeader("Authorization", authorization);
+        postArtifact.addHeader("Authorization", getAuthorization());
 
         StringBody paramsBody = new StringBody(jobConfigOverlays.toString(),
                 ContentType.APPLICATION_JSON);

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV2.java
@@ -33,12 +33,14 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
     private final String tokenUrl;
     private final String apiKey;
     private final String statusUrl;
+    
+    private String authorization;
 
     StreamingAnalyticsServiceV2(JsonObject service) {
         super(service);
-        tokenUrl = StreamsRestUtils.getTokenUrl(credentials);
-        apiKey = StreamsRestUtils.getServiceApiKey(credentials);
-        statusUrl = jstring(credentials, "v2_rest_url");
+        tokenUrl = StreamsRestUtils.getTokenUrl(credentials());
+        apiKey = StreamsRestUtils.getServiceApiKey(credentials());
+        statusUrl = jstring(credentials(), "v2_rest_url");
     }
 
     // Synchronized because it needs to read and possibly write two members
@@ -59,7 +61,7 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
         if (null != response) {
             String accessToken = StreamsRestUtils.getToken(response);
             if (null != accessToken) {
-                setAuthorization(StreamsRestUtils.createBearerAuth(accessToken));
+            	authorization = StreamsRestUtils.createBearerAuth(accessToken);
                 authExpiryTime = StreamsRestUtils.getTokenExpiryMillis(response);
             }
         }
@@ -193,8 +195,7 @@ class StreamingAnalyticsServiceV2 extends AbstractStreamingAnalyticsService {
 
     @Override
     AbstractStreamingAnalyticsConnection createStreamsConnection() throws IOException {
-        return StreamingAnalyticsConnectionV2.of(service, getAuthorization(),
-                authExpiryTime, false);
+        return StreamingAnalyticsConnectionV2.of(this, service, false);
     }
 
 }

--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -5,12 +5,8 @@
 package com.ibm.streamsx.rest;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.List;
 
-import org.apache.http.client.fluent.Executor;
-
-import com.ibm.streamsx.topology.internal.streams.InvokeCancel;
 import com.ibm.streamsx.topology.internal.streams.Util;
 
 /**
@@ -24,31 +20,10 @@ public class StreamsConnection {
     private String authToken;
     private String url;
 
-    /**
-     * @deprecated No replacement {@code StreamsConnection} is not intended to be sub-classed.
-     */
-    @Deprecated
-    protected String apiKey;
-    
-    /**
-     * @deprecated No replacement {@code StreamsConnection} is not intended to be sub-classed.
-     */
-    @Deprecated
-    protected Executor executor;
-
     StreamsConnection(IStreamsConnection delegate,
             boolean allowInsecure) {
         this.delegate = delegate;
         this.allowInsecure = allowInsecure;
-        refreshState();
-    }
-
-    /**
-     * @deprecated No replacement {@code StreamsConnection} is not intended to be sub-classed.
-     */
-    @Deprecated
-    protected StreamsConnection(String userName, String authToken, String url) {
-        this(createDelegate(userName, authToken, url), false);
     }
 
     /**
@@ -109,7 +84,6 @@ public class StreamsConnection {
      *         </ul>
      */
     public boolean allowInsecureHosts(boolean allowInsecure) {
-        refreshState();
         if (allowInsecure != this.allowInsecure
                 && null != userName && null != authToken && null != url) {
             try {
@@ -129,34 +103,6 @@ public class StreamsConnection {
     }
 
     /**
-     * Cancels a job identified by the jobId.
-     * <BR>
-     * <B>WARNING:</B> This cancels the job in the domain
-     * and instance identified by the environment variables
-     * {@code STREAMS_DOMAIN_ID} and {@code STREAMS_INSTANCE_ID}
-     * which may not be the intended job.
-     * <BR>
-     * Use {@link Job#cancel()} to cancel a job.
-     * 
-     * @param jobId
-     *            string identifying the job to be cancelled
-     * @return a boolean indicating
-     *         <ul>
-     *         <li>true if the jobId is cancelled</li>
-     *         <li>false if the jobId did not get cancelled</li>
-     *         </ul>
-     * @throws Exception
-     * @deprecated Not recommend for use as an instance is not uniquely defined
-     * by a {@code StreamsConnection}. Use {@link Job#cancel()}.
-     */
-    @Deprecated
-    public boolean cancelJob(String jobId) throws Exception {
-        refreshState();
-        InvokeCancel cancelJob = new InvokeCancel(new BigInteger(jobId), userName);
-        return cancelJob.invoke(false) == 0;
-    }
-
-    /**
      * Gets a specific {@link Instance instance} identified by the instanceId at
      * this IBM Streams connection
      * 
@@ -166,7 +112,6 @@ public class StreamsConnection {
      * @throws IOException
      */
     public Instance getInstance(String instanceId) throws IOException {
-        refreshState();
         return delegate.getInstance(instanceId);
     }
 
@@ -179,27 +124,9 @@ public class StreamsConnection {
      * @throws IOException
      */
     public List<Instance> getInstances() throws IOException {
-        refreshState();
         return delegate.getInstances();
     }
 
-    // Refresh protected members from the previous implementation
-    void refreshState() {
-        if (delegate instanceof AbstractStreamsConnection) {
-            AbstractStreamsConnection asc = (AbstractStreamsConnection)delegate;
-            apiKey = asc.getAuthorization();
-            executor = asc.getExecutor();
-        }
-    }
-
-    /**
-     * @deprecated No replacement {@code StreamsConnection} is not intended to be sub-classed.
-     */
-    @Deprecated
-    protected void setStreamsRESTURL(String url) {
-        delegate = createDelegate(userName, authToken, url);
-        refreshState();
-    }
 
     private static IStreamsConnection createDelegate(String userName,
             String authToken, String url) {

--- a/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
@@ -13,7 +13,7 @@ class StreamsConnectionImpl extends AbstractStreamsConnection {
     private final String userName;
 
     StreamsConnectionImpl(String userName, String authorization,
-            String resourcesUrl, boolean allowInsecure) throws IOException {
+            String resourcesUrl, boolean allowInsecure) {
         super(resourcesUrl, allowInsecure);
         this.userName = userName;
         this.authorization = authorization;

--- a/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
@@ -9,12 +9,14 @@ import com.ibm.streamsx.topology.internal.streams.InvokeSubmit;
 
 class StreamsConnectionImpl extends AbstractStreamsConnection {
 
+	private final String authorization;
     private final String userName;
 
     StreamsConnectionImpl(String userName, String authorization,
             String resourcesUrl, boolean allowInsecure) throws IOException {
-        super(authorization, resourcesUrl, allowInsecure);
+        super(resourcesUrl, allowInsecure);
         this.userName = userName;
+        this.authorization = authorization;
     }
 
     @Override

--- a/test/java/src/com/ibm/streamsx/rest/test/AppBundleSasTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/AppBundleSasTest.java
@@ -1,6 +1,6 @@
 /*
 # Licensed Materials - Property of IBM
-# Copyright IBM Corp. 2017
+# Copyright IBM Corp. 2018
  */
 
 package com.ibm.streamsx.rest.test;
@@ -19,11 +19,5 @@ public class AppBundleSasTest extends AppBundleTest {
 	@Override
 	protected Instance getInstance() throws IOException {
 		return StreamingAnalyticsConnectionTest.getTestService().getInstance();
-	}
-	
-	@Override
-	public void testAppBundles() throws Exception {
-		// TODO Add test in when implemented.
-		//super.testAppBundles();
 	}
 }

--- a/test/java/src/com/ibm/streamsx/rest/test/AppBundleTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/AppBundleTest.java
@@ -1,6 +1,6 @@
 /*
 # Licensed Materials - Property of IBM
-# Copyright IBM Corp. 2017
+# Copyright IBM Corp. 2018
  */
 
 package com.ibm.streamsx.rest.test;

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
@@ -52,7 +52,7 @@ public class StreamsConnectionTest {
     public StreamsConnectionTest() {
     }
 
-    protected String getStreamsPort() {
+    static String getStreamsPort() {
         String streamsPort = System.getenv("STREAMS_INSTANCE_PORT");
         if ((streamsPort == null) || streamsPort.isEmpty()) {
             // if port not specified, assume default one

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamsOnlyConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamsOnlyConnectionTest.java
@@ -23,12 +23,12 @@ import com.ibm.streamsx.rest.StreamsConnection;
  * Tests that only make sense with an on-prem streams.
  *
  */
-public class StreamsOnlyConnectionTest extends StreamsConnectionTest{
+public class StreamsOnlyConnectionTest {
 
     @Test
     public void testBadConnections() throws Exception {
 
-        String sPort = getStreamsPort();
+        String sPort = StreamsConnectionTest.getStreamsPort();
 
         // send in wrong url
         String badUrl = "https://localhost:" + sPort + "/streams/re";
@@ -72,11 +72,14 @@ public class StreamsOnlyConnectionTest extends StreamsConnectionTest{
 
     @Test
     public void testGetInstances() throws Exception {
-        setupConnection();
+        StreamsConnection connection = StreamsConnection.createInstance(null, null, null);
+        connection.allowInsecureHosts(true);
         // get all instances in the domain
         List<Instance> instances = connection.getInstances();
         // there should be at least one instance
         assertTrue(instances.size() > 0);
+        
+        String instanceName = System.getenv("STREAMS_INSTANCE_ID");
 
         Instance i2 = connection.getInstance(instanceName);
         assertEquals(instanceName, i2.getId());
@@ -90,7 +93,7 @@ public class StreamsOnlyConnectionTest extends StreamsConnectionTest{
         }
         
         for (Instance instance : instances)
-            checkDomainFromInstance(instance);
+            StreamsConnectionTest.checkDomainFromInstance(instance);
 
         try {
             // try a fake instance name


### PR DESCRIPTION
Remove deprecated methods to allow clean split between connections and delegates.