### PR TITLE
Fixes for standalone builds.

### DIFF
--- a/java/src/com/ibm/streamsx/rest/build/StreamsBuildService.java
+++ b/java/src/com/ibm/streamsx/rest/build/StreamsBuildService.java
@@ -39,13 +39,13 @@ class StreamsBuildService extends AbstractConnection implements BuildService {
             if (buildServiceEndpoint == null) {
                 buildServiceEndpoint = Util.getenv(Util.STREAMS_BUILD_URL);
             }
-            if (!buildServiceEndpoint.endsWith(STREAMS_REST_BUILDS) &&
-                    authenticator instanceof StandaloneAuthenticator) {
+            if (!buildServiceEndpoint.endsWith(STREAMS_REST_BUILDS)) {
                 // URL was user-provided root of service, add the path
                 URL url = new URL(buildServiceEndpoint);
                 URL buildsUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), STREAMS_REST_BUILDS);
                 buildServiceEndpoint = buildsUrl.toExternalForm();
             }
+            return StreamsBuildService.of(authenticator, buildServiceEndpoint, verify);
         }
         return new StreamsBuildService(buildServiceEndpoint, authenticator, verify);
     }
@@ -54,8 +54,7 @@ class StreamsBuildService extends AbstractConnection implements BuildService {
 
         if (buildServiceEndpoint == null) {
             buildServiceEndpoint = Util.getenv(Util.STREAMS_BUILD_URL);
-            if (!buildServiceEndpoint.endsWith(STREAMS_REST_BUILDS) &&
-                    authenticator instanceof StandaloneAuthenticator) {
+            if (!buildServiceEndpoint.endsWith(STREAMS_REST_BUILDS)) {
                 // URL was user-provided root of service, add the path
                 URL url = new URL(buildServiceEndpoint);
                 URL buildsUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), STREAMS_REST_BUILDS);

--- a/java/src/com/ibm/streamsx/rest/internal/StandaloneAuthenticator.java
+++ b/java/src/com/ibm/streamsx/rest/internal/StandaloneAuthenticator.java
@@ -168,8 +168,8 @@ public class StandaloneAuthenticator implements Function<Executor,String> {
                     securityUrl = resource.resource;
                 } else if (INSTANCES_RESOURCE.equals(resource.name)) {
                     instancesUrl = resource.resource;
-                } else if (BUILDS_RESOURCE.equals(resource.name)) { 
-                    buildsEndpoint = null;
+                } else if (BUILDS_RESOURCE.equals(resource.name)) {
+                    buildsEndpoint = resource.resource;
                 }
             }
 


### PR DESCRIPTION
- Set builds URL correctly in `StandaloneAuthenticator`
- Munge endpoints to get the right / expected ones in `BuildService` and `StreamsBuildService`