### PR TITLE
Add support for standalone configurations with build service

### DIFF
--- a/java/src/com/ibm/streamsx/rest/Instance.java
+++ b/java/src/com/ibm/streamsx/rest/Instance.java
@@ -238,9 +238,15 @@ public class Instance extends Element {
 
     private static StreamsConnection createStandaloneConnection(String endpoint,
             String userName, String password, boolean verify) throws IOException {
+        if (!endpoint.endsWith(STREAMS_REST_RESOURCES)) {
+            URL url = new URL(endpoint);
+            URL resourcesUrl = new URL(url.getProtocol(), url.getHost(),
+                    url.getPort(), STREAMS_REST_RESOURCES);
+            endpoint = resourcesUrl.toExternalForm();
+        }
         StandaloneAuthenticator auth = StandaloneAuthenticator.of(endpoint, userName, password);
         if (auth.config(verify) != null) {
-            return StreamsConnection.ofAuthenticator(auth.getResourcesUrl(), auth);
+            return StreamsConnection.ofAuthenticator(endpoint, auth);
         } else {
             // Couldn't configure standalone authenticator, try Basic
             return StreamsConnection.createInstance(userName, password, endpoint);

--- a/java/src/com/ibm/streamsx/rest/internal/StandaloneAuthenticator.java
+++ b/java/src/com/ibm/streamsx/rest/internal/StandaloneAuthenticator.java
@@ -4,12 +4,14 @@
  */
 package com.ibm.streamsx.rest.internal;
 
+import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jobject;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.http.client.fluent.Executor;
@@ -33,12 +35,29 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
 
     private JsonObject cfg;
 
+    // Resources URL path
     private static final String STREAMS_REST_RESOURCES = "/streams/rest/resources";
+    // Resources response array
     private static final String RESOURCES = "resources";
+    // Resource name for security service URL
     private static final String ACCESS_TOKENS = "accessTokens";
+    // Resrouce name for instances URL
+    private static final String INSTANCES_RESOURCE = "instances";
+    // Instances response array
+    private static final String INSTANCES_ARRAY = "instances";
+    // Instance URL element
+    private static final String SELF = "self";
+    // Request / response info for security tokens
     private static final String AUDIENCE_STREAMS = "{\"audience\":[\"streams\"]}";
     private static final String EXPIRE_TIME = "expireTime";
     private static final String ACCESS_TOKEN = "accessToken";
+    // Service definition elements
+    private static final String SERVICE_TOKEN_EXPIRE = "service_token_expire";
+    private static final String CONNECTION_INFO = "connection_info";
+    // Connection info elements
+    private static final String SERVICE_TOKEN = "service_token";
+    private static final String SERVICE_REST_ENDPOINT = "serviceRestEndpoint";
+
     private static long MS = 1000;
 
     public static StandaloneAuthenticator of(String endpoint, String userName, String password) {
@@ -49,16 +68,8 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
             }
         }
 
-        // Fix up endpoint if necessary to get resources URL
-        if (!endpoint.endsWith(STREAMS_REST_RESOURCES)) {
-            try {
-                URL url = new URL(endpoint);
-                URL restUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), STREAMS_REST_RESOURCES);
-                endpoint = restUrl.toExternalForm();
-            } catch (MalformedURLException ignored) {
-                // Leave as-is
-            }
-        }
+        // Fix endpoint if necessary
+        endpoint = getResourcesUrl(endpoint);
 
         // Fill in user / password defaults if required
         if (userName == null || password == null) {
@@ -70,6 +81,22 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
         return new StandaloneAuthenticator(endpoint, userName, password);
     }
 
+    public static StandaloneAuthenticator of(JsonObject service) {
+        String endpoint = jstring(jobject(service, CONNECTION_INFO), SERVICE_REST_ENDPOINT);
+        Objects.requireNonNull(endpoint);
+
+        StandaloneAuthenticator authenticator = new StandaloneAuthenticator(endpoint, null, null);
+
+        String serviceToken = jstring(service, SERVICE_TOKEN);
+        if (serviceToken != null) {
+            authenticator.auth = RestUtils.createBearerAuth(serviceToken);
+            authenticator.expire = service.get(SERVICE_TOKEN_EXPIRE).getAsLong();
+        }
+        authenticator.cfg = service;
+
+        return authenticator;
+    }
+
     @Override
     public String apply(Executor executor) {
         if (auth == null || System.currentTimeMillis() > expire) {
@@ -79,7 +106,6 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
                 // Leave as-is and let use fail with auth error
             }
         }
-
         return auth;
     }
 
@@ -97,7 +123,7 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
         this.cfg = null;
     }
 
-    private void refreshAuth(Executor executor) throws IOException {
+    private String refreshAuth(Executor executor) throws IOException {
         Request post = Request.Post(securityUrl)
                 .addHeader("Authorization", RestUtils.createBasicAuth(userName, password))
                 .addHeader("Accept", ContentType.APPLICATION_JSON.getMimeType())
@@ -115,6 +141,8 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
             // Short expiry (same as python)
             expire = System.currentTimeMillis() + 4 * 60 * MS;
         }
+
+        return token;
     }
 
     public JsonObject config(boolean verify) throws IOException {
@@ -130,12 +158,12 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
             return cfg;
         }
 
-        // Try to discover security service and build URLs
+        // Try to discover security service and instance URLs
+        String streamsEndpoint = null;
         try {
-            Request get = Request.Get(resourcesUrl)
-                    .addHeader("Authorization", RestUtils.createBasicAuth(userName, password))
-                    .addHeader("Accept", ContentType.APPLICATION_JSON.getMimeType());
-            JsonObject resp = RestUtils.requestGsonResponse(executor, get);
+            String instancesUrl = null;
+            String basicAuth = RestUtils.createBasicAuth(userName, password);
+            JsonObject resp = RestUtils.getGsonResponse(executor, basicAuth, resourcesUrl);
             if (resp == null || !resp.has(RESOURCES)) {
                 // Not a standalone instance
                 return null;
@@ -146,36 +174,60 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
             for (Resource resource : resources.resources) {
                 if (ACCESS_TOKENS.equals(resource.name)) {
                     securityUrl = resource.resource;
-                    break;
+                } else if (INSTANCES_RESOURCE.equals(resource.name)) {
+                    instancesUrl = resource.resource;
+                }
+            }
+
+            if (instancesUrl != null) {
+                resp = RestUtils.getGsonResponse(executor, basicAuth, instancesUrl);
+                JsonArray instances = resp.getAsJsonArray(INSTANCES_ARRAY);
+                if (instances != null && instances.size() == 1) {
+                    streamsEndpoint = jstring(instances.get(0).getAsJsonObject(), SELF);
                 }
             }
         } catch (IOException ignored) {}
 
-        if (securityUrl == null) {
+        if (securityUrl == null || streamsEndpoint == null) {
             // Unable to configure, return null to indicate may not be a
             // standalone instance
             return null;
         }
 
-        refreshAuth(executor);
+        String token = refreshAuth(executor);
 
         JsonObject config = new JsonObject();
 
         config.addProperty("type", "streams");
         config.addProperty("externalClient", true);
-        config.addProperty("service_token", auth);
-        config.addProperty("service_token_expire", expire);
+        config.addProperty(SERVICE_TOKEN, token);
+        config.addProperty(SERVICE_TOKEN_EXPIRE, expire);
 
         URL securityUrl = new URL(resourcesUrl);
         config.addProperty("cluster_ip", securityUrl.getHost());
         config.addProperty("cluster_port", securityUrl.getPort());
 
-        JsonObject connInfo = new JsonObject();       
-        connInfo.addProperty("serviceRestEndpoint", resourcesUrl);
-        config.add("connection_info", connInfo);
+        // Get service rest endpoint from instancesUrl
+        
+        JsonObject connInfo = new JsonObject();
+        connInfo.addProperty(SERVICE_REST_ENDPOINT, streamsEndpoint);
+        config.add(CONNECTION_INFO, connInfo);
 
         cfg = config;
         return config;
+    }
+
+    private static String getResourcesUrl(String endpoint) {
+        if (!endpoint.endsWith(STREAMS_REST_RESOURCES)) {
+            try {
+                URL url = new URL(endpoint);
+                URL restUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), STREAMS_REST_RESOURCES);
+                endpoint = restUrl.toExternalForm();
+            } catch (MalformedURLException ignored) {
+                // Leave as-is
+            }
+        }
+        return endpoint;
     }
 
     private static class Resource {

--- a/java/src/com/ibm/streamsx/topology/context/ContextProperties.java
+++ b/java/src/com/ibm/streamsx/topology/context/ContextProperties.java
@@ -148,7 +148,18 @@ public interface ContextProperties {
      * @since 1.13
      */
     String STREAMS_INSTANCE = "topology.streamsInstance";
-    
+
+    /**
+     * Set URL for remote build service.
+     * 
+     * For Cloud Pak for Data standalone configurations the build service used
+     * for remote builds is given by this URL. This is ignored by other contexts
+     * or configurations.
+     * 
+     * @since 1.13
+     */
+    String BUILD_SERVICE_URL = "topology.buildServiceUrl";
+
     /**
      * Set SSL certification verification state.
      * 

--- a/java/src/com/ibm/streamsx/topology/internal/context/streams/DistributedStreamsContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streams/DistributedStreamsContext.java
@@ -87,10 +87,16 @@ public class DistributedStreamsContext extends
             InvokeSubmit.checkPreconditions();
             useRestApi.set(false);
     	} catch (IllegalStateException e) {
-    		// See if the REST api is setup.
-    	    Util.getenv(Util.ICP4D_DEPLOYMENT_URL);
-    		Util.getenv(Util.STREAMS_INSTANCE_ID);
-    		Util.getenv(Util.STREAMS_PASSWORD);
+    	    // See if the REST api is setup.
+    	    if (System.getenv(Util.ICP4D_DEPLOYMENT_URL) != null) {
+    	        // Integrated configuration
+    	        Util.getenv(Util.STREAMS_INSTANCE_ID);
+    	    } else {
+    	        // Standalone configuration
+                Util.getenv(Util.STREAMS_REST_URL);
+                Util.getenv(Util.STREAMS_BUILD_URL);
+    	    }
+            Util.getenv(Util.STREAMS_PASSWORD);
     		useRestApi.set(true);
     	}
     }

--- a/java/src/com/ibm/streamsx/topology/internal/streams/Util.java
+++ b/java/src/com/ibm/streamsx/topology/internal/streams/Util.java
@@ -24,6 +24,7 @@ public class Util {
     private static final String STREAMS_INSTALL = "STREAMS_INSTALL";
     public static final String STREAMS_USERNAME = "STREAMS_USERNAME";
     public static final String STREAMS_PASSWORD = "STREAMS_PASSWORD";
+    public static final String STREAMS_BUILD_URL = "STREAMS_BUILD_URL";
     public static final String STREAMS_REST_URL = "STREAMS_REST_URL";
     public static final String ICP4D_DEPLOYMENT_URL = "CP4D_URL";
     private static String streamsInstall;


### PR DESCRIPTION
Still testing and cleaning up.

Allow standalone users to specify a build service URL at submit with `ContextProperties.BUILD_SERVICE_URL`.

Update `StandaloneAuthenticator` to correctly set up connection info and add ability to create from service definition for build service.

Update uses in context and build service code to use `StandaloneAuthenticator`
instead of `ICP4DAuthenticator` as appropriate.