### PR TITLE
ICP4D authentication improvements.

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -359,6 +359,7 @@ class _ICPDExternalAuthHandler(_BearerAuthHandler):
                     'serviceRestEndpoint': streams_url},
                 'serviceTokenEndpoint': service_token_url,
                 'service_token': service_token,
+                'service_token_expire': int(self._auth_expiry_time * 1000.0),
                 'service_name': service_name,
                 'cluster_ip': cluster_ip,
                 'cluster_port': cluster_port,

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamsConnection.java
@@ -26,7 +26,10 @@ abstract class AbstractStreamsConnection {
     private final String resourcesUrl;
 
     protected Executor executor;
+    private boolean verify;
     private String instancesUrl;
+    
+    private StreamsConnection streamsConnection;
     
     /**
      * Cancel a job.
@@ -63,12 +66,25 @@ abstract class AbstractStreamsConnection {
     AbstractStreamsConnection(String resourcesUrl,
             boolean allowInsecure) {
         this.resourcesUrl = resourcesUrl;
-        this.executor = RestUtils.createExecutor(allowInsecure);
+        allowInsecureHosts(allowInsecure);
     }
     
     public boolean allowInsecureHosts(boolean allowInsecure) {
     	this.executor = RestUtils.createExecutor(allowInsecure);
+    	verify = !allowInsecure;
     	return allowInsecure;
+    }
+    
+    final boolean isVerify() {
+        return verify;
+    }
+    
+    void setStreamsConnection(StreamsConnection streamsConnection) {
+        this.streamsConnection = streamsConnection;
+    }
+    
+    StreamsConnection getStreamsConnection() {
+        return streamsConnection;
     }
 
     /**

--- a/java/src/com/ibm/streamsx/rest/Element.java
+++ b/java/src/com/ibm/streamsx/rest/Element.java
@@ -49,6 +49,10 @@ public abstract class Element {
         this.self = self;
     }
     
+    public StreamsConnection getStreamsConnection() {
+        return connection().getStreamsConnection();
+    }
+    
 
     @Override
     public final String toString() {

--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -147,8 +147,7 @@ public class Instance extends Element {
         URL restUrl = new URL(instanceUrl.getProtocol(), instanceUrl.getHost(), instanceUrl.getPort(),
                 "/streams/rest/resources");
                        
-        StreamsConnection conn = StreamsConnection.ofBearerToken(restUrl.toExternalForm(),
-                StreamsKeys.getBearerToken(deploy));
+        StreamsConnection conn = StreamsConnection.ofAuthorization(restUrl.toExternalForm(), authenticator);
         
         if (!verify)
             conn.allowInsecureHosts(true);

--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -140,14 +140,14 @@ public class Instance extends Element {
                 endpoint, name, userName, password);
         
         JsonObject deploy = new JsonObject();
-        deploy.add(StreamsKeys.SERVICE_DEFINITION, authenticator.config(RestUtils.createExecutor(!verify)));
+        deploy.add(StreamsKeys.SERVICE_DEFINITION, authenticator.config(verify));
         
         URL instanceUrl  = new URL(getStreamsInstanceURL(deploy));
 
         URL restUrl = new URL(instanceUrl.getProtocol(), instanceUrl.getHost(), instanceUrl.getPort(),
                 "/streams/rest/resources");
                        
-        StreamsConnection conn = StreamsConnection.ofAuthorization(restUrl.toExternalForm(), authenticator);
+        StreamsConnection conn = StreamsConnection.ofAuthenticator(restUrl.toExternalForm(), authenticator);
         
         if (!verify)
             conn.allowInsecureHosts(true);

--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -9,6 +9,9 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+
+import org.apache.http.client.fluent.Executor;
 
 import com.ibm.streamsx.rest.internal.RestUtils;
 import com.ibm.streamsx.topology.internal.streams.Util;
@@ -74,10 +77,10 @@ public class StreamsConnection {
         return sc;
     }
     
-    public static StreamsConnection ofBearerToken(String url, String bearerToken) {
+    public static StreamsConnection ofAuthorization(String url, Function<Executor, String> authorization) {
         
         AbstractStreamsConnection delegate = new StreamsConnectionImpl(null,
-                executor -> RestUtils.createBearerAuth(bearerToken),
+                authorization,
                 url, false);
         StreamsConnection sc = new StreamsConnection(delegate);
         return sc;      

--- a/java/src/com/ibm/streamsx/rest/StreamsConnection.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnection.java
@@ -24,6 +24,7 @@ public class StreamsConnection {
 
     StreamsConnection(AbstractStreamsConnection delegate) {
         this.delegate = delegate;
+        delegate.setStreamsConnection(this);
     }
     
     private final AbstractStreamsConnection delegate() {
@@ -77,13 +78,20 @@ public class StreamsConnection {
         return sc;
     }
     
-    public static StreamsConnection ofAuthorization(String url, Function<Executor, String> authorization) {
+    public static StreamsConnection ofAuthenticator(String url, Function<Executor, String> authenticator) {
         
         AbstractStreamsConnection delegate = new StreamsConnectionImpl(null,
-                authorization,
+                authenticator,
                 url, false);
         StreamsConnection sc = new StreamsConnection(delegate);
         return sc;      
+    }
+    
+    public Function<Executor, String> getAuthenticator() {
+        Object delegate = delegate();
+        if (delegate instanceof StreamsConnectionImpl)
+            return ((StreamsConnectionImpl) delegate).getAuthenticator();
+        return null;
     }
 
     /**
@@ -104,6 +112,10 @@ public class StreamsConnection {
      */
     public boolean allowInsecureHosts(boolean allowInsecure) {
     	return delegate().allowInsecureHosts(allowInsecure);
+    }
+    
+    public final boolean isVerify() {
+        return delegate().isVerify();
     }
 
     /**

--- a/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
+++ b/java/src/com/ibm/streamsx/rest/StreamsConnectionImpl.java
@@ -14,19 +14,23 @@ import com.ibm.streamsx.topology.internal.streams.InvokeSubmit;
 
 class StreamsConnectionImpl extends AbstractStreamsConnection {
 
-	private final Function<Executor, String> authorization;
+	private final Function<Executor, String> authenticator;
     private final String userName;
 
-    StreamsConnectionImpl(String userName, Function<Executor, String> authorization,
+    StreamsConnectionImpl(String userName, Function<Executor, String> authenticator,
             String resourcesUrl, boolean allowInsecure) {
         super(resourcesUrl, allowInsecure);
         this.userName = userName;
-        this.authorization = authorization;
+        this.authenticator = authenticator;
+    }
+    
+    Function<Executor, String> getAuthenticator() {
+        return authenticator;
     }
 
     @Override
     String getAuthorization() {
-        return authorization.apply(this.executor);
+        return authenticator.apply(this.executor);
     }
     
     @Override

--- a/java/src/com/ibm/streamsx/rest/build/BuildService.java
+++ b/java/src/com/ibm/streamsx/rest/build/BuildService.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import com.google.gson.JsonObject;
 import com.ibm.streamsx.rest.Job;
 import com.ibm.streamsx.rest.Result;
+import com.ibm.streamsx.rest.internal.ICP4DAuthenticator;
+import com.ibm.streamsx.rest.internal.RestUtils;
 
 /**
  * Access to a IBM Streams build service.
@@ -18,9 +20,22 @@ import com.ibm.streamsx.rest.Result;
  */
 public interface BuildService {
 	
-	static BuildService of(String endpoint, String bearerToken) {
-		return new StreamsBuildService(endpoint, bearerToken);
+	public static BuildService ofEndpoint(String endpoint, String name, String userName, String password,
+            boolean verify) throws IOException {
+	    
+	    ICP4DAuthenticator authenticator = ICP4DAuthenticator.of(endpoint, name, userName, password);
+	    JsonObject serviceDefinition = authenticator.config(RestUtils.createExecutor(!verify));
+	    
+	    return StreamsBuildService.of(authenticator, serviceDefinition, verify);
+	    
 	}
+
+    public static BuildService ofServiceDefinition(JsonObject serviceDefinition, boolean verify) throws IOException {
+
+        ICP4DAuthenticator authenticator = ICP4DAuthenticator.of(serviceDefinition);
+
+        return StreamsBuildService.of(authenticator, serviceDefinition, verify);
+    }
 	
 	void allowInsecureHosts();
 

--- a/java/src/com/ibm/streamsx/rest/build/BuildService.java
+++ b/java/src/com/ibm/streamsx/rest/build/BuildService.java
@@ -24,7 +24,7 @@ public interface BuildService {
             boolean verify) throws IOException {
 	    
 	    ICP4DAuthenticator authenticator = ICP4DAuthenticator.of(endpoint, name, userName, password);
-	    JsonObject serviceDefinition = authenticator.config(RestUtils.createExecutor(!verify));
+	    JsonObject serviceDefinition = authenticator.config(verify);
 	    
 	    return StreamsBuildService.of(authenticator, serviceDefinition, verify);
 	    

--- a/java/src/com/ibm/streamsx/rest/internal/ICP4DAuthenticator.java
+++ b/java/src/com/ibm/streamsx/rest/internal/ICP4DAuthenticator.java
@@ -70,7 +70,9 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
         this.password = password;
     }
     
-    public JsonObject config(Executor executor) throws IOException {
+    public JsonObject config(boolean verify) throws IOException {
+        
+        Executor executor = RestUtils.createExecutor(!verify);
         
         JsonObject namepwd = new JsonObject();
         String[] userPwd = Util.getDefaultUserPassword(user, password);

--- a/java/src/com/ibm/streamsx/rest/internal/ICP4DAuthenticator.java
+++ b/java/src/com/ibm/streamsx/rest/internal/ICP4DAuthenticator.java
@@ -20,7 +20,6 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 
 import com.google.gson.JsonObject;
-import com.ibm.streamsx.topology.internal.context.streamsrest.StreamsKeys;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.internal.streams.Util;
 
@@ -159,9 +158,7 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
         return cfg;
     }
     
-    public static ICP4DAuthenticator of(JsonObject deploy) throws MalformedURLException, UnsupportedEncodingException {
-        
-        JsonObject service = deploy.get(StreamsKeys.SERVICE_DEFINITION).getAsJsonObject();
+    public static ICP4DAuthenticator of(JsonObject service) throws MalformedURLException, UnsupportedEncodingException {
         
         String cpd_host = jstring(service, "cluster_ip");
         int cpd_port = GsonUtilities.jint(service, "cluster_port");

--- a/java/src/com/ibm/streamsx/rest/internal/ICP4DAuthenticator.java
+++ b/java/src/com/ibm/streamsx/rest/internal/ICP4DAuthenticator.java
@@ -59,6 +59,8 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
     private String serviceAuth;
     private long expire;
     
+    private JsonObject cfg;
+    
     ICP4DAuthenticator(URL icpdUrl, URL authorizeUrl, URL detailsUrl, URL serviceTokenUrl,
             String instanceName, String user, String password) {
         this.icpdUrl = icpdUrl;
@@ -71,6 +73,9 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
     }
     
     public JsonObject config(boolean verify) throws IOException {
+        
+        if (cfg != null)
+            return cfg;
         
         Executor executor = RestUtils.createExecutor(!verify);
         
@@ -157,6 +162,7 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
         cfg.addProperty("cluster_port", icpdUrl.getPort());
         cfg.addProperty("service_id", serviceId);
         
+        this.cfg = cfg;
         return cfg;
     }
     
@@ -166,13 +172,15 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
         int cpd_port = GsonUtilities.jint(service, "cluster_port");
         URL cpd_url = new URL("https", cpd_host, cpd_port, "");
         
-        ICP4DAuthenticator auth = ICP4DAuthenticator.of(cpd_url.toExternalForm(), jstring(service, "service_name"), (String) null, (String) null);       
+        ICP4DAuthenticator auth = ICP4DAuthenticator.of(cpd_url.toExternalForm(), jstring(service, "service_name"), (String) null, (String) null);
+        
       
         String serviceToken = jstring(service, "service_token");
         if (serviceToken != null) {
             auth.serviceAuth = RestUtils.createBearerAuth(serviceToken);
             auth.expire = service.get("service_token_expire").getAsLong();
         }
+        auth.cfg = service;
         return auth;
     }
 

--- a/java/src/com/ibm/streamsx/rest/internal/ICP4DAuthenticator.java
+++ b/java/src/com/ibm/streamsx/rest/internal/ICP4DAuthenticator.java
@@ -20,6 +20,7 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 
 import com.google.gson.JsonObject;
+import com.ibm.streamsx.topology.internal.context.streamsrest.StreamsKeys;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 import com.ibm.streamsx.topology.internal.streams.Util;
 
@@ -46,6 +47,8 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
         return new ICP4DAuthenticator(icpdUrl, authorizeUrl, detailsUrl, serviceTokenUrl, instanceName, user, password);
     }
     
+
+    
     private final URL icpdUrl;
     private final URL authorizeUrl;
     private final URL detailsUrl;
@@ -53,6 +56,7 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
     private final String instanceName;
     private final String user;
     private final String password;
+    
     private String serviceAuth;
     private long expire;
     
@@ -119,8 +123,7 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
         
         serviceAuth = RestUtils.createBearerAuth(serviceToken);
         expire = System.currentTimeMillis() + 19 * 60;
-        
-        
+                
         URL buildEndpoint = new URL(jstring(sci, "externalBuildEndpoint"));
         
         // Ensure the build endpoint matches the fully external ICP4D URL
@@ -147,6 +150,7 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
         cfg.addProperty("type", "streams");
         cfg.add("connection_info", connInfo);
         cfg.addProperty("service_token", serviceToken);
+        cfg.addProperty("service_token_expire", expire);
         cfg.addProperty("service_name", serviceName);
         cfg.addProperty("cluster_ip", icpdUrl.getHost());
         cfg.addProperty("cluster_port", icpdUrl.getPort());
@@ -154,13 +158,27 @@ public class ICP4DAuthenticator implements Function<Executor,String> {
         
         return cfg;
     }
+    
+    public static ICP4DAuthenticator of(JsonObject deploy) throws MalformedURLException, UnsupportedEncodingException {
+        
+        JsonObject service = deploy.get(StreamsKeys.SERVICE_DEFINITION).getAsJsonObject();
+        
+        String cpd_host = jstring(service, "cluster_ip");
+        int cpd_port = GsonUtilities.jint(service, "cluster_port");
+        URL cpd_url = new URL("https", cpd_host, cpd_port, "");
+        
+        ICP4DAuthenticator auth = ICP4DAuthenticator.of(cpd_url.toExternalForm(), jstring(service, "service_name"), (String) null, (String) null);       
+      
+        String serviceToken = jstring(service, "service_token");
+        if (serviceToken != null) {
+            auth.serviceAuth = RestUtils.createBearerAuth(serviceToken);
+            auth.expire = service.get("service_token_expire").getAsLong();
+        }
+        return auth;
+    }
 
     @Override
-    public String apply(Executor executor) {
-        
-        
-        return null;
-    }
-    
-    
+    public String apply(Executor executor) {   
+        return serviceAuth;
+    }  
 }

--- a/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/BuildServiceContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/BuildServiceContext.java
@@ -8,6 +8,7 @@ import static com.ibm.streamsx.topology.context.ContextProperties.KEEP_ARTIFACTS
 import static com.ibm.streamsx.topology.generator.spl.SPLGenerator.getSPLCompatibleName;
 import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.createJobConfigOverlayFile;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jboolean;
+import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.object;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +42,8 @@ public class BuildServiceContext extends BuildRemoteContext<BuildService> {
 
     @Override
     protected BuildService createSubmissionContext(JsonObject deploy) throws Exception {
-        return BuildService.of(StreamsKeys.getBuildServiceURL(deploy), StreamsKeys.getBearerToken(deploy));
+        JsonObject serviceDefinition = object(deploy, StreamsKeys.SERVICE_DEFINITION);
+        return BuildService.ofServiceDefinition(serviceDefinition, sslVerify(deploy));
     }
 
     @Override

--- a/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/DistributedStreamsRestContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/DistributedStreamsRestContext.java
@@ -24,7 +24,6 @@ import com.ibm.streamsx.rest.Result;
 import com.ibm.streamsx.rest.StreamsConnection;
 import com.ibm.streamsx.rest.build.BuildService;
 import com.ibm.streamsx.rest.internal.ICP4DAuthenticator;
-import com.ibm.streamsx.rest.internal.RestUtils;
 import com.ibm.streamsx.topology.internal.context.remote.SubmissionResultsKeys;
 import com.ibm.streamsx.topology.internal.gson.GsonUtilities;
 
@@ -52,7 +51,7 @@ public class DistributedStreamsRestContext extends BuildServiceContext {
             // Use defaults from env.
             ICP4DAuthenticator authenticator = ICP4DAuthenticator.of(null, null, null, null);
             
-            deploy.add(StreamsKeys.SERVICE_DEFINITION, authenticator.config(RestUtils.createExecutor(!sslVerify(deploy))));
+            deploy.add(StreamsKeys.SERVICE_DEFINITION, authenticator.config(sslVerify(deploy)));
         }
         
         // Verify the Streams service endpoint has the correct format.
@@ -80,7 +79,7 @@ public class DistributedStreamsRestContext extends BuildServiceContext {
                 "/streams/rest/resources");
                        
         JsonObject serviceDefinition = object(deploy, StreamsKeys.SERVICE_DEFINITION);
-        StreamsConnection conn = StreamsConnection.ofAuthorization(restUrl.toExternalForm(), ICP4DAuthenticator.of(serviceDefinition));
+        StreamsConnection conn = StreamsConnection.ofAuthenticator(restUrl.toExternalForm(), ICP4DAuthenticator.of(serviceDefinition));
         
         if (!sslVerify(deploy))
             conn.allowInsecureHosts(true);

--- a/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/DistributedStreamsRestContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/DistributedStreamsRestContext.java
@@ -6,6 +6,7 @@ package com.ibm.streamsx.topology.internal.context.streamsrest;
 
 import static com.ibm.streamsx.topology.context.ContextProperties.KEEP_ARTIFACTS;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jboolean;
+import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.object;
 
 import java.io.File;
 import java.net.URL;
@@ -78,7 +79,8 @@ public class DistributedStreamsRestContext extends BuildServiceContext {
         URL restUrl = new URL(instanceUrl.getProtocol(), instanceUrl.getHost(), instanceUrl.getPort(),
                 "/streams/rest/resources");
                        
-        StreamsConnection conn = StreamsConnection.ofAuthorization(restUrl.toExternalForm(), ICP4DAuthenticator.of(deploy));
+        JsonObject serviceDefinition = object(deploy, StreamsKeys.SERVICE_DEFINITION);
+        StreamsConnection conn = StreamsConnection.ofAuthorization(restUrl.toExternalForm(), ICP4DAuthenticator.of(serviceDefinition));
         
         if (!sslVerify(deploy))
             conn.allowInsecureHosts(true);

--- a/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/DistributedStreamsRestContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/DistributedStreamsRestContext.java
@@ -78,7 +78,7 @@ public class DistributedStreamsRestContext extends BuildServiceContext {
         URL restUrl = new URL(instanceUrl.getProtocol(), instanceUrl.getHost(), instanceUrl.getPort(),
                 "/streams/rest/resources");
                        
-        StreamsConnection conn = StreamsConnection.ofBearerToken(restUrl.toExternalForm(), StreamsKeys.getBearerToken(deploy));
+        StreamsConnection conn = StreamsConnection.ofAuthorization(restUrl.toExternalForm(), ICP4DAuthenticator.of(deploy));
         
         if (!sslVerify(deploy))
             conn.allowInsecureHosts(true);

--- a/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
+++ b/test/java/src/com/ibm/streamsx/rest/test/StreamsConnectionTest.java
@@ -94,6 +94,7 @@ public class StreamsConnectionTest {
 			}
             // don't continue if the instance isn't started
             assumeTrue(instance.getStatus().equals("running"));
+            assertSame(connection, instance.getStreamsConnection());
         }
     }
 
@@ -107,6 +108,8 @@ public class StreamsConnectionTest {
 			assertNotNull(domain.getZooKeeperConnectionString());
 			assertNotNull(domain.getCreationUser());
 			assertTrue(domain.getCreationTime() <= instance.getCreationTime());
+			
+			assertSame(domain.getStreamsConnection(), instance.getStreamsConnection());
 		}
         
         checkResourceAllocations(instance.getResourceAllocations(), false);
@@ -173,6 +176,7 @@ public class StreamsConnectionTest {
             }
         }
         assertTrue(foundJob);
+        assertSame(job.getStreamsConnection(), instance.getStreamsConnection());
 
         // get a specific job
         final Job job2 = instance.getJob(jobId);
@@ -240,8 +244,10 @@ public class StreamsConnectionTest {
         
        List<ProcessingElement> jobpes = job.getPes();
         for (Operator op : operators) {
+            assertSame(this.connection, op.getStreamsConnection());
             ProcessingElement pe = op.getPE();
             assertNotNull(pe);
+            assertSame(this.connection, pe.getStreamsConnection());
             boolean inJobList = false;
             for (ProcessingElement pej : jobpes) {
                 if (pej.getId().equals(pe.getId())) {

--- a/test/java/src/com/ibm/streamsx/topology/test/distributed/JobConfigSubmissionTest.java
+++ b/test/java/src/com/ibm/streamsx/topology/test/distributed/JobConfigSubmissionTest.java
@@ -4,17 +4,19 @@
  */
 package com.ibm.streamsx.topology.test.distributed;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Random;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import com.ibm.streamsx.rest.Instance;
-import com.ibm.streamsx.rest.StreamsConnection;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.context.ContextProperties;
@@ -58,11 +60,79 @@ public class JobConfigSubmissionTest extends TestTopology {
         String jobName = "nameSC" + System.currentTimeMillis();
         config.setJobName(jobName);
         
-        Instance instance = Instance.ofEndpoint((String) null, (String) null,
-                (String) null, (String) null, false);
-        getConfig().put(ContextProperties.STREAMS_INSTANCE, instance);
+        boolean verify = true;
+        if (getConfig().containsKey(ContextProperties.SSL_VERIFY))
+            verify = (Boolean) getConfig().get(ContextProperties.SSL_VERIFY);
         
-        testItDirect("testSubmitUsingInstance", config, "<jobId>", jobName, "default", "<empty>");
+        Instance instance = Instance.ofEndpoint((String) null, (String) null,
+                (String) null, (String) null, verify);
+        
+        assertEquals(verify, instance.getStreamsConnection().isVerify());
+        
+        getConfig().put(ContextProperties.STREAMS_INSTANCE, instance);
+        getConfig().remove(ContextProperties.SSL_VERIFY);
+
+        final String cpd_url = setEnv("ICPD_URL", null);
+        final String sid = setEnv("STREAMS_INSTANCE_ID", null);
+        
+        try {
+            testItDirect("testSubmitUsingInstance", config, "<jobId>", jobName, "default", "<empty>");
+        } finally {
+            setEnv("ICPD_URL", cpd_url);
+            setEnv("STREAMS_INSTANCE_ID", sid);
+        }
+    }
+    @Test
+    public void testSubmitUsingInstanceWithRemoteBuild() throws Exception {
+    	
+    	assumeTrue(getTesterContext().getType() == Type.DISTRIBUTED_TESTER);
+    	assumeTrue(System.getenv("ICPD_URL") != null);
+        
+        JobConfig config = new JobConfig();
+        String jobName = "nameSC" + System.currentTimeMillis();
+        config.setJobName(jobName);
+        
+        boolean verify = true;
+        if (getConfig().containsKey(ContextProperties.SSL_VERIFY))
+            verify = (Boolean) getConfig().get(ContextProperties.SSL_VERIFY);
+        
+        Instance instance = Instance.ofEndpoint((String) null, (String) null,
+                (String) null, (String) null, verify);
+        getConfig().put(ContextProperties.STREAMS_INSTANCE, instance);
+        getConfig().put(ContextProperties.FORCE_REMOTE_BUILD, true);
+        getConfig().remove(ContextProperties.SSL_VERIFY);
+
+        final String cpd_url = setEnv("ICPD_URL", null);
+        final String sid = setEnv("STREAMS_INSTANCE_ID", null);
+        
+        assertNull(System.getenv("ICPD_URL"));
+        assertNull(System.getenv("STREAMS_INSTANCE_ID"));
+        
+        try {
+            testItDirect("testSubmitUsingInstanceWithRemoteBuild", config, "<jobId>", jobName, "default", "<empty>");
+        } finally {
+            setEnv("ICPD_URL", cpd_url);
+            setEnv("STREAMS_INSTANCE_ID", sid);
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    private static String setEnv(String key, String value) {
+        try {
+            Map<String, String> env = System.getenv();
+            Class<?> cl = env.getClass();
+            Field field = cl.getDeclaredField("m");
+            field.setAccessible(true);
+            Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+            if (value == null) {
+                return writableEnv.remove(key);
+            } else {
+                writableEnv.put(key, value);
+                return value;
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to clear environment variable", e);
+        }
     }
     
     @Test


### PR DESCRIPTION
Always use ICP4DAuthenticator in Java for ICPD requests, rather that just bearer authentication with the service token.

Support using an ICPD `Instance` as `ContextProperties.STREAMS_INSTANCE` with distributed remote build and submit.