### PR TITLE
partitioning python topology windows by attribute

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate.xml
@@ -115,6 +115,17 @@
         <type>boolean</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>pyPartitionBy</name>
+        <description>The attribute or python callable used for partitioning.  This is required if the window is partitioned, and ignored if it is not.</description>
+        <optional>true</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <!-- TODO perhaps this should be Attribute -->
+        <expressionMode>Constant</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+        <portScope><port>0</port></portScope>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate.xml
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate.xml
@@ -120,7 +120,6 @@
         <description>The attribute or python callable used for partitioning.  This is required if the window is partitioned, and ignored if it is not.</description>
         <optional>true</optional>
         <rewriteAllowed>false</rewriteAllowed>
-        <!-- TODO perhaps this should be Attribute -->
         <expressionMode>Constant</expressionMode>
         <type>rstring</type>
         <cardinality>1</cardinality>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -204,13 +204,16 @@ void MY_OPERATOR::aggregateRemaining() {
     SPL::AutoPortMutex am(mutex_, *this);
 #endif
     WindowType::StorageType & storage = window_.getWindowStorage();
-    WindowType::DataType & content = storage[0];
-    if (!content.empty()) {
-        beforeWindowFlushEvent(window_, 0);
+    // Iterate through the partitions.
+    for (WindowType::StorageType::iterator partition = storage.begin(); partition != storage.end(); ++partition) {
+        WindowType::DataType & content = partition->second;
+	if (!content.empty()) {
+            beforeWindowFlushEvent(window_, partition->first);
 
-       // Since we have processed these tuples in batch
-       // don't process them again. 
-       content.clear();
+           // Since we have processed these tuples in batch
+           // don't process them again. 
+           content.clear();
+        }
     }
 }
 <%}%>

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -177,7 +177,12 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
     SPL::AutoPortMutex am(mutex_, *this);
 #endif
 
+#if SPLPY_PARTITION_BY_ATTRIBUTE == 1
+  PartitionType const & partition = getPartitionValue(static_cast<TupleType const &>(tuple));
+  window_.insert(python_value, partition);
+#else
   window_.insert(python_value);
+#endif
 }
 
 void MY_OPERATOR::process(Punctuation const & punct, uint32_t port)

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_cpp.cgt
@@ -192,14 +192,14 @@ void MY_OPERATOR::process(Punctuation const & punct, uint32_t port)
 <% if ($window->isTumbling()) {%>
 void MY_OPERATOR::aggregateRemaining() {
 #if SPLPY_AGGREGATE_TIME_POLICIES == 1
-    SPL::AutoWindowDataAcquirer<PyObject *> awd(window_);
+    SPL::AutoWindowDataAcquirer<WindowType::TupleType, WindowType::PartitionType, WindowType::DataType, WindowType::StorageType> awd(window_);
 #elif SPLPY_OP_STATE_HANDLER == 1
     SPL::AutoMutex am(mutex_);
 #else
     SPL::AutoPortMutex am(mutex_, *this);
 #endif
-    Window<PyObject *>::StorageType & storage = window_.getWindowStorage();
-    Window<PyObject *>::DataType & content = storage[0];
+    WindowType::StorageType & storage = window_.getWindowStorage();
+    WindowType::DataType & content = storage[0];
     if (!content.empty()) {
         beforeWindowFlushEvent(window_, 0);
 
@@ -218,7 +218,7 @@ void MY_OPERATOR::aggregateRemaining() {
 <% if ($window->isSliding()) {%>
 
 void MY_OPERATOR::afterTupleEvictionEvent(
-     Window<PyObject *> & window,  Window<PyObject *>::TupleType & tuple,  Window<PyObject *>::PartitionType const & partition) {
+     WindowEventType::WindowType & window,  WindowEventType::TupleType & tuple,  WindowEventType::PartitionType const & partition) {
      // Drop reference to tuple after it is removed from the window.
      SplpyGIL lock;
      Py_DECREF(tuple);
@@ -233,10 +233,10 @@ void MY_OPERATOR::onWindowTriggerEvent(
 <% if ($window->isTumbling()) {%>
 void MY_OPERATOR::beforeWindowFlushEvent(
 <%}%>
-    Window<PyObject *> & window, Window<PyObject *>::PartitionType const & key){    
-    Window<PyObject *>::StorageType & storage = window.getWindowStorage();
+    WindowEventType::WindowType & window, WindowEventType::PartitionType const & key){    
+    WindowType::StorageType & storage = window.getWindowStorage();
 
-    Window<PyObject *>::DataType & content = storage[key];
+    WindowType::DataType & content = storage[key];
     PyObject *items;
     {
     SplpyGIL lock;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -20,6 +20,7 @@ using namespace streamsx::topology;
  my @partitionByTypes = SPL::CodeGen::getParameterCppTypes($partitionByParam);
  my $windowCppType;
  my $windowEventCppType;
+ my $partitionParamName;
  if ($partitionByParam) {
    if (scalar @partitionByTypes > 1) {
      SPL::CodeGen::exitln('Only a single partition attribute is allowed.');
@@ -32,6 +33,13 @@ using namespace streamsx::topology;
      $windowCppType = SPL::CodeGen::getWindowCppType($window, "PyObject *", $partitionByType);
 
      $windowEventCppType = SPL::CodeGen::getWindowEventCppType($window, "PyObject *", $partitionByType);
+
+     # Validate that the tuple type contains an attribute with name 
+     # matching $partitionByParam
+     $partitionParamName = substr $partitionByParam->getValueAt(0)->getSPLExpression(), 1, -1;
+     if (! $inputPort->getAttributeByName($partitionParamName)) {
+     	SPL::CodeGen::exitln("The input port does not contain the parameter \"$partitionParamName\", which has been specified for partitioning");
+     }
    }
  }
  else {
@@ -98,7 +106,7 @@ private:
 
 <%if ($partitionByParam) {%>
      PartitionByType const & getPartitionValue(TupleType const & tuple) {
-       return tuple.get_<%=substr $partitionByParam->getValueAt(0)->getSPLExpression(), 1, -1%>();
+       return tuple.get_<%=$partitionParamName%>();
      }
 <%}%>
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -16,18 +16,22 @@ using namespace streamsx::topology;
  my $inputPort = $model->getInputPortAt(0); 
  my $window = $inputPort->getWindow();
  my $windowCppType = SPL::CodeGen::getWindowCppType($window,"PyObject *");
+ my $windowEventCppType = SPL::CodeGen::getWindowEventCppType($window,"PyObject *"); # TODO optional third param is for partition type.
 %>
 
 #define SPLPY_AGGREGATE_TIME_POLICIES <%=$window->getEvictionPolicyType() == $SPL::Operator::Instance::Window::Time || ($window->hasTriggerPolicy() && $window->getEvictionPolicyType() == $SPL::Operator::Instance::Window::Time) ? 1 : 0%>
 
 @include "../pyspltuple.cgt"
 class MY_OPERATOR : public MY_BASE_OPERATOR,
-      public WindowEvent<PyObject *>
+      public <%=$windowEventCppType%>
 #if SPLPY_OP_STATE_HANDLER == 1
  , public SPL::StateHandler
 #endif
 {
 public:
+  typedef <%=$windowCppType%> WindowType;
+  typedef <%=$windowEventCppType%> WindowEventType;
+
   MY_OPERATOR();
   virtual ~MY_OPERATOR(); 
   void prepareToShutdown(); 
@@ -37,14 +41,14 @@ public:
   
 <% if ($window->isSliding()) {%>
   void onWindowTriggerEvent(
-     Window<PyObject *> & window, Window<PyObject *>::PartitionType const& key);
+     WindowEventType::WindowType & window, WindowEventType::PartitionType const& key);
   void afterTupleEvictionEvent(
-     Window<PyObject *> & window,  Window<PyObject *>::TupleType & tuple,
-     Window<PyObject *>::PartitionType const & partition);
+     WindowEventType::WindowType & window,  WindowEventType::TupleType & tuple,
+     WindowEventType::PartitionType const & partition);
 <%}%>
 <% if ($window->isTumbling()) {%>
   void beforeWindowFlushEvent(
-     Window<PyObject *> & window, Window<PyObject *>::PartitionType const& key);
+     WindowEventType::WindowType & window, WindowEventType::PartitionType const& key);
 <%}%>
 
 #if SPLPY_OP_STATE_HANDLER == 1
@@ -78,7 +82,7 @@ private:
     int32_t occ_;
 
     // Window definition
-    <%=$windowCppType%>  window_;	       
+    WindowType window_;	       
 
 #if SPLPY_AGGREGATE_TIME_POLICIES == 0
     // Locking is through window acquire data when

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Aggregate/Aggregate_h.cgt
@@ -15,8 +15,32 @@ using namespace streamsx::topology;
 # Configure Windowing
  my $inputPort = $model->getInputPortAt(0); 
  my $window = $inputPort->getWindow();
- my $windowCppType = SPL::CodeGen::getWindowCppType($window,"PyObject *");
- my $windowEventCppType = SPL::CodeGen::getWindowEventCppType($window,"PyObject *"); # TODO optional third param is for partition type.
+
+ my $partitionByParam = $model->getParameterByName("pyPartitionBy");
+ my @partitionByTypes = SPL::CodeGen::getParameterCppTypes($partitionByParam);
+ my $windowCppType;
+ my $windowEventCppType;
+ if ($partitionByParam) {
+   if (scalar @partitionByTypes > 1) {
+     SPL::CodeGen::exitln('Only a single partition attribute is allowed.');
+   }
+   else {
+%>
+#define SPLPY_PARTITION_BY_ATTRIBUTE 1
+<%
+     my $partitionByType = $partitionByTypes[0];
+     $windowCppType = SPL::CodeGen::getWindowCppType($window, "PyObject *", $partitionByType);
+
+     $windowEventCppType = SPL::CodeGen::getWindowEventCppType($window, "PyObject *", $partitionByType);
+   }
+ }
+ else {
+%>
+#define SPLPY_PARTITION_BY_ATTRIBUTE 0
+<%
+   $windowCppType = SPL::CodeGen::getWindowCppType($window,"PyObject *");
+   $windowEventCppType = SPL::CodeGen::getWindowEventCppType($window,"PyObject *");
+ }    
 %>
 
 #define SPLPY_AGGREGATE_TIME_POLICIES <%=$window->getEvictionPolicyType() == $SPL::Operator::Instance::Window::Time || ($window->hasTriggerPolicy() && $window->getEvictionPolicyType() == $SPL::Operator::Instance::Window::Time) ? 1 : 0%>
@@ -31,7 +55,10 @@ class MY_OPERATOR : public MY_BASE_OPERATOR,
 public:
   typedef <%=$windowCppType%> WindowType;
   typedef <%=$windowEventCppType%> WindowEventType;
-
+<%if ($partitionByParam) {%>
+  typedef <%=$partitionByTypes[0]%> PartitionByType;
+  typedef <%=$inputPort->getCppTupleType()%> TupleType;
+<%}%>
   MY_OPERATOR();
   virtual ~MY_OPERATOR(); 
   void prepareToShutdown(); 
@@ -66,6 +93,13 @@ private:
     SplpyOp * op() const { return funcop_; }
 <% if ($window->isTumbling()) {%>
    void aggregateRemaining();
+<%}%>
+
+
+<%if ($partitionByParam) {%>
+     PartitionByType const & getPartitionValue(TupleType const & tuple) {
+       return tuple.get_<%=substr $partitionByParam->getValueAt(0)->getSPLExpression(), 1, -1%>();
+     }
 <%}%>
 
     // Members

--- a/test/python/topology/test2_python_window.py
+++ b/test/python/topology/test2_python_window.py
@@ -240,21 +240,6 @@ class TestPythonWindowing(unittest.TestCase):
         tester.contents(s, [('b',1), ('c',7)] )
         tester.test(self.test_ctxtype, self.test_config)
 
-    def test_structured_as_tuple_partitioned(self):
-        schema = StreamSchema("tuple<rstring a, int32 b>").as_tuple()
-        topo = Topology()
-        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17)])
-        s = s.map(lambda x: x, schema = schema)
-
-        s = s.last(3).trigger(2).partition('a').aggregate(lambda items: (items[1][0], items[0][1]))
-
-        #s.print()
-        #streamsx.topology.context.submit('TOOLKIT', topo)
-
-        tester = Tester(topo)
-        tester.contents(s, [('a',1), ('b',7), ('a', 2), ('b', 9)] )
-        tester.test(self.test_ctxtype, self.test_config)
-
     def test_structured_as_named_tuple(self):
         schema = StreamSchema("tuple<rstring a, int32 b>").as_tuple(named=True)
         topo = Topology()

--- a/test/python/topology/test2_python_window.py
+++ b/test/python/topology/test2_python_window.py
@@ -291,7 +291,7 @@ class TestPythonWindowing(unittest.TestCase):
         s = topo.source(lambda : range(20))
         b = s.batch(4)
         r = b.aggregate(lambda items : sum(items))
- 
+
         tester = Tester(topo)
         tester.contents(r, [0+1+2+3,4+5+6+7,8+9+10+11,12+13+14+15,16+17+18+19])
         tester.tuple_count(r, 5)

--- a/test/python/topology/test2_python_window_partition.py
+++ b/test/python/topology/test2_python_window_partition.py
@@ -1,0 +1,172 @@
+import unittest
+
+from streamsx.topology.topology import *
+from streamsx.topology import context
+from streamsx.topology.schema import CommonSchema, StreamSchema
+from streamsx.topology.tester import Tester
+from streamsx.spl import op
+
+# Test partitioned windows in python topology operators.
+class TestPythonWindowPartition(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
+    def setUp(self):
+        Tester.setup_standalone(self)
+
+    # Partition by attribute not supported for common schema
+    def test_common_schema_python(self):
+        topo = Topology()
+        s = topo.source([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
+        self.assertIs(s.oport.schema, CommonSchema.Python)
+        # We cannot partition by attribute because the attributes are not
+        # named
+        with self.assertRaises(ValueError):
+            s = s.last(10).trigger(2).partition('a').aggregate(lambda x: float(sum(x))/float(len(x)))
+
+    # Partition by attribute not supported for common schema
+    def test_common_schema_json(self):
+        topo = Topology()
+        s = topo.source(['1','3','5','7'])
+        s = s.map(lambda x: x, schema = CommonSchema.String)
+        self.assertIs(s.oport.schema, CommonSchema.String)
+        # We cannot partition by attribute because the attributes are not
+        # named
+        with self.assertRaises(ValueError):
+            s = s.last(3).trigger(1).partition('x').aggregate(lambda tuples: ''.join(tuples))
+
+    # Partition by attribute not supported for common schema
+    def test_common_schema_json(self):
+        topo = Topology()
+        s = topo.source([{'a':1},{'b':2,'c':3}, {'d': 4, 'e': 5}])
+        
+        s = s.map(lambda x: x, schema = CommonSchema.Json)
+        self.assertIs(s.oport.schema, CommonSchema.Json)
+        with self.assertRaises(ValueError):
+            s = s.last(3).trigger(1).partition('a').aggregate(lambda tuples: [[set(tup.keys()), sum(tup.values())] for tup in tuples])
+
+
+    # Partition by attribute supported for streams schema
+    def test_structured_as_dict(self):
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17)])
+        s = s.map(lambda x: x, schema = "tuple<rstring c, int32 d>")
+
+        s = s.last(3).trigger(2).partition('c').aggregate(lambda items: (items[1]['c'],items[0]['d']))
+
+        tester = Tester(topo)
+        tester.contents(s, [('a',1), ('b',7), ('a', 2), ('b', 9)] )
+        tester.test(self.test_ctxtype, self.test_config)
+
+
+    # Partition by attribute supported for streams schema
+    def test_structured_as_tuple(self):
+        schema = StreamSchema("tuple<rstring c, int32 d>").as_tuple()
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17)])
+        s = s.map(lambda x: x, schema = schema)
+
+        s = s.last(3).trigger(2).partition('c').aggregate(lambda items: (items[1][0], items[0][1]))
+
+        # s.print()
+        # streamsx.topology.context.submit('TOOLKIT', topo)
+
+        tester = Tester(topo)
+        tester.contents(s, [('a',1), ('b',7), ('a', 2), ('b', 9)] )
+        tester.test(self.test_ctxtype, self.test_config)
+
+
+    # Partition by attribute supported for streams schema
+    def test_structured_as_named_tuple(self):
+        schema = StreamSchema("tuple<rstring c, int32 d>").as_tuple(named=True)
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17)])
+        s = s.map(lambda x: x, schema = schema)
+
+        s = s.last(3).trigger(2).partition('c').aggregate(lambda items: (items[1].c, items[0].d))
+
+        tester = Tester(topo)
+        tester.contents(s, [('a',1), ('b',7), ('a', 2), ('b', 9)] )
+        tester.test(self.test_ctxtype, self.test_config)
+
+    # partition by attribute not part of schema
+    def test_partition_by_attribute_not_part_of_schema(self):
+        schema = StreamSchema("tuple<rstring c, int32 d>").as_tuple()
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17)])
+        s = s.map(lambda x: x, schema = schema)
+
+        s = s.last(3).trigger(2).partition('q').aggregate(lambda items: (items[1][0], items[0][1]))
+
+        tester = Tester(topo)
+        self.assertFalse(tester.test(self.test_ctxtype, self.test_config, assert_on_fail=False))
+
+    # partition before trigger
+    def test_partition_before_trigger(self):
+        schema = StreamSchema("tuple<rstring c, int32 d>").as_tuple()
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17)])
+        s = s.map(lambda x: x, schema = schema)
+
+        s = s.last(3).partition('c').trigger(2).aggregate(lambda items: (items[1][0], items[0][1]))
+
+        tester = Tester(topo)
+        tester.contents(s, [('a',1), ('b',7), ('a', 2), ('b', 9)] )
+        tester.test(self.test_ctxtype, self.test_config)
+
+    # no trigger
+    def test_partition_no_trigger(self):
+        schema = StreamSchema("tuple<rstring c, int32 d>").as_tuple()
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17)])
+        s = s.map(lambda x: x, schema = schema)
+
+        s = s.last(3).partition('c').aggregate(lambda items: (items[0][0], items[0][1]))
+
+        tester = Tester(topo)
+        tester.contents(s, [('a',1), ('b',7), ('a', 1), ('b', 7), ('a', 1), ('a', 2), ('b', 7), ('b', 9)] )
+        tester.test(self.test_ctxtype, self.test_config)
+
+    # batch (tumbling) window with partition
+    # one partition has an incomplete batch to be aggregated at the end
+    # of the run
+    def test_partition_batch_one_incomplete(self):
+        schema = StreamSchema("tuple<rstring c, int32 d>").as_tuple()
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17), ('a', 10)])
+        s = s.map(lambda x: x, schema = schema)
+
+        s = s.batch(2).partition('c').aggregate(lambda items: (items[0][0], sum(item[1] for item in items)))
+
+        tester = Tester(topo)
+        tester.contents(s, [('a',3), ('b',16), ('a', 9), ('b', 25), ('a', 10)])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    # batch (tumbling) window with partition
+    # all partitions have an incomplete batch to be aggregated at the end
+    # of the run
+    def test_partition_batch_all_incomplete(self):
+        schema = StreamSchema("tuple<rstring c, int32 d>").as_tuple()
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17), ('a', 10), ('b', 11)])
+        s = s.map(lambda x: x, schema = schema)
+
+        s = s.batch(2).partition('c').aggregate(lambda items: (items[0][0], sum(item[1] for item in items)))
+
+        tester = Tester(topo)
+        tester.contents(s, [('a',3), ('b',16), ('a', 9), ('b', 25), ('a', 10), ('b', 11)])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    # batch (tumbling) window with partition
+    # no partition has an incomplete batch to be aggregated at the end
+    # of the run
+    def test_partition_batch_no_incomplete(self):
+        schema = StreamSchema("tuple<rstring c, int32 d>").as_tuple()
+        topo = Topology()
+        s = topo.source([('a',1),('b', 7),('a', 2),('b', 9), ('a', 4), ('a', 5), ('b', 8), ('b', 17)])
+        s = s.map(lambda x: x, schema = schema)
+
+        s = s.batch(2).partition('c').aggregate(lambda items: (items[0][0], sum(item[1] for item in items)))
+
+        tester = Tester(topo)
+        tester.contents(s, [('a',3), ('b',16), ('a', 9), ('b', 25)])
+        tester.test(self.test_ctxtype, self.test_config)


### PR DESCRIPTION
Support for partitioned windows in python topology operators.  This contains support for partitioned windows in operator with structured schemas, partitioning by a single attribute in the schema.