### PR TITLE
Add streamsx.ec.shutdown() event

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Source/Source_cpp.cgt
@@ -87,7 +87,7 @@ void MY_OPERATOR::process(uint32_t idx)
                 // Has the iterator completed?
                 if (SplpyGeneral::isNone(pyReturnVar)) {
                     Py_CLEAR(pyReturnVar);
-                    allDone = true;
+                    allDone = !getPE().getShutdownRequested();
                 } else {
                     submitTuple = true;
 

--- a/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy_op.h
@@ -159,6 +159,8 @@ class SplpyOp {
       */
       void prepareToShutdown() {
           SplpyGIL lock;
+          SplpyGeneral::callVoidFunction(
+               "streamsx.ec", "_prepare_shutdown", NULL, NULL);
           SplpyGeneral::flush_PyErrPyOut();
 
           if (op()->getPE().isStandalone()) {

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -162,6 +162,30 @@ def _check():
     if not _State._state._supported:
         raise NotImplementedError("Access to the execution context requires Streams 4.2 or later")
 
+_SHUTDOWN = threading.Event()
+
+def _prepare_shutdown():
+    _SHUTDOWN.set()
+
+def shutdown():
+    """Return the processing element (PE) shutdown event.
+
+    The event is set when the PE is being shutdown.
+    Can be used in source iterators that need to block by sleeping::
+
+        # Sleep for 60 seconds unless the PE is being shutdown
+        if streamsx.ec.shutdown.wait(60.0):
+            return None
+
+    Code must not call ``set()`` on the returned event.
+
+    Returns:
+        threading.Event: Event object representing PE shutdown.
+    
+    .. versionadded:: 1.11
+    """
+    return _SHUTDOWN
+
 def domain_id():
     """
     Return the instance identifier.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/runtime.py
@@ -51,7 +51,9 @@ class _SourceIterable(streamsx._streams._runtime._WrapOpLogic):
             while True:
                 tuple_ = next(self._it)
                 if tuple_ is not None:
-                     return tuple_
+                    return tuple_
+                elif streamsx.ec.shutdown().is_set():
+                    return None
         except StopIteration:
             self._it = None
             return None

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/runtime.py
@@ -272,6 +272,8 @@ class _IterableAnyOut(_FunctionalCallable):
                 tuple_ = next(self._it)
                 if not tuple_ is None:
                     return tuple_
+                elif ec.shutdown().is_set():
+                    return None
             except StopIteration:
                 return None
 

--- a/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
+++ b/com.ibm.streamsx.topology/opt/python/templates/operators/PythonFunctionSource_cpp.cgt
@@ -77,7 +77,7 @@ void MY_OPERATOR::prepareToShutdown()
 }
 
 <%
-  my $no_tuples_action = "allDone=true;";
+  my $no_tuples_action = "allDone=!getPE().getShutdownRequested();";
 %>
 
 void MY_OPERATOR::process(uint32_t idx)


### PR DESCRIPTION
Adds `streamsx.ec.shutdown` to allow sleep until shutdown event.

Ensures that if an source operator/iterator returns `None` control is passed back to the C++ primitive operators when PE is being shutdown.

Part of #1869