### PR TITLE
Support BUNDLE with Sas

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/runner.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/scripts/runner.py
@@ -72,9 +72,9 @@ def _parse_args(args):
     """
     cmd_parser = argparse.ArgumentParser(description='Execute a Streams application using a Streaming Analytics service.')
 
-    ctx_group = cmd_parser.add_mutually_exclusive_group(required=True)
+    ctx_group = cmd_parser.add_argument_group('Action')
     ctx_group.add_argument('--service-name', help='Submit to Streaming Analytics service')
-    ctx_group.add_argument('--create-bundle', action='store_true', help='Create a bundle using a local IBM Streams install. No job submission occurs.')
+    ctx_group.add_argument('--create-bundle', action='store_true', help='Create a bundle (sab file).  No job submission occurs.')
 
     app_group = cmd_parser.add_mutually_exclusive_group(required=True)
     app_group.add_argument('--topology', help='Topology to call')
@@ -132,7 +132,7 @@ def _get_topology_app(cmd_args):
 def _get_spl_app(cmd_args):
     topo = op.main_composite(kind=cmd_args.main_composite,
         toolkits=cmd_args.toolkits)[0]
-    if cmd_args.create_bundle:
+    if cmd_args.create_bundle and 'STREAMS_INSTALL' in os.environ:
         # Mimic what the build service does by indexing
         # any required toolkits including Python operator extraction
         # but only if we can write to it.
@@ -159,7 +159,7 @@ def _submit_topology(cmd_args, app):
     cfg = app.cfg
     if cmd_args.create_bundle:
         ctxtype = ctx.ContextTypes.BUNDLE
-    elif cmd_args.service_name:
+    else:
         cfg[ctx.ConfigParams.FORCE_REMOTE_BUILD] = True
         cfg[ctx.ConfigParams.SERVICE_NAME] = cmd_args.service_name
         ctxtype = ctx.ContextTypes.STREAMING_ANALYTICS_SERVICE

--- a/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/AbstractStreamingAnalyticsService.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.http.HttpEntity;
@@ -52,7 +53,7 @@ import com.ibm.streamsx.topology.internal.streams.Util;
  */
 abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsService {
     
-    private static final String DEFAULT_ORIGINATOR;
+    static final String DEFAULT_ORIGINATOR;
     static {
         String originator = "rest:java";
         String version = System.getProperty("java.version");
@@ -63,7 +64,7 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
 
     private final JsonObject credentials;
     final protected JsonObject service;
-    private final String serviceName;
+    protected final String serviceName;
 
     // Connection to Streams REST API
     AbstractStreamingAnalyticsConnection streamsConnection;
@@ -285,7 +286,7 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
             
             if (GsonUtilities.jboolean(buildConfig, BuildConfigKeys.KEEP_ARTIFACTS)) {
                 final long startDownloadSabTime = System.currentTimeMillis();
-                if (downloadArtifacts(httpclient, artifacts)) {
+                if (downloadArtifacts(httpclient, artifacts) != null) {
                     final long endDownloadSabTime = System.currentTimeMillis();
                     metrics.addProperty(SubmissionResultsKeys.DOWNLOAD_SABS_TIME, (endDownloadSabTime - startDownloadSabTime));
                 }
@@ -297,7 +298,9 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
         }
     }
     
-    protected abstract boolean downloadArtifacts(CloseableHttpClient httpclient, JsonArray artifacts);
+
+    
+    protected abstract List<File> downloadArtifacts(CloseableHttpClient httpclient, JsonArray artifacts);
 
     /**
      * Add any required Streams console URLs into the result.
@@ -316,7 +319,7 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
         return result;
     }
 
-    private String prettyPrintOutput(JsonObject output) {
+    String prettyPrintOutput(JsonObject output) {
         StringBuilder sb = new StringBuilder();
         for(JsonElement messageElem : array(output, "output")){
             JsonObject message = messageElem.getAsJsonObject();
@@ -328,7 +331,7 @@ abstract class AbstractStreamingAnalyticsService implements StreamingAnalyticsSe
     private static final String HEXES = "0123456789ABCDEF";
     private static final int HEXES_L = HEXES.length();
 
-    private static String randomHex(final int length) {
+    static String randomHex(final int length) {
         char[] name = new char[length];
         for (int i = 0; i < length; i++) {
             name[i] = HEXES.charAt(ThreadLocalRandom.current().nextInt(HEXES_L));

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsService.java
@@ -11,6 +11,7 @@ import static com.ibm.streamsx.topology.context.AnalyticsServiceProperties.VCAP_
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -162,6 +163,29 @@ public interface StreamingAnalyticsService {
      */
     Result<Job,JsonObject> buildAndSubmitJob(File archive, JsonObject jco, String buildName, JsonObject buildConfig) throws IOException;
 
+    /**
+     * Submit an archive to build against Streaming Analytics service.
+     * <P>
+     * The returned {@link Result} instance has:
+     * <UL>
+     * <LI>{@link Result#getId()} returning the build identifier.</LI>
+     * <LI>{@link Result#getElement()} returning a list of the created sab files.</LI>
+     * <LI>{@link Result#getRawResult()} return the JSON build information.</LI>
+     * </UL>
+     * </P>
+     * <P>
+     * Only supported for Streaming Analytics with v2 REST api.
+     * </P>
+     * @param archive The application archive to build.
+     * @param buildName A name for the build, or null.
+     * @param buildConfig Build configuration, or null.
+     * @return Result of the build.
+     * @throws IOException Error communicating with the service.
+     * 
+     * @since 1.14
+     */
+    Result<List<File>,JsonObject> build(File archive, String buildName, JsonObject buildConfig) throws IOException;
+    
     /**
      * Submit an archive to build and run on the Streaming Analytics service.
      * 

--- a/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
+++ b/java/src/com/ibm/streamsx/rest/StreamingAnalyticsServiceV1.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpGet;
@@ -184,7 +186,13 @@ class StreamingAnalyticsServiceV1 extends AbstractStreamingAnalyticsService {
     }
     
     @Override
-    protected boolean downloadArtifacts(CloseableHttpClient httpclient, JsonArray artifacts) {
-        return false;
+    protected List<File> downloadArtifacts(CloseableHttpClient httpclient, JsonArray artifacts) {
+        return null;
+    }
+    
+    @Override
+    public Result<List<File>, JsonObject> build(File archive,
+            String buildName, JsonObject buildConfig) throws IOException {
+        throw new UnsupportedOperationException("com.ibm.streamsx.rest.StreamingAnalyticsService.build() V1");
     }
 }

--- a/java/src/com/ibm/streamsx/topology/context/remote/RemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/context/remote/RemoteContext.java
@@ -30,6 +30,7 @@ public interface RemoteContext<T> {
         STREAMING_ANALYTICS_SERVICE,
         BUNDLE,
         DISTRIBUTED,
+        SAS_BUNDLE, // Internal value only for v4 Sas service.
     }
     
     

--- a/java/src/com/ibm/streamsx/topology/context/remote/RemoteContextFactory.java
+++ b/java/src/com/ibm/streamsx/topology/context/remote/RemoteContextFactory.java
@@ -3,6 +3,7 @@ package com.ibm.streamsx.topology.context.remote;
 import com.ibm.streamsx.topology.internal.context.streamsrest.BuildServiceContext;
 import com.ibm.streamsx.topology.internal.context.streamsrest.DistributedStreamsRestContext;
 import com.ibm.streamsx.topology.internal.context.remote.RemoteBuildAndSubmitRemoteContext;
+import com.ibm.streamsx.topology.internal.context.remote.Sas4BuildContext;
 import com.ibm.streamsx.topology.internal.context.remote.ToolkitRemoteContext;
 import com.ibm.streamsx.topology.internal.context.remote.ZippedToolkitRemoteContext;
 import com.ibm.streamsx.topology.internal.messages.Messages;
@@ -26,6 +27,8 @@ public class RemoteContextFactory {
             return new BuildServiceContext();
         case DISTRIBUTED:
             return new DistributedStreamsRestContext();
+        case SAS_BUNDLE:
+            return new Sas4BuildContext();
         default:
             throw new IllegalArgumentException(Messages.getString("CONTEXT_UNKNOWN_TYPE", type));
         }

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteBuildAndSubmitRemoteContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/RemoteBuildAndSubmitRemoteContext.java
@@ -29,7 +29,7 @@ import com.ibm.streamsx.topology.internal.streaminganalytics.VcapServices;
  */
 public class RemoteBuildAndSubmitRemoteContext extends BuildRemoteContext<StreamingAnalyticsService> {
     
-    private static final ThreadLocal<Map<String,Long>> SERVICE_ACCESS = new ThreadLocal<Map<String,Long>>() {
+    static final ThreadLocal<Map<String,Long>> SERVICE_ACCESS = new ThreadLocal<Map<String,Long>>() {
         protected java.util.Map<String,Long> initialValue() {
             return new HashMap<>();
         }

--- a/java/src/com/ibm/streamsx/topology/internal/context/remote/Sas4BuildContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/remote/Sas4BuildContext.java
@@ -1,0 +1,66 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2016, 2019
+ */
+package com.ibm.streamsx.topology.internal.context.remote;
+
+import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.SERVICE_NO_CHECK_PERIOD;
+import static com.ibm.streamsx.topology.internal.context.remote.DeployKeys.SERVICE_RUNNING_TIME;
+import static com.ibm.streamsx.topology.internal.context.remote.RemoteBuildAndSubmitRemoteContext.SERVICE_ACCESS;
+
+import java.io.File;
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.ibm.streamsx.rest.Result;
+import com.ibm.streamsx.rest.StreamingAnalyticsService;
+
+/**
+ * Build and job submitter using a build archive and the build service
+ * for the Streaming Analytics service on public cloud.
+ */
+public class Sas4BuildContext extends BuildRemoteContext<StreamingAnalyticsService> {
+    
+	@Override
+    public Type getType() {
+        return Type.SAS_BUNDLE;
+    }
+	
+    @Override
+    protected StreamingAnalyticsService createSubmissionContext(JsonObject deploy)
+            throws Exception {
+        return RemoteBuildAndSubmitRemoteContext.streamingAnalyticServiceFromDeploy(deploy);
+    }
+	
+    @Override
+    protected JsonObject submitBuildArchive(StreamingAnalyticsService sas,
+            File buildArchive, JsonObject deploy, JsonObject jco,
+            String buildName, JsonObject buildConfig) throws Exception {
+
+        // See if we can avoid a service check from
+        // a time in the JSON deploy section or the last
+        // time this thread saw the service was running.
+        boolean checkIfRunning = true;
+        if (deploy.has(SERVICE_RUNNING_TIME)) {
+            long last = deploy.get(SERVICE_RUNNING_TIME).getAsLong();
+            checkIfRunning = (System.currentTimeMillis()
+                    - last) > SERVICE_NO_CHECK_PERIOD;
+        } else if (SERVICE_ACCESS.get().containsKey(sas.getName())) {
+            long last = SERVICE_ACCESS.get().get(sas.getName());
+            checkIfRunning = (System.currentTimeMillis()
+                    - last) > SERVICE_NO_CHECK_PERIOD;
+        }
+
+        if (checkIfRunning) {
+            report("Checking service");
+            RemoteContexts.checkServiceRunning(sas);
+        }
+
+        report("Building application");
+        Result<List<File>, JsonObject> submitResult = sas.build(buildArchive, buildName, buildConfig);
+
+        SERVICE_ACCESS.get().put(sas.getName(), System.currentTimeMillis());
+
+        return submitResult.getRawResult();
+    }
+}

--- a/python/sphinx/source/scripts/runner.rst
+++ b/python/sphinx/source/scripts/runner.rst
@@ -6,7 +6,7 @@ streamsx-runner
 Overview
 ********
 
-Submits a Streams application to the Streaming Analytics service.
+Submits or builds a Streams application to the Streaming Analytics service.
 
 The application to be submitted can be:
 
@@ -14,13 +14,48 @@ The application to be submitted can be:
  * An SPL application (main composite) using the ``--main-composite`` flag.
  * A Streams application bundle (``sab`` file) using the ``--bundle`` flag.
 
+***************************
+Streaming Analytics service
+***************************
+
+The Streaming Analytics service is defined by:
+
+ * Service name - ``--service-name`` defaulting to environment variable ``STREAMING_ANALYTICS_SERVICE_NAME``. The service name must exist in the vcap services.
+ * Vcap services - Environment variable ``VCAP_SERVICES`` containing JSON representation of the service definitions or a file name containing the service definitions.
+
+**************
+Job submission
+**************
+
+Job submission occurs unless ``--create-bundle`` is set.
+
+***************
+Bundle creation
+***************
+
+When ``-create-bundle`` is specified with ``-main-composite`` or ``--topology``
+then a Streams application bundle (sab file) is created.
+
+If environment variable `STREAMS_INSTALL` is set the the build is local
+otherwise the build occurs in the IBM Cloud using the Streaming Analytics
+service.
+
+When ``STREAMS_INSTALL`` is not set then `streamsx-runner` can be executed
+with no local Streams install.
+
+When compiling an SPL application (``--main-composite``) then the
+path to the application toolkit containing the main composite must
+be listed with ``--toolkits``. 
+
+Any other required local toolkits must be listed with with ``--toolkits``.
+
 *****
 Usage
 *****
 
 .. code-block:: none
 
-    streamsx-runner [-h] (--service-name SERVICE_NAME | --create-bundle)
+    streamsx-runner [-h] [--service-name SERVICE_NAME] | [--create-bundle]
                  (--topology TOPOLOGY | --main-composite MAIN_COMPOSITE | --bundle BUNDLE)
                  [--toolkits TOOLKITS [TOOLKITS ...]] [--job-name JOB_NAME]
                  [--preload] [--trace {error,warn,info,debug,trace}]
@@ -33,8 +68,7 @@ Usage
       -h, --help            show this help message and exit
       --service-name SERVICE_NAME
                             Submit to Streaming Analytics service
-      --create-bundle       Create a bundle using a local IBM Streams install. No
-                            job submission occurs.
+      --create-bundle       Create a bundle (sab file). No job submission occurs.
       --topology TOPOLOGY   Topology to call
       --main-composite MAIN_COMPOSITE
                             SPL main composite (namespace::composite_name)
@@ -45,8 +79,8 @@ Usage
       Application build options
     
       --toolkits TOOLKITS [TOOLKITS ...]
-                            SPL toolkit containing the main composite and any
-                            other required SPL toolkits.
+                            SPL toolkit path containing the main composite and any
+                            other required SPL toolkit paths.
     
     Job options:
       Job configuration options


### PR DESCRIPTION
Supports BUNDLE using a vcap services definition.

Adds `--create-bundle` support to `streamsx-runner` when not using a local Streams install.