### PR TITLE
Fix issue #1866

### DIFF
--- a/samples/python/com.ibm.streamsx.topology.pysamples/build.xml
+++ b/samples/python/com.ibm.streamsx.topology.pysamples/build.xml
@@ -43,7 +43,7 @@
     <exec executable="${streams.install}/bin/sc" failonerror="true">
       <arg value="-M"/>
       <arg value="com.ibm.streamsx.topology.pysamples.apps::NoopSample"/>
-      <arg value="--output-directory=output/com.ibm.streamsx.topology.pysamples.apps.MailSample/BuildConfig"/>
+      <arg value="--output-directory=output/com.ibm.streamsx.topology.pysamples.apps.NoopSample/BuildConfig"/>
       <arg value="--data-directory=data"/>
       <arg value="-a"/>
       <arg value="--no-toolkit-indexing"/>
@@ -51,7 +51,7 @@
     </exec>
   </target>
 
-  <target name="spldoc" description="Make the SPL documentation.">
+  <target name="spldoc" depends="toolkit" description="Make the SPL documentation.">
     <exec executable="${streams.install}/bin/spl-make-doc" failonerror="true">
       <arg value="--include-composite-operator-diagram"/>
       <arg value="-i"/>


### PR DESCRIPTION
In the sample/python/com.ibm.streamsx.topology.pysamples/build.xm :
the spldoc-target depends now on the-toolkit which extracts the python primitive operators