### PR TITLE
Compile main composite only invocation directly.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/graph.py
@@ -93,6 +93,7 @@ class SPLGraph(object):
         self._layout_group_id = 0
         self._colocate_tag_mapping = {}
         self._id_gen = 0
+        self._main_composite = None
 
     def _unique_id(self, prefix):
         """
@@ -203,6 +204,11 @@ class SPLGraph(object):
             _ops.append(op.generateSPLOperator())
 
         _graph["operators"] = _ops
+
+        # Is this just a single main composite invocation,
+        # If so toolkit generation will be skipped.
+        if self._main_composite and len(_ops) == 1:
+            _graph['mainComposite'] = self._main_composite
         return _graph
 
     def _determine_model(self, graph_cfg):

--- a/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
+++ b/java/src/com/ibm/streamsx/topology/generator/spl/SPLGenerator.java
@@ -766,8 +766,6 @@ public class SPLGenerator {
         
         createCheckpointConfig(graphConfig);
         
-        graphConfig.addProperty("supportsJobConfigOverlays", versionAtLeast(4,2));
-
         String namespace = splAppNamespace(graph);
         if (namespace != null && !namespace.isEmpty()) {
             sb.append("namespace ");

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/DeployKeys.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/DeployKeys.java
@@ -129,11 +129,6 @@ public interface DeployKeys {
 
         if (deploy.has(DeployKeys.JOB_CONFIG_OVERLAYS)) {
             JsonObject graph = graph(submission);
-            JsonObject graphConfig = object(graph, "config");
-
-            boolean jcos_ok = jboolean(graphConfig, "supportsJobConfigOverlays");
-            if (!jcos_ok)
-                return null;
 
             String namespace = splAppNamespace(graph);
             String name = splAppName(graph);

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/ToolkitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/ToolkitRemoteContext.java
@@ -147,7 +147,7 @@ public class ToolkitRemoteContext extends RemoteContextImpl<File> {
      * Create a Job Config Overlays structure if it does not exist.
      * Set the deployment from the graph config.
      */
-    private void setupJobConfigOverlays(JsonObject deploy, JsonObject graph) {
+    public static void setupJobConfigOverlays(JsonObject deploy, JsonObject graph) {
         JsonArray jcos = array(deploy, JOB_CONFIG_OVERLAYS);
         if (jcos == null) {
             deploy.add(JOB_CONFIG_OVERLAYS, jcos = new JsonArray());

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/ZippedToolkitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/ZippedToolkitRemoteContext.java
@@ -66,20 +66,30 @@ public class ZippedToolkitRemoteContext extends ToolkitRemoteContext {
     public Future<File> _submit(JsonObject submission) throws Exception {
         
         JsonObject deploy = deploy(submission);
-        final File toolkitRoot = super._submit(submission).get();
+        JsonObject graph = object(submission, SUBMISSION_GRAPH);
+        String mainCompositeKind = jstring(graph, "mainComposite");
+
+        File toolkitRoot = null;
+        if (mainCompositeKind == null) {
+            toolkitRoot = super._submit(submission).get();
+        } else {
+            // Just a main composite
+        }
+         
         try {
               report("Building code archive");
-              return createCodeArchive(toolkitRoot, submission);
+              return createCodeArchive(toolkitRoot, submission, mainCompositeKind);
         } finally {
-            deleteToolkit(toolkitRoot, deploy);
+            if (toolkitRoot != null)
+                deleteToolkit(toolkitRoot, deploy);
         }
     }
     
-    public Future<File> createCodeArchive(File toolkitRoot, JsonObject submission) throws IOException, URISyntaxException {
+    private Future<File> createCodeArchive(File toolkitRoot, JsonObject submission, String mainCompositeKind) throws IOException, URISyntaxException {
         
-        String tkName = toolkitRoot.getName();
+        String tkName = toolkitRoot != null ? toolkitRoot.getName() : null;
                 
-        Path zipOutPath = pack(toolkitRoot.toPath(), submission, tkName);
+        Path zipOutPath = pack(toolkitRoot, submission, tkName, mainCompositeKind);
         
         if (keepBuildArchive || keepArtifacts(submission)) {
         	final JsonObject submissionResult = GsonUtilities.objectCreate(submission, RemoteContext.SUBMISSION_RESULTS);
@@ -89,13 +99,17 @@ public class ZippedToolkitRemoteContext extends ToolkitRemoteContext {
         return new CompletedFuture<File>(zipOutPath.toFile());
     }
         
-    private static Path pack(final Path folder, JsonObject submission, String tkName) throws IOException, URISyntaxException {
+    private static Path pack(final File appTkRoot, JsonObject submission, String tkName, String mainCompositeKind) throws IOException, URISyntaxException {
         
         JsonObject graph = graph(submission);
-        String namespace = splAppNamespace(graph);
-        String name = splAppName(graph);
         
-        Path zipFilePath = Paths.get(folder.toAbsolutePath().toString() + ".zip");
+        if (mainCompositeKind == null) {
+            String namespace = splAppNamespace(graph);
+            String name = splAppName(graph);
+            mainCompositeKind = namespace + "::" + name;
+        }
+        
+        Path zipFilePath = Files.createTempFile("code_archive", ".zip");
         
         final Path topologyToolkit = TkInfo.getTopologyToolkitRoot().getAbsoluteFile().toPath(); 
         final String topologyToolkitName = topologyToolkit.getFileName().toString();
@@ -105,17 +119,19 @@ public class ZippedToolkitRemoteContext extends ToolkitRemoteContext {
         
         // Paths to completely copy into the code archive
         Map<Path,String> toolkits = new HashMap<>();
-        toolkits.put(folder, tkName);
+        if (appTkRoot != null)
+            toolkits.put(appTkRoot.toPath(), tkName);
         toolkits.put(topologyToolkit, topologyToolkitName);
         
         // Avoid multiple concurrent executions overwriting files.
-        Path manifestTmp = Files.createTempFile("manifest_tk", "txt");
-        Path mainCompTmp = Files.createTempFile("main_composite", "txt");
-        Path scOptsTmp = Files.createTempFile("sc_opts", "txt");
+        Path manifestTmp = Files.createTempFile("manifest_tk", ".txt");
+        Path mainCompTmp = Files.createTempFile("main_composite", ".txt");
+        Path scOptsTmp = Files.createTempFile("sc_opts", ".txt");
         
         // tkManifest is the list of toolkits contained in the archive
         try (PrintWriter tkManifest = new PrintWriter(manifestTmp.toFile(), "UTF-8")) {
-            tkManifest.println(tkName);
+            if (tkName != null)
+                tkManifest.println(tkName);
             tkManifest.println(topologyToolkitName);
             
             JsonObject configSpl = object(graph, CONFIG, "spl");
@@ -136,7 +152,7 @@ public class ZippedToolkitRemoteContext extends ToolkitRemoteContext {
         // mainComposite is a string of the namespace and the main composite.
         // This is used by the Makefile
         try (PrintWriter mainComposite = new PrintWriter(mainCompTmp.toFile(), "UTF-8")) {
-            mainComposite.print(namespace + "::" + name);
+            mainComposite.print(mainCompositeKind);
         }
         
         JsonObject deploy = deploy(submission);

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/ZippedToolkitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/ZippedToolkitRemoteContext.java
@@ -74,6 +74,7 @@ public class ZippedToolkitRemoteContext extends ToolkitRemoteContext {
             toolkitRoot = super._submit(submission).get();
         } else {
             // Just a main composite
+            ToolkitRemoteContext.setupJobConfigOverlays(deploy, graph); 
         }
          
         try {

--- a/java/src/com/ibm/streamsx/topology/internal/streams/InvokeSubmit.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/InvokeSubmit.java
@@ -45,7 +45,7 @@ public class InvokeSubmit {
         if (domainId == null)
         	checkPreconditions();
         
-        File jobidFile = Files.createTempFile("streamsjobid", "txt").toFile();
+        File jobidFile = Files.createTempFile("streamsjobid", ".txt").toFile();
 
         List<String> commands = new ArrayList<>();
 

--- a/test/python/topology/test2_spl.py
+++ b/test/python/topology/test2_spl.py
@@ -375,6 +375,8 @@ class TestMainComposite(unittest.TestCase):
         rc = streamsx.topology.context.submit('BUNDLE', r[0])
         self.assertEqual(0, rc['return_code'])
         shutil.rmtree(tkl)
+        self.assertEqual('app.MyMain.sab', os.path.basename(rc['bundlePath']))
+        self.assertEqual('app.MyMain_JobConfig.json', os.path.basename(rc['jobConfigPath']))
         os.remove(rc['bundlePath'])
         os.remove(rc['jobConfigPath'])
 


### PR DESCRIPTION
If `streamsx.op.main_composite` is called to simply invoke a main composite with no subsequent additional code or tests then don't build an intermediate toolkit, instead compile the main composite directly.