### PR TITLE
Simplify acquiring permit in Python source operators.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -24,8 +24,7 @@ MY_OPERATOR::MY_OPERATOR() :
    pyInStyleObj_(NULL),
    loads(NULL),
    occ_(-1),
-   window_(<%=$windowCppInitializer%>),
-   crContext(this)
+   window_(<%=$windowCppInitializer%>)
 {
 <% if ($window->isSliding()) {%>
     window_.registerOnWindowTriggerHandler(this);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -78,7 +78,6 @@ private:
     <%=$windowCppType%>  window_;	       
 
     @include "../../opt/python/codegen/py_enable_cr.cgt"
-    OptionalConsistentRegionContext crContext;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -9,8 +9,7 @@
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
-   pyInStyleObj_(NULL),
-   crContext(this)
+   pyInStyleObj_(NULL)
 {
     funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, "<%=$pywrapfunc%>");
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_h.cgt
@@ -39,7 +39,6 @@ private:
     PyObject *pyInStyleObj_;
 
     @include "../../opt/python/codegen/py_enable_cr.cgt"
-    OptionalConsistentRegionContext crContext;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_cpp.cgt
@@ -15,8 +15,7 @@
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
    pyInStyleObj_(NULL),
-   occ_(-1),
-   crContext(this)
+   occ_(-1)
 { 
     const char * wrapfn = "<%=$pywrapfunc%>";
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/FlatMap/FlatMap_h.cgt
@@ -44,7 +44,6 @@ private:
     int32_t occ_;
 
     @include "../../opt/python/codegen/py_enable_cr.cgt"
-    OptionalConsistentRegionContext crContext;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -8,8 +8,7 @@
 
 MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
-   pyInStyleObj_(NULL),
-   crContext(this)
+   pyInStyleObj_(NULL)
 {
     funcop_ = new SplpyFuncOp(this, SPLPY_OP_STATEFUL, "<%=$pywrapfunc%>");
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_h.cgt
@@ -39,7 +39,6 @@ private:
     PyObject *pyInStyleObj_;
 
     @include "../../opt/python/codegen/py_enable_cr.cgt"
-    OptionalConsistentRegionContext crContext;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_cpp.cgt
@@ -16,8 +16,7 @@ MY_OPERATOR::MY_OPERATOR() :
    funcop_(NULL),
    pyInStyleObj_(NULL),
    pyOutNames_0(NULL),
-   occ_(-1),
-   crContext(this)
+   occ_(-1)
 {
     const char * wrapfn = "<%=$pywrapfunc%>";
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Map/Map_h.cgt
@@ -59,7 +59,6 @@ if ($pyoutstyle eq 'dict') {
     int32_t occ_;
 
     @include "../../opt/python/codegen/py_enable_cr.cgt"
-    OptionalConsistentRegionContext crContext;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
@@ -5,8 +5,7 @@
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
     funcop_(NULL),
-    occ_(-1),
-    crContext(this)
+    occ_(-1)
 {
     const char * wrapfn = "<%=$pywrapfunc%>";
 <%
@@ -59,13 +58,19 @@ void MY_OPERATOR::prepareToShutdown()
 // Processing for source and threaded operators   
 void MY_OPERATOR::process(uint32_t idx)
 {
+#if SPLPY_OP_CR == 1
+  SPL::ConsistentRegionContext *crc = static_cast<SPL::ConsistentRegionContext *>(getContext().getOptionalContext(CONSISTENT_REGION));
+#endif
+
   PyObject *pyReturnVar = NULL;
 
   while(!getPE().getShutdownRequested()) {
    try {
     OPort0Type otuple;
 
-    AutoConsistentRegionPermit crp(crContext);
+#if SPLPY_OP_CR == 1
+    ConsistentRegionPermit crp(crc);
+#endif
     OptionalAutoLock stateLock(this);
     { // start lock
       SplpyGIL lock;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_h.cgt
@@ -43,7 +43,6 @@ private:
   int32_t occ_;
 
   @include "../../opt/python/codegen/py_enable_cr.cgt"
-  OptionalConsistentRegionContext crContext;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
@@ -19,5 +19,4 @@
   static const bool isCheckpointing = <%=$splpy_op_stateful ? "true" : "false" %>;
 
   typedef OptionalConsistentRegionContextImpl<isInConsistentRegion> OptionalConsistentRegionContext;
-  typedef OptionalConsistentRegionContext::Permit AutoConsistentRegionPermit;
   typedef OptionalAutoLockImpl<isCheckpointing> OptionalAutoLock;

--- a/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
+++ b/com.ibm.streamsx.topology/opt/python/codegen/py_enable_cr.cgt
@@ -12,11 +12,8 @@
  # to support checkpointing and consistent region.
 
 %>
-  // True if this operator is in a consistent region.
-  static const bool isInConsistentRegion = <%= $isInConsistentRegion ? "true" :" false" %>;
   // True if operator is stateful and checkpoint is enabled, 
   // whether directly or through consistent region.
   static const bool isCheckpointing = <%=$splpy_op_stateful ? "true" : "false" %>;
 
-  typedef OptionalConsistentRegionContextImpl<isInConsistentRegion> OptionalConsistentRegionContext;
   typedef OptionalAutoLockImpl<isCheckpointing> OptionalAutoLock;

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_cr.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_cr.h
@@ -12,14 +12,6 @@
 namespace streamsx {
   namespace topology {
 
-/** 
- * OptionalConsistentRegionContext<true> holds a pointer to a 
- * ConsistentRegionContext,
- * OptionalConsistentRegionContxt<false> does nothing.
- */
-template<bool b>
-class OptionalConsistentRegionContextImpl;
-
 /**
  * OptionalAutoLockImpl<bool> is intended to be used with an instance of
  * DelegatingStateHandler.  OptionalAutoLockImpl<false> does nothing,
@@ -76,24 +68,6 @@ private:
   void unlock() { mutex_.unlock(); }
 
   SPL::Mutex mutex_;
-};
-
-template<>
-class OptionalConsistentRegionContextImpl<true> {
- public:
-  OptionalConsistentRegionContextImpl(SPL::Operator *op) : crContext(NULL) {
-    crContext = static_cast<SPL::ConsistentRegionContext *>(op->getContext().getOptionalContext(CONSISTENT_REGION));
-  }
-  operator SPL::ConsistentRegionContext *() {return crContext;}
-
-private:
-  SPL::ConsistentRegionContext * crContext;
-};
-
-template<>
-class OptionalConsistentRegionContextImpl<false> {
- public:
-  OptionalConsistentRegionContextImpl(SPL::Operator * op) {}
 };
 
 template<>

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_cr.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_cr.h
@@ -15,8 +15,6 @@ namespace streamsx {
 /** 
  * OptionalConsistentRegionContext<true> holds a pointer to a 
  * ConsistentRegionContext,
- * and ConsistentRegionContext::Permit is an RAII helper
- * for acquiring and releasing a ConsistentRegionPermit.
  * OptionalConsistentRegionContxt<false> does nothing.
  */
 template<bool b>
@@ -87,7 +85,6 @@ class OptionalConsistentRegionContextImpl<true> {
     crContext = static_cast<SPL::ConsistentRegionContext *>(op->getContext().getOptionalContext(CONSISTENT_REGION));
   }
   operator SPL::ConsistentRegionContext *() {return crContext;}
-  typedef SPL::ConsistentRegionPermit Permit;
 
 private:
   SPL::ConsistentRegionContext * crContext;
@@ -97,10 +94,6 @@ template<>
 class OptionalConsistentRegionContextImpl<false> {
  public:
   OptionalConsistentRegionContextImpl(SPL::Operator * op) {}
-  class Permit {
-  public:
-    Permit(OptionalConsistentRegionContextImpl<false>){}
-  };
 };
 
 template<>

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -30,8 +30,7 @@
 // Constructor
 MY_OPERATOR::MY_OPERATOR() :
    pyop_(NULL),
-   pyOutNames_0(NULL),
-   crContext(this)
+   pyOutNames_0(NULL)
 {
    PyObject * callable;
 @include  "../../opt/.__splpy/common/py_constructor.cgt"
@@ -83,10 +82,17 @@ void MY_OPERATOR::prepareToShutdown()
 
 void MY_OPERATOR::process(uint32_t idx)
 {
+#if SPLPY_OP_CR == 1
+  SPL::ConsistentRegionContext *crc = static_cast<SPL::ConsistentRegionContext *>(getContext().getOptionalContext(CONSISTENT_REGION));
+#endif
+
   while(!getPE().getShutdownRequested()) {
 
     try {
-      AutoConsistentRegionPermit permit(crContext);
+
+#if SPLPY_OP_CR == 1
+      ConsistentRegionPermit crp(crc);
+#endif
       OptionalAutoLock stateLock(this);
 
       // GIL is released across submission

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_h.cgt
@@ -56,7 +56,6 @@ private:
     void fromPyDictToSPLTuple(PyObject *pyTuple, OPort0Type & otuple);
 
 @include "../../opt/.__splpy/common/py_enable_cr.cgt"
-    OptionalConsistentRegionContext crContext;
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>


### PR DESCRIPTION
Removes also OptionalConsistentRegionContext class and fields as it was only every useful for source operators.