### PR TITLE
Don't support /streams/rest/resources

### DIFF
--- a/java/src/com/ibm/streamsx/rest/build/BuildService.java
+++ b/java/src/com/ibm/streamsx/rest/build/BuildService.java
@@ -5,6 +5,8 @@
 
 package com.ibm.streamsx.rest.build;
 
+import static com.ibm.streamsx.rest.build.StreamsBuildService.STREAMS_BUILD_PATH;
+import static com.ibm.streamsx.rest.build.StreamsBuildService.STREAMS_REST_RESOURCES;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
 
 import java.io.IOException;
@@ -29,9 +31,6 @@ import com.ibm.streamsx.topology.internal.streams.Util;
  * @since 1.12
  */
 public interface BuildService {
-	
-    public static final String STREAMS_REST_RESOURCES = "/streams/rest/resources";
-    public static final String STREAMS_BUILD_PATH = "/streams/rest/builds";
 
     public static BuildService ofEndpoint(String endpoint, String name, String userName, String password,
             boolean verify) throws IOException {
@@ -40,13 +39,11 @@ public interface BuildService {
             if (endpoint == null) {
                 endpoint = Util.getenv(Util.STREAMS_BUILD_URL);
             }
-	        String resourcesEndpoint = endpoint;
-            if (!resourcesEndpoint.endsWith(STREAMS_REST_RESOURCES)) {
-                URL url = new URL(endpoint);
-                URL resourcesUrl = new URL(url.getProtocol(), url.getHost(),
+            URL url = new URL(endpoint);
+            URL resourcesUrl = new URL(url.getProtocol(), url.getHost(),
                         url.getPort(), STREAMS_REST_RESOURCES);
-                resourcesEndpoint = resourcesUrl.toExternalForm();
-            }
+            String resourcesEndpoint = resourcesUrl.toExternalForm();
+
 	        StandaloneAuthenticator auth = StandaloneAuthenticator.of(resourcesEndpoint, userName, password);
 	        JsonObject serviceDefinition = auth.config(verify);
 	        if (serviceDefinition == null) {
@@ -60,10 +57,9 @@ public interface BuildService {
 	            String basicAuth = RestUtils.createBasicAuth(userName, password);
 	            String buildsEndpoint = endpoint;
 	            if (!buildsEndpoint.endsWith(STREAMS_BUILD_PATH)) {
-	                URL url = new URL(endpoint);
-	                URL resourcesUrl = new URL(url.getProtocol(), url.getHost(),
+	                URL buildUrl = new URL(url.getProtocol(), url.getHost(),
 	                        url.getPort(), STREAMS_BUILD_PATH);
-	                buildsEndpoint = resourcesUrl.toExternalForm();
+	                buildsEndpoint = buildUrl.toExternalForm();
 	            }
 	            return StreamsBuildService.of(e -> basicAuth, buildsEndpoint, verify);
 	        }

--- a/java/src/com/ibm/streamsx/rest/build/StreamsBuildService.java
+++ b/java/src/com/ibm/streamsx/rest/build/StreamsBuildService.java
@@ -3,9 +3,8 @@ package com.ibm.streamsx.rest.build;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.jstring;
 import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.object;
 
-import java.io.IOException;
 import java.io.File;
-import java.net.MalformedURLException;
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -20,29 +19,28 @@ import org.apache.http.entity.ContentType;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
-
 import com.ibm.streamsx.rest.RESTException;
 import com.ibm.streamsx.rest.internal.RestUtils;
-
-import com.ibm.streamsx.rest.internal.ICP4DAuthenticator;
 import com.ibm.streamsx.rest.internal.StandaloneAuthenticator;
 import com.ibm.streamsx.topology.internal.streams.Util;
 
 class StreamsBuildService extends AbstractConnection implements BuildService {
     
-    private static final String STREAMS_REST_BUILDS = "/streams/rest/builds";
+    static final String STREAMS_REST_RESOURCES = "/streams/rest/resources";
+    static final String STREAMS_BUILD_PATH = "/streams/rest/builds";
 
-    public static BuildService of(Function<Executor,String> authenticator, JsonObject serviceDefinition, boolean verify) throws IOException {
+
+    static BuildService of(Function<Executor,String> authenticator, JsonObject serviceDefinition, boolean verify) throws IOException {
         
         String buildServiceEndpoint = jstring(object(serviceDefinition, "connection_info"), "serviceBuildEndpoint");
         if (authenticator instanceof StandaloneAuthenticator) {
             if (buildServiceEndpoint == null) {
                 buildServiceEndpoint = Util.getenv(Util.STREAMS_BUILD_URL);
             }
-            if (!buildServiceEndpoint.endsWith(STREAMS_REST_BUILDS)) {
+            if (!buildServiceEndpoint.endsWith(STREAMS_BUILD_PATH)) {
                 // URL was user-provided root of service, add the path
                 URL url = new URL(buildServiceEndpoint);
-                URL buildsUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), STREAMS_REST_BUILDS);
+                URL buildsUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), STREAMS_BUILD_PATH);
                 buildServiceEndpoint = buildsUrl.toExternalForm();
             }
             return StreamsBuildService.of(authenticator, buildServiceEndpoint, verify);
@@ -50,14 +48,14 @@ class StreamsBuildService extends AbstractConnection implements BuildService {
         return new StreamsBuildService(buildServiceEndpoint, authenticator, verify);
     }
 
-    public static BuildService of(Function<Executor,String> authenticator, String buildServiceEndpoint, boolean verify) throws IOException {
+    static BuildService of(Function<Executor,String> authenticator, String buildServiceEndpoint, boolean verify) throws IOException {
 
         if (buildServiceEndpoint == null) {
             buildServiceEndpoint = Util.getenv(Util.STREAMS_BUILD_URL);
-            if (!buildServiceEndpoint.endsWith(STREAMS_REST_BUILDS)) {
+            if (!buildServiceEndpoint.endsWith(STREAMS_BUILD_PATH)) {
                 // URL was user-provided root of service, add the path
                 URL url = new URL(buildServiceEndpoint);
-                URL buildsUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), STREAMS_REST_BUILDS);
+                URL buildsUrl = new URL(url.getProtocol(), url.getHost(), url.getPort(), STREAMS_BUILD_PATH);
                 buildServiceEndpoint = buildsUrl.toExternalForm();
             }
         }


### PR DESCRIPTION
Don't support `BuildService.of_endpoint` being passed in a URL ending in `/streams/rest/resources` as that is not an expected value. Expected is the service URL (just host/port) or possible one ending with (`streams/rest/builds`).

Move the constants into the implementation class to avoid them being part of the public api.