### PR TITLE
Revert to basic auth if external to cluster

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/build.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/build.py
@@ -30,6 +30,7 @@ import json
 import logging
 import re
 import requests
+import socket
 import tempfile
 from pprint import pformat
 from urllib import parse
@@ -255,11 +256,19 @@ class BuildService(_AbstractStreamsConnection):
                 sc.rest_client.session.verify = verify
             for resource in sc.get_resources():
                 if resource.name == 'accessTokens':
-                    auth=_JWTAuthHandler(resource.resource, username, password, verify)
-                    sc = BuildService(resource_url=build_url, auth=auth)
-                    if verify is not None:
-                        sc.rest_client.session.verify = verify
-                    break
+                    atinfo = parse.urlparse(resource.resource)
+                    try:
+                        # If we are external to the cluster then
+                        # We can't resolve the security manager
+                        # so revert to basic auth
+                        socket.gethostbyname(atinfo.hostname)
+                        auth=_JWTAuthHandler(resource.resource, username, password, verify)
+                        sc = BuildService(resource_url=build_url, auth=auth)
+                        if verify is not None:
+                            sc.rest_client.session.verify = verify
+                        break
+                    except:
+                        pass
             else:
                 # No security service could be found.  We can try to proceed 
                 # with basic authentication.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -1750,11 +1750,20 @@ class Instance(_ResourceElement):
                 sc.rest_client.session.verify = verify
             for resource in sc.get_resources():
                 if resource.name == 'accessTokens':
-                    auth=_JWTAuthHandler(resource.resource, username, password, verify)
-                    sc = streamsx.rest.StreamsConnection(resource_url=resource_url, auth=auth)
-                    if verify is not None:
-                        sc.rest_client.session.verify = verify
-                    break
+                    atinfo = parse.urlparse(resource.resource)
+                    try:
+                        # If we are external to the cluster then
+                        # We can't resolve the security manager
+                        # so revert to basic auth
+                        socket.gethostbyname(atinfo.hostname)
+                        auth=_JWTAuthHandler(resource.resource, username, password, verify)
+                        sc = streamsx.rest.StreamsConnection(resource_url=resource_url, auth=auth)
+                        if verify is not None:
+                            sc.rest_client.session.verify = verify
+                        break
+                    except:
+                        pass
+                  
 
             # There should be exactly one instance in this configuration.
             return sc.get_instances()[0]


### PR DESCRIPTION
The `accessTokens` URL returned in the REST apis is only visible inside the k8s cluster.

So if cannot resolve the URL's hostname then revert to basic authentication.