### PR TITLE
 Initial remote sc code

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/sc.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/sc.py
@@ -28,6 +28,7 @@ def _submit_build(cmd_args, topo):
      cfg[ConfigParams.FORCE_REMOTE_BUILD] = True
      if cmd_args.disable_ssl_verify:
          cfg[ConfigParams.SSL_VERIFY] = False
+         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
      _sc_options(cmd_args, cfg)
      submit('BUNDLE', topo, cfg)
 
@@ -86,7 +87,7 @@ def _parse_args(args):
 def _buildservice_args(cmd_parser):
     rem = cmd_parser.add_argument_group('build service arguments', 'Arguments specific to use of the build service. Not supported by sc.')
 
-    cmd_parser.add_argument('--disable-ssl-verify', action='store_true', help='Generate the facade tuples when it is possible.')
+    cmd_parser.add_argument('--disable-ssl-verify', action='store_true', help='Disable SSL verification.')
 
 def _deprecated_args(cmd_parser):
     dep = cmd_parser.add_argument_group('deprecated arguments', 'Arguments that have been deprecated by sc and are ignored')

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/sc.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/sc.py
@@ -6,6 +6,7 @@ import sys
 import sysconfig
 import os
 import argparse
+import urllib3
 import streamsx.rest
 from streamsx.spl.op import main_composite
 from streamsx.spl.toolkit import add_toolkit
@@ -73,7 +74,7 @@ def _create_topo(cmd_args):
 def _parse_args(args):
     """ Argument parsing
     """
-    cmd_parser = argparse.ArgumentParser(description='SPL Compile alias for build service.')
+    cmd_parser = argparse.ArgumentParser(description='SPL compiler (sc) alias for build service.')
     cmd_parser.add_argument('--main-composite', '-M', required=True, help='SPL Main composite', metavar='name')
 
     cmd_parser.add_argument('--optimized-code-generation', '-a', action='store_true', help='Generate optimized code with less runtime error checking.')

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/sc.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/sc.py
@@ -1,0 +1,104 @@
+# coding=utf-8
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2019
+
+import sys
+import sysconfig
+import os
+import argparse
+import streamsx.rest
+from streamsx.spl.op import main_composite
+from streamsx.spl.toolkit import add_toolkit
+from streamsx.topology.context import submit, ConfigParams
+
+_FACADE=['--prefer-facade-tuples', '-k']
+
+def main(args=None):
+    """ Mimics SPL SPL compiler sc against the ICP4D build service.
+    """
+    cmd_args = _parse_args(args)
+    topo = _create_topo(cmd_args)
+    _add_toolkits(cmd_args, topo)
+    _submit_build(cmd_args, topo)
+    return 0
+
+def _submit_build(cmd_args, topo):
+     cfg = {}
+     # Only supported for remote builds.
+     cfg[ConfigParams.FORCE_REMOTE_BUILD] = True
+     if cmd_args.disable_ssl_verify:
+         cfg[ConfigParams.SSL_VERIFY] = False
+     _sc_options(cmd_args, cfg)
+     submit('BUNDLE', topo, cfg)
+
+def _sc_options(cmd_args, cfg):
+    args = []
+    if cmd_args.prefer_facade_tuples:
+        args.append(_FACADE[0])
+
+    if args:
+        cfg[ConfigParams.SC_OPTIONS] = args
+
+def _add_toolkits(cmd_args, topo):
+    _add_cwd(cmd_args, topo)
+
+def _add_cwd(cmd_args, topo):
+    cwd = os.getcwd()
+    if _is_toolkit(cwd):
+        add_toolkit(topo, cwd)
+
+def _is_toolkit(tkdir):
+    """
+    Determine if a directory looks like an SPL toolkit.
+    """
+    for fn in ['toolkit.xml', 'info.xml']:
+        if os.path.isfile(os.path.join(tkdir, fn)):
+            return True
+    for dirpath, dirnames, filenames in os.walk(tkdir):
+        for fn in filenames:
+            if fn.endswith('.spl'):
+                return True
+            if fn.endswith('._cpp.cgt'):
+                return True
+        if '.namespace' in filenames:
+            return True
+        if 'native.function' in dirnames:
+            return True
+
+def _create_topo(cmd_args):
+    topo,invoke = main_composite(kind=cmd_args.main_composite)
+    return topo
+    
+def _parse_args(args):
+    """ Argument parsing
+    """
+    cmd_parser = argparse.ArgumentParser(description='SPL Compile alias for build service.')
+    cmd_parser.add_argument('--main-composite', '-M', required=True, help='SPL Main composite', metavar='name')
+
+    cmd_parser.add_argument('--optimized-code-generation', '-a', action='store_true', help='Generate optimized code with less runtime error checking.')
+    cmd_parser.add_argument('--no-optimized-code-generation', action='store_true', help='Generate non-optimized code with more runtime error checking. Do not use with the --optimized-code-generation option.')
+    cmd_parser.add_argument(*_FACADE, action='store_true', help='Generate the facade tuples when it is possible.')
+    _buildservice_args(cmd_parser)
+    _deprecated_args(cmd_parser)
+
+    return cmd_parser.parse_args(args)
+
+def _buildservice_args(cmd_parser):
+    rem = cmd_parser.add_argument_group('build service arguments', 'Arguments specific to use of the build service. Not supported by sc.')
+
+    cmd_parser.add_argument('--disable-ssl-verify', action='store_true', help='Generate the facade tuples when it is possible.')
+
+def _deprecated_args(cmd_parser):
+    dep = cmd_parser.add_argument_group('deprecated arguments', 'Arguments that have been deprecated by sc and are ignored')
+
+    dep.add_argument('--static-link', '-s', action='store_true')
+    dep.add_argument('--standalone-application', '-T', action='store_true')
+    dep.add_argument('--set-relax-fusion-relocatability-restartability', '-O', action='store_true')
+
+    dep.add_argument('--checkpoint-directory', '-K', action='store', metavar='path')
+    dep.add_argument('--profiling-sampling', '-S', action='store', metavar='rate')
+    
+
+if __name__ == '__main__':
+    rc = main()
+    sys.exit(rc)


### PR DESCRIPTION
Initial work for supporting a script that mimics `sc` but uses the build-service in V5 (ICP4D).

Simple applications (app contained in a single toolkit or using product toolkits) can be compiled like:

`python3 -m streamsx.scripts.sc --main-composite Main`