### PR TITLE
Removing state handler's from non-stateful Python operators.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -1,10 +1,3 @@
-/* Additional includes go here */
-
-#include "splpy.h"
-#include "splpy_funcop.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 @include "../pyspltuple.cgt"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -65,7 +65,7 @@ MY_OPERATOR::MY_OPERATOR() :
  }
 %>
 
-    funcop_ = new SplpyFuncOp(this, out_wrapfn);
+    funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, out_wrapfn);
 
 @include "../pyspltuple_constructor.cgt"
     
@@ -78,6 +78,9 @@ MY_OPERATOR::MY_OPERATOR() :
     loads = SplpyGeneral::loadFunction("json", "loads");
     <% } %>
     }
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -20,8 +20,10 @@ using namespace streamsx::topology;
 
 @include "../pyspltuple.cgt"
 class MY_OPERATOR : public MY_BASE_OPERATOR,
-      public WindowEvent<PyObject *>,
-      public DelegatingStateHandler
+      public WindowEvent<PyObject *>
+#if SPLPY_OP_STATEFUL == 1
+      ,public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -1,4 +1,7 @@
-/* Additional includes go here */
+@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../../opt/python/codegen/py_state.cgt"
+
+#include "splpy.h"
 #include "splpy_funcop.h"
 #include <SPL/Runtime/Window/Window.h>
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -1,4 +1,4 @@
-@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../py_pystateful.cgt"
 @include "../../opt/python/codegen/py_state.cgt"
 
 #include "splpy.h"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -1,10 +1,3 @@
-/* Additional includes go here */
-
-#include "splpy.h"
-#include "splpy_funcop.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 @include "../pyspltuple.cgt"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -12,9 +12,13 @@ MY_OPERATOR::MY_OPERATOR() :
    pyInStyleObj_(NULL),
    crContext(this)
 {
-    funcop_ = new SplpyFuncOp(this, "<%=$pywrapfunc%>");
+    funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, "<%=$pywrapfunc%>");
 
 @include "../pyspltuple_constructor.cgt"
+
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
@@ -10,7 +10,10 @@ using namespace streamsx::topology;
 
 @include "../../opt/python/codegen/py_disallow_cr_trigger.cgt"
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+ , public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
@@ -1,4 +1,4 @@
-@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../py_pystateful.cgt"
 @include "../../opt/python/codegen/py_state.cgt"
 
 #include "splpy.h"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
@@ -1,4 +1,7 @@
-/* Additional includes go here */
+@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../../opt/python/codegen/py_state.cgt"
+
+#include "splpy.h"
 #include "splpy_funcop.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
@@ -1,11 +1,3 @@
-/* Additional includes go here */
-
-#include "splpy.h"
-#include "splpy_tuple.h"
-#include "splpy_funcop.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 @include "../pyspltuple.cgt"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
@@ -51,9 +51,12 @@ MY_OPERATOR::MY_OPERATOR() :
  }
 %>
 
-    funcop_ = new SplpyFuncOp(this, wrapfn);
+    funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, wrapfn);
 
 @include "../pyspltuple_constructor.cgt"
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
@@ -1,4 +1,8 @@
-/* Additional includes go here */
+@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../../opt/python/codegen/py_state.cgt"
+
+#include "splpy.h"
+#include "splpy_tuple.h"
 #include "splpy_funcop.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
@@ -1,4 +1,4 @@
-@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../py_pystateful.cgt"
 @include "../../opt/python/codegen/py_state.cgt"
 
 #include "splpy.h"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
@@ -11,7 +11,10 @@ using namespace streamsx::topology;
 
 @include "../../opt/python/codegen/py_disallow_cr_trigger.cgt"
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+      ,public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -1,10 +1,3 @@
-/* Additional includes go here */
-
-#include "splpy.h"
-#include "splpy_funcop.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 @include "../pyspltuple.cgt"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -11,9 +11,13 @@ MY_OPERATOR::MY_OPERATOR():
    funcop_(NULL),
    pyInStyleObj_(NULL)
 {
-    funcop_ = new SplpyFuncOp(this, "<%=$pywrapfunc%>");
+    funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, "<%=$pywrapfunc%>");
 
 @include "../pyspltuple_constructor.cgt"
+
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_h.cgt
@@ -8,7 +8,10 @@ using namespace streamsx::topology;
 
 <%SPL::CodeGen::headerPrologue($model);%>
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+      ,public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_h.cgt
@@ -1,4 +1,4 @@
-@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../py_pystateful.cgt"
 @include "../../opt/python/codegen/py_state.cgt"
 
 #include "splpy.h"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_h.cgt
@@ -1,4 +1,7 @@
-/* Additional includes go here */
+@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../../opt/python/codegen/py_state.cgt"
+
+#include "splpy.h"
 #include "splpy_funcop.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -11,9 +11,13 @@ MY_OPERATOR::MY_OPERATOR() :
    pyInStyleObj_(NULL),
    crContext(this)
 {
-    funcop_ = new SplpyFuncOp(this, "<%=$pywrapfunc%>");
+    funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, "<%=$pywrapfunc%>");
 
 @include "../pyspltuple_constructor.cgt"
+
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -1,8 +1,3 @@
-#include "splpy.h"
-#include "splpy_funcop.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 @include "../pyspltuple.cgt"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
@@ -10,7 +10,10 @@ using namespace streamsx::topology;
 
 @include "../../opt/python/codegen/py_disallow_cr_trigger.cgt"
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+      ,public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
@@ -1,4 +1,4 @@
-@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../py_pystateful.cgt"
 @include "../../opt/python/codegen/py_state.cgt"
 
 #include "splpy.h"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
@@ -1,4 +1,7 @@
-/* Additional includes go here */
+@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../../opt/python/codegen/py_state.cgt"
+
+#include "splpy.h"
 #include "splpy_funcop.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -1,10 +1,3 @@
-/* Additional includes go here */
-
-#include "splpy.h"
-#include "splpy_funcop.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 @include "../pyspltuple.cgt"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -49,7 +49,7 @@ MY_OPERATOR::MY_OPERATOR() :
  }
 %>
 
-    funcop_ = new SplpyFuncOp(this, wrapfn);
+    funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, wrapfn);
 
 @include "../pyspltuple_constructor.cgt"
 
@@ -59,6 +59,10 @@ MY_OPERATOR::MY_OPERATOR() :
   pyOutNames_0 = Splpy::pyAttributeNames(getOutputPortAt(0));
   }
 <%}%>
+
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
@@ -16,7 +16,10 @@ using namespace streamsx::topology;
  my $oport = $model->getOutputPortAt(0);
 %>
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+      ,public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
@@ -1,6 +1,7 @@
 @include "../../opt/python/codegen/py_pystateful.cgt"
 @include "../../opt/python/codegen/py_state.cgt"
 
+#include "splpy.h"
 #include "splpy_funcop.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
@@ -1,4 +1,4 @@
-@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../py_pystateful.cgt"
 @include "../../opt/python/codegen/py_state.cgt"
 
 #include "splpy.h"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
@@ -1,4 +1,6 @@
-/* Additional includes go here */
+@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../../opt/python/codegen/py_state.cgt"
+
 #include "splpy_funcop.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source.xml
@@ -70,15 +70,6 @@
         <cardinality>1</cardinality>
       </parameter>
       <parameter>
-       <name>pyStateful</name>
-        <description>Whether the operator has state to be saved in checkpointing.</description>
-        <optional>false</optional>
-        <rewriteAllowed>false</rewriteAllowed>
-        <expressionMode>Constant</expressionMode>
-        <type>boolean</type>
-        <cardinality>1</cardinality>
-      </parameter>
-      <parameter>
         <name>submissionParamNames</name>
         <description>Submission parameter names</description>
         <optional>true</optional>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
@@ -31,7 +31,11 @@ MY_OPERATOR::MY_OPERATOR() :
  }
 %>
 
-    funcop_ = new SplpyFuncOp(this, wrapfn);
+    funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, wrapfn);
+
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
@@ -1,10 +1,3 @@
-/* Additional includes go here */
-
-#include "splpy.h"
-#include "splpy_funcop.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 <% my $pywrapfunc='source_pickle'; %>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_h.cgt
@@ -1,4 +1,4 @@
-@include "../../opt/python/codegen/py_pystateful.cgt"
+<% my $pyStateful = 1; %>
 @include "../../opt/python/codegen/py_state.cgt"
 
 #include "splpy.h"

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_h.cgt
@@ -1,4 +1,7 @@
-/* Additional includes go here */
+@include "../../opt/python/codegen/py_pystateful.cgt"
+@include "../../opt/python/codegen/py_state.cgt"
+
+#include "splpy.h"
 #include "splpy_funcop.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_h.cgt
@@ -10,7 +10,10 @@ using namespace streamsx::topology;
 
 @include "../../opt/python/codegen/py_disallow_cr_trigger.cgt"
  
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+      ,public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/py_pystateful.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/py_pystateful.cgt
@@ -1,0 +1,4 @@
+<% 
+ # State $pyStateful from functional operator parameter.
+ my $pyStateful = $model->getParameterByName("pyStateful")->getValueAt(0)->getSPLExpression() eq "true";
+%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/py_pystateful.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/py_pystateful.cgt
@@ -1,4 +1,4 @@
 <% 
  # State $pyStateful from functional operator parameter.
- my $pyStateful = $model->getParameterByName("pyStateful")->getValueAt(0)->getSPLExpression() eq "true";
+ my $pyStateful = $model->getParameterByName("pyStateful")->getValueAt(0)->getSPLExpression() eq "true" ? 1 : 0;
 %>

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
@@ -21,5 +21,3 @@
   typedef OptionalConsistentRegionContextImpl<isInConsistentRegion> OptionalConsistentRegionContext;
   typedef OptionalConsistentRegionContext::Permit AutoConsistentRegionPermit;
   typedef OptionalAutoLockImpl<isCheckpointing> OptionalAutoLock;
-
-

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
@@ -11,27 +11,12 @@
  # It also provides some typedefs for types to be used by the operator
  # to support checkpointing and consistent region.
 
- my $isInConsistentRegion = $model->getContext()->getOptionalContext("ConsistentRegion");
- my $ckptKind = $model->getContext()->getCheckpointingKind();
- my $pyStateful = $model->getParameterByName("pyStateful");
- my $stateful = 0;
- if (defined($pyStateful)) {
-   $stateful = $pyStateful->getValueAt(0)->getSPLExpression() eq "true";
- }
- else {
-   # no pyStateful parameter.  Try calling splpy_OperatorCallable().
-   if (defined &splpy_OperatorCallable) {
-     $stateful = splpy_OperatorCallable() eq 'class'
-   }
- }
-
- my $isCheckpointing = $stateful && ($isInConsistentRegion or $ckptKind ne "none");
 %>
   // True if this operator is in a consistent region.
   static const bool isInConsistentRegion = <%= $isInConsistentRegion ? "true" :" false" %>;
   // True if operator is stateful and checkpoint is enabled, 
   // whether directly or through consistent region.
-  static const bool isCheckpointing = <%=$isCheckpointing ? "true" : "false" %>;
+  static const bool isCheckpointing = <%=$splpy_op_stateful ? "true" : "false" %>;
 
   typedef OptionalConsistentRegionContextImpl<isInConsistentRegion> OptionalConsistentRegionContext;
   typedef OptionalConsistentRegionContext::Permit AutoConsistentRegionPermit;

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_pystateful.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_pystateful.cgt
@@ -1,0 +1,4 @@
+<% 
+ # State $pyStateful from functional operator parameter.
+ my $XpyStateful = $model->getParameterByName("pyStateful")->getValueAt(0)->getSPLExpression() eq "true";
+%>

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_pystateful.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_pystateful.cgt
@@ -1,4 +1,0 @@
-<% 
- # State $pyStateful from functional operator parameter.
- my $XpyStateful = $model->getParameterByName("pyStateful")->getValueAt(0)->getSPLExpression() eq "true";
-%>

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_state.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_state.cgt
@@ -2,17 +2,16 @@
  # State handling setup for Python operators.
  # Requires $pyStateful is set
  # Sets CPP defines:
- #     SPLPY_OP_STATEFUL - Set if the operator needs a state handle.
+ #     SPLPY_OP_STATEFUL - Set to 1 if the operator needs a state handle.
 
- my $isInConsistentRegion = $model->getContext()->getOptionalContext("ConsistentRegion");
+ my $isInConsistentRegion = $model->getContext()->getOptionalContext("ConsistentRegion") ? 1 : 0;
  my $ckptKind = $model->getContext()->getCheckpointingKind();
 %>
 // isInConsistentRegion <%=$isInConsistentRegion%>
 // ckptKind <%=$ckptKind%>
 // pyStateful <%=$pyStateful%>
 <%
- my $splpy_op_stateful = $pyStateful && ($isInConsistentRegion or $ckptKind ne "none");
- if ($splpy_op_stateful) {
+ my $splpy_op_stateful = $pyStateful && ($isInConsistentRegion or $ckptKind ne "none") ? 1 : 0;
 %>
-#define SPLPY_OP_STATEFUL
-<%}%>
+#define SPLPY_OP_STATEFUL <%=$splpy_op_stateful%>
+#define SPLPY_OP_CR <%=$isInConsistentRegion%>

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_state.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_state.cgt
@@ -2,17 +2,17 @@
  # State handling setup for Python operators.
  # Requires $pyStateful is set
  # Sets CPP defines:
- #     SPLPY_STATE_HANDLER - Set if the operator needs a state handle.
+ #     SPLPY_OP_STATEFUL - Set if the operator needs a state handle.
 
  my $isInConsistentRegion = $model->getContext()->getOptionalContext("ConsistentRegion");
  my $ckptKind = $model->getContext()->getCheckpointingKind();
 %>
 // isInConsistentRegion <%=$isInConsistentRegion%>
 // ckptKind <%=$ckptKind%>
-// XpyStateful <%=$XpyStateful%>
+// pyStateful <%=$pyStateful%>
 <%
- my $needStateHandler = $XpyStateful && ($isInConsistentRegion or $ckptKind ne "none");
- if ($needStateHandler) {
+ my $splpy_op_stateful = $pyStateful && ($isInConsistentRegion or $ckptKind ne "none");
+ if ($splpy_op_stateful) {
 %>
-#define SPLPY_STATE_HANDLER
+#define SPLPY_OP_STATEFUL
 <%}%>

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_state.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_state.cgt
@@ -1,0 +1,18 @@
+<% 
+ # State handling setup for Python operators.
+ # Requires $pyStateful is set
+ # Sets CPP defines:
+ #     SPLPY_STATE_HANDLER - Set if the operator needs a state handle.
+
+ my $isInConsistentRegion = $model->getContext()->getOptionalContext("ConsistentRegion");
+ my $ckptKind = $model->getContext()->getCheckpointingKind();
+%>
+// isInConsistentRegion <%=$isInConsistentRegion%>
+// ckptKind <%=$ckptKind%>
+// XpyStateful <%=$XpyStateful%>
+<%
+ my $needStateHandler = $XpyStateful && ($isInConsistentRegion or $ckptKind ne "none");
+ if ($needStateHandler) {
+%>
+#define SPLPY_STATE_HANDLER
+<%}%>

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_cr.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_cr.h
@@ -120,7 +120,7 @@ template<>
 class OptionalAutoLockImpl<false>
 {
  public:
-  OptionalAutoLockImpl(DelegatingStateHandler*) {}
+  OptionalAutoLockImpl(void* outer) {}
 };
 
 inline void DelegatingStateHandler::checkpoint(SPL::Checkpoint & ckpt) {

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
@@ -29,13 +29,15 @@ namespace streamsx {
 class SplpyFuncOp : public SplpyOp {
   public:
 
-      SplpyFuncOp(SPL::Operator * op, const std::string & wrapfn) :
+      SplpyFuncOp(SPL::Operator * op, bool stateful,  const std::string & wrapfn) :
         SplpyOp(op, "/opt/python/packages/streamsx/topology")
       {
          setSubmissionParameters();
          addAppPythonPackages();
-         loadAndWrapCallable(wrapfn);
+         loadAndWrapCallable(stateful, wrapfn);
       }
+
+      virtual ~SplpyFuncOp() {}
       
   private:
       int hasParam(const char *name) {
@@ -77,7 +79,7 @@ class SplpyFuncOp : public SplpyOp {
        * Load and wrap the callable that will be invoked
        * by the operator.
       */
-      void loadAndWrapCallable(const std::string & wrapfn) {
+      void loadAndWrapCallable(bool stateful, const std::string & wrapfn) {
           SplpyGIL lock;
 
           // pointer to the application function or callable class
@@ -104,7 +106,7 @@ class SplpyFuncOp : public SplpyOp {
 
           setCallable(SplpyGeneral::callFunction(
                "streamsx.topology.runtime", wrapfn, appCallable, extraArg));
-          setup();
+          setup(stateful);
       }
 
       /*

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_funcop.h
@@ -107,10 +107,6 @@ class SplpyFuncOp : public SplpyOp {
           setup();
       }
 
-      virtual bool isStateful() {
-        return static_cast<SPL::boolean>(op()->getParameterValues("pyStateful")[0]->getValue());
-      }
- 
       /*
        *  Add any packages in the application directory
        *  to the Python path. The application directory

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
@@ -183,7 +183,11 @@ class SplpyOp {
        * Is this operator stateful for checkpointing?  Derived classes
        * must override this to support checkpointing.
        */
-      virtual bool isStateful () { return false; }
+#ifdef SPLPY_OP_STATEFUL
+      bool isStateful () { return true; }
+#else
+      bool isStateful () { return false; }
+#endif
 
       /**
        * Register a state handler for the operator.  The state handler

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_pyop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_pyop.h
@@ -28,6 +28,8 @@ class SplpyPyOp : public SplpyOp {
       SplpyPyOp(SPL::Operator * op) :
           SplpyOp(op, "/opt/.__splpy/common") {
       }
+
+      virtual ~SplpyPyOp() {}
 };
 
 }}

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_pyop.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_pyop.h
@@ -26,19 +26,8 @@ namespace streamsx {
 class SplpyPyOp : public SplpyOp {
   public:
       SplpyPyOp(SPL::Operator * op) :
-          SplpyOp(op, "/opt/.__splpy/common"), isStateful_(false) {
+          SplpyOp(op, "/opt/.__splpy/common") {
       }
-
-      void setStateful(bool stateful) {
-        isStateful_ = stateful;
-      }
-
-      virtual bool isStateful() {
-        return isStateful_;
-      }
-
- private:
-      bool isStateful_;
 };
 
 }}

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -143,7 +143,7 @@ class SPLGraph(object):
         return self._requested_name(name)
 
 
-    def addOperator(self, kind, function=None, name=None, params=None, sl=None, stateful=False):
+    def addOperator(self, kind, function=None, name=None, params=None, sl=None, stateful=None):
         if(params is None):
             params = {}
 
@@ -272,7 +272,7 @@ class SPLGraph(object):
 
 class _SPLInvocation(object):
 
-    def __init__(self, index, kind, function, name, params, graph, view_configs = None, sl=None, stateful = False):
+    def __init__(self, index, kind, function, name, params, graph, view_configs = None, sl=None, stateful=None):
         self.index = index
         self.kind = kind
         self.model = None
@@ -443,7 +443,7 @@ class _SPLInvocation(object):
             self._ex_op._generate(_op)
         return _op
 
-    def _addOperatorFunction(self, function, stateful=False):
+    def _addOperatorFunction(self, function, stateful):
         if (function is None):
             return None
         if not hasattr(function, "__call__"):
@@ -470,7 +470,8 @@ class _SPLInvocation(object):
             # dill format is binary; base64 encode so it is json serializable 
             self.params["pyCallable"] = base64.b64encode(dill.dumps(function)).decode("ascii")
 
-        self.params["pyStateful"] = bool(stateful)
+        if stateful is not None:
+            self.params["pyStateful"] = bool(stateful)
 
         # note: functions in the __main__ module cannot be used as input to operations 
         # function.__module__ will be '__main__', so C++ operators cannot import the module

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -282,13 +282,12 @@ class _SPLInvocation(object):
         self.category = None
         self.params = {}
         self.setParameters(params)
-        self._addOperatorFunction(self.function, stateful)
+        self.config = {}
         self.graph = graph
         self.viewable = True
         self.sl = sl
         self._placement = {}
         self._start_op = False
-        self.config = {}
         self._consistent = None
         # Arbitrary JSON for operator
         self._op_def = {}
@@ -301,6 +300,7 @@ class _SPLInvocation(object):
         self.inputPorts = []
         self.outputPorts = []
         self._layout_hints = {}
+        self._addOperatorFunction(self.function, stateful)
 
     def addOutputPort(self, oWidth=None, name=None, inputPort=None, schema= CommonSchema.Python,partitioned_keys=None, routing = None):
         if name is None:
@@ -471,8 +471,10 @@ class _SPLInvocation(object):
             self.params["pyCallable"] = base64.b64encode(dill.dumps(function)).decode("ascii")
 
         if stateful is not None:
-            self.params["pyStateful"] = bool(stateful)
-
+            self.params['pyStateful'] = bool(stateful)
+            if not stateful:
+                self.config['noCheckpoint'] = True
+                 
         # note: functions in the __main__ module cannot be used as input to operations 
         # function.__module__ will be '__main__', so C++ operators cannot import the module
         self.params["pyModule"] = function.__module__

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -473,7 +473,7 @@ class Topology(object):
         sl = _SourceLocation(_source_info(), "source")
         _name = self.graph._requested_name(_name, action='source', func=func)
         # source is always stateful
-        op = self.graph.addOperator(self.opnamespace+"::Source", func, name=_name, sl=sl, stateful=True)
+        op = self.graph.addOperator(self.opnamespace+"::Source", func, name=_name, sl=sl)
         op._layout(kind='Source', name=_name, orig_name=name)
         oport = op.addOutputPort(name=_name)
         return Stream(self, oport)._make_placeable()

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
@@ -70,7 +70,7 @@
 %>
 <% if (not $skip_set_callable) { %>
      this->pyop_->setCallable(callable);
-     this->pyop_->setup();
+     this->pyop_->setup(SPLPY_OP_STATEFUL);
 <% } %>
 
     }

--- a/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/common/py_constructor.cgt
@@ -18,10 +18,6 @@
     if (splpy_OperatorCallable() eq 'class') {
 %>
    { 
-     // The callable is a class, so there may be state that can be saved
-     // and restored for checkpointing.
-     this->pyop_->setStateful(true);
-
      // Pass all the arguments by name in a dictionary
      // object, effectively as **kwargs. Python will
      // unpack correctly to the actual __init__ args

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
@@ -66,6 +66,9 @@ MY_OPERATOR::MY_OPERATOR() :
                getInputPortAt(0));
    }
 <% } %>
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 MY_OPERATOR::~MY_OPERATOR() 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_cpp.cgt
@@ -3,11 +3,6 @@
  * # Copyright IBM Corp. 2015,2016
  */
 
-#include "splpy.h"
-#include "splpy_pyop.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 <%

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_h.cgt
@@ -14,12 +14,13 @@ my $pyStateful = splpy_OperatorCallable() eq 'class';
 using namespace streamsx::topology;
 
 <%SPL::CodeGen::headerPrologue($model);%>
-<%
-  require "splpy_operator.pm";
-%>
+
 @include "../../opt/.__splpy/common/py_disallow_cr_trigger.cgt"
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+    ,public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor
@@ -36,6 +37,7 @@ public:
 
   // Punctuation processing
   void process(Punctuation const & punct, uint32_t port);
+
 private:
     SplpyOp *op() { return pyop_; }
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionFilter_h.cgt
@@ -1,8 +1,14 @@
 /*
  * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2015,2016
+ * # Copyright IBM Corp. 2015,2018
  */
+<%
+require "splpy_operator.pm";
+my $pyStateful = splpy_OperatorCallable() eq 'class';
+%>
+@include "../../opt/.__splpy/common/py_state.cgt"
 
+#include "splpy.h"
 #include "splpy_pyop.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -3,10 +3,6 @@
  * # Copyright IBM Corp. 2015,2016
  */
 
-#include "splpy.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 <%
@@ -61,6 +57,10 @@ MY_OPERATOR::MY_OPERATOR() :
                getInputPortAt(0));
 <% } %>
    }
+
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_cpp.cgt
@@ -4,7 +4,6 @@
  */
 
 #include "splpy.h"
-#include "splpy_pyop.h"
 
 using namespace streamsx::topology;
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
@@ -8,14 +8,12 @@ my $pyStateful = splpy_OperatorCallable() eq 'class';
 %>
 @include "../../opt/.__splpy/common/py_state.cgt"
 
+#include "splpy.h"
 #include "splpy_pyop.h"
 
 using namespace streamsx::topology;
 
 <%SPL::CodeGen::headerPrologue($model);%>
-<%
-  require "splpy_operator.pm";
-%>
 
 @include "../../opt/.__splpy/common/py_disallow_cr_trigger.cgt"
 
@@ -24,7 +22,10 @@ using namespace streamsx::topology;
   my $iport = $model->getInputPortAt(0);
 %>
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+    , public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor
@@ -41,8 +42,10 @@ public:
 
   // Punctuation processing
   void process(Punctuation const & punct, uint32_t port);
+
 private:
     SplpyOp *op() { return pyop_; }
+
   // Members
     SplpyPyOp *pyop_;
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionPipe_h.cgt
@@ -1,7 +1,12 @@
 /*
  * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2015  
+ * # Copyright IBM Corp. 2015,2018
  */
+<%
+require "splpy_operator.pm";
+my $pyStateful = splpy_OperatorCallable() eq 'class';
+%>
+@include "../../opt/.__splpy/common/py_state.cgt"
 
 #include "splpy_pyop.h"
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
@@ -4,7 +4,6 @@
  */
 
 #include "splpy.h"
-#include "splpy_pyop.h"
 
 using namespace streamsx::topology;
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_cpp.cgt
@@ -3,10 +3,6 @@
  * # Copyright IBM Corp. 2015,2016
  */
 
-#include "splpy.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 @include "../../opt/.__splpy/common/py_disallow_cr_trigger.cgt"
@@ -56,6 +52,10 @@ MY_OPERATOR::MY_OPERATOR() :
                getInputPortAt(0));
    }
 <% } %>
+
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_h.cgt
@@ -1,7 +1,12 @@
 /*
  * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2015  
+ * # Copyright IBM Corp. 2015,2018
  */
+<%
+require "splpy_operator.pm";
+my $pyStateful = splpy_OperatorCallable() eq 'class';
+%>
+@include "../../opt/.__splpy/common/py_state.cgt"
 
 #include "splpy_pyop.h"
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSink_h.cgt
@@ -8,16 +8,17 @@ my $pyStateful = splpy_OperatorCallable() eq 'class';
 %>
 @include "../../opt/.__splpy/common/py_state.cgt"
 
+#include "splpy.h"
 #include "splpy_pyop.h"
 
 using namespace streamsx::topology;
 
 <%SPL::CodeGen::headerPrologue($model);%>
-<%
-  require "splpy_operator.pm";
-%>
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+    ,public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -3,10 +3,6 @@
  * # Copyright IBM Corp. 2015,2018
  */
 
-#include "splpy.h"
-
-using namespace streamsx::topology;
-
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 <% 
@@ -49,10 +45,13 @@ MY_OPERATOR::MY_OPERATOR() :
              "streamsx.spl.runtime", "_SourceIterable",
              callable, NULL);   
      this->pyop_->setCallable(callable);
-     this->pyop_->setup();
+     this->pyop_->setup(SPLPY_OP_STATEFUL);
 
      pyOutNames_0 = Splpy::pyAttributeNames(getOutputPortAt(0));
    }
+#if SPLPY_OP_STATEFUL == 1
+   this->getContext().registerStateHandler(*this);
+#endif
 }
 
 // Destructor

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -1,10 +1,9 @@
 /*
  * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2015,2016
+ * # Copyright IBM Corp. 2015,2018
  */
 
 #include "splpy.h"
-#include "splpy_pyop.h"
 
 using namespace streamsx::topology;
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
@@ -8,14 +8,12 @@ my $pyStateful = splpy_OperatorCallable() eq 'class';
 %>
 @include "../../opt/.__splpy/common/py_state.cgt"
 
+#include "splpy.h"
 #include "splpy_pyop.h"
 
 using namespace streamsx::topology;
 
 <%SPL::CodeGen::headerPrologue($model);%>
-<%
-  require "splpy_operator.pm";
-%>
 
 @include "../../opt/.__splpy/common/py_disallow_cr_trigger.cgt"
 
@@ -23,7 +21,10 @@ using namespace streamsx::topology;
   my $oport = $model->getOutputPortAt(0);
 %>
 
-class MY_OPERATOR : public MY_BASE_OPERATOR, public DelegatingStateHandler
+class MY_OPERATOR : public MY_BASE_OPERATOR
+#if SPLPY_OP_STATEFUL == 1
+     , public DelegatingStateHandler
+#endif
 {
 public:
   // Constructor
@@ -42,12 +43,12 @@ public:
   void process(uint32_t idx);
 
 private:
+    SplpyOp *op() { return pyop_; }
 
   // Members
     SplpyPyOp *pyop_;
     PyObject *pyOutNames_0;
 
-    SplpyOp *op() { return pyop_; }
     void pySubmitTuplesPort0(PyObject * value);
     void fromPythonToPort0(PyObject * pyTuple, OPort0Type & otuple);
     void fromPythonDictToPort0(PyObject * pyDict, OPort0Type & otuple);

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
@@ -1,7 +1,12 @@
 /*
  * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2015  
+ * # Copyright IBM Corp. 2015,2018
  */
+<%
+require "splpy_operator.pm";
+my $pyStateful = splpy_OperatorCallable() eq 'class';
+%>
+@include "../../opt/.__splpy/common/py_state.cgt"
 
 #include "splpy_pyop.h"
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -1,8 +1,7 @@
 /*
  * # Licensed Materials - Property of IBM
- * # Copyright IBM Corp. 2017
+ * # Copyright IBM Corp. 2017,2018
  */
-
 #include "splpy.h"
 
 using namespace streamsx::topology;

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_cpp.cgt
@@ -2,9 +2,6 @@
  * # Licensed Materials - Property of IBM
  * # Copyright IBM Corp. 2017,2018
  */
-#include "splpy.h"
-
-using namespace streamsx::topology;
 
 <%SPL::CodeGen::implementationPrologue($model);%>
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -2,6 +2,11 @@
  * # Licensed Materials - Property of IBM
  * # Copyright IBM Corp. 2017
  */
+<%
+require "splpy_operator.pm";
+my $pyStateful = splpy_OperatorCallable() eq 'class';
+%>
+@include "../../opt/.__splpy/common/py_state.cgt"
 
 #include "splpy_pyop.h"
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonPrimitive_h.cgt
@@ -8,6 +8,7 @@ my $pyStateful = splpy_OperatorCallable() eq 'class';
 %>
 @include "../../opt/.__splpy/common/py_state.cgt"
 
+#include "splpy.h"
 #include "splpy_pyop.h"
 
 using namespace streamsx::topology;
@@ -38,9 +39,8 @@ public:
 
 private:
     SplpyOp *op() { return pyop_; }
+
     SplpyPyOp *pyop_;
-
-
 
 <%if ($model->getNumberOfInputPorts() != 0) {%>
     PyObject *pyinputfns_;

--- a/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/OperatorGenerator.java
@@ -647,7 +647,7 @@ class OperatorGenerator {
         }
     }
 
-    static void configClause(JsonObject graphConfig, JsonObject op, StringBuilder sb) {
+    void configClause(JsonObject graphConfig, JsonObject op, StringBuilder sb) {
 
         if (!op.has(OpProperties.CONFIG))
             return;
@@ -655,6 +655,13 @@ class OperatorGenerator {
         JsonObject config = jobject(op, OpProperties.CONFIG);
 
         StringBuilder sbConfig = new StringBuilder();
+        
+        // Inherit the graph wide checkpoint unless the operator invocation says no
+        if (!jboolean(config, "noCheckpoint")) {
+        	String checkpoint = splGenerator.getCheckpointConfig();
+        	if (checkpoint != null)
+        		sbConfig.append(checkpoint);
+        }
 
         if (config.has("streamViewability")) {
             sbConfig.append("    streamViewability: ");

--- a/test/python/spl/tests/test_splpy_consistent.py
+++ b/test/python/spl/tests/test_splpy_consistent.py
@@ -42,7 +42,6 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         tester.tuple_count(s, iterations)
         tester.contents(s, list(zip(range(0,iterations))))
 
-        # cfg={}
         # job_config = streamsx.topology.context.JobConfig(tracing='debug')
         # job_config.add(self.test_config)
 
@@ -121,10 +120,8 @@ class TestDistributedConsistentRegion(unittest.TestCase):
 
         transit = op.Map('com.ibm.streamsx.topology.pytest.checkpoint::EnterExitMap', source.stream, schema.StreamSchema('tuple<rstring from, int32 enter, int32 exit>').as_tuple())
 
-#        streamsx.topology.context.submit('TOOLKIT', topo)
-
         tester = Tester(topo)
-        tester.resets(5)
+        tester.resets(10)
 
         # On each operator, __enter__ and __exit__ should be called once for 
         # each reset.  Also __enter__ should be called at startup and __exit__
@@ -139,9 +136,8 @@ class TestDistributedConsistentRegion(unittest.TestCase):
         tester.eventual_result(source.stream, lambda tuple_ : True if tuple_ == ('source', 6, 5) else None)
         tester.eventual_result(transit.stream, lambda tuple_ : True if tuple_ == ('transit', 6, 5) else None)
 
-        # cfg={}
-        # job_config = streamsx.topology.context.JobConfig(tracing='debug')
-        # job_config.add(self.test_config)
+        job_config = streamsx.topology.context.JobConfig(tracing='debug')
+        job_config.add(self.test_config)
 
         tester.test(self.test_ctxtype, self.test_config)
 

--- a/test/python/topology/test2_consistent.py
+++ b/test/python/topology/test2_consistent.py
@@ -46,11 +46,25 @@ class TimeCounter(object):
         # Otherwise increment, sleep, and return.
         to_return = self.count
         self.count += 1
+        self._metric.value = self.count
         time.sleep(self.period)
         return to_return
 
     def next(self):
         return self.__next__()
+
+    def __enter__(self):
+        self._metric = ec.CustomMetric(self, "nTuplesSent", "Logical tuples sent")
+        self._metric.value = self.count
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if '_metric' in state:
+            del state['_metric']
+        return state
 
 # This just provides a __call__ method that computes the average of its
 # parameter, but since it is a class it is stateful and will have its state
@@ -353,11 +367,7 @@ class TestOperatorDriven(unittest.TestCase):
         tester = Tester(topo)
         self.assertFalse(tester.test(self.test_ctxtype, self.test_config, assert_on_fail=False))
 
-    def test_for_each(self):
-        pass # There is no way to set consistent on a sink
-
-    def test_hash_adder(self):
-        pass # There is no way to set consistent on hash_adder
+    # There is no way to set consistent on a sink or hash_adder
 
     def test_map(self):
         topo = Topology()


### PR DESCRIPTION
For #1892
1. Add (unused currently) #define to indicate if operator needs state handler
2. Now StateHandler is only created for Python operator if the operator is stateful.
3. Added metrics that show if the operator is in a checkpoint/consistent region (`nCheckpoints` , `nResets`)