### PR TITLE
Support standalone build service for remote

### DIFF
--- a/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/BuildServiceContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/BuildServiceContext.java
@@ -43,7 +43,11 @@ public class BuildServiceContext extends BuildRemoteContext<BuildService> {
     @Override
     protected BuildService createSubmissionContext(JsonObject deploy) throws Exception {
         JsonObject serviceDefinition = object(deploy, StreamsKeys.SERVICE_DEFINITION);
-        return BuildService.ofServiceDefinition(serviceDefinition, sslVerify(deploy));
+        if (serviceDefinition != null)
+            return BuildService.ofServiceDefinition(serviceDefinition, sslVerify(deploy));
+        
+        // Remote environment context set through environment variables.
+        return BuildService.ofEndpoint(null, null, null, null, sslVerify(deploy));
     }
 
     @Override


### PR DESCRIPTION
For submission from Python if service definition is not set then it must be standalone and the setup will be from environment variables, passed from Python into Java.

Need similar changes for the distributed submission context but will do those after PR #2263 is done to avoid merge issues (and to be able to test).