### PR TITLE
Use provided capabilities to get specific toolkits

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/build.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/build.py
@@ -98,14 +98,17 @@ class BuildService(_AbstractStreamsConnection):
         """
         return super().get_resources()
 
-    def get_toolkits(self):
+    def get_toolkits(self, name=None):
         """Retrieves a list of all installed Streams Toolkits.
 
         Returns:
             :py:obj:`list` of :py:class:`~.rest_primitives.Toolkit`: List of all Toolkit resources.
 
+        Args:
+           name(str): Return toolkits matching name as a regular expression.
+
         """
-        return self._get_elements('toolkits', Toolkit)
+        return self._get_elements('toolkits', Toolkit, name=name)
      
     def get_toolkit(self, id):
         """Retrieves available toolkit matching a specific toolkit ID.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest.py
@@ -70,7 +70,7 @@ __version__ = streamsx._streams._version.__version__
 
 from streamsx import st
 from .rest_primitives import (Domain, Instance, Installation, RestResource, Toolkit, _StreamsRestClient, StreamingAnalyticsService, _streams_delegator,
-    _exact_resource, _IAMStreamsRestClient, _IAMConstants, _StreamsRestDelegator)
+    _exact_resource, _IAMStreamsRestClient, _IAMConstants, _StreamsRestDelegator, _matching_resource)
 
 logger = logging.getLogger('streamsx.rest')
 
@@ -90,12 +90,14 @@ class _AbstractStreamsConnection(object):
         json_resources = self.rest_client.make_request(self.resource_url)['resources']
         return [RestResource(resource, self.rest_client) for resource in json_resources]
 
-    def _get_elements(self, resource_name, eclass, id=None):
+    def _get_elements(self, resource_name, eclass, id=None, name=None):
         for resource in self.get_resources():
             if resource.name == resource_name:
                 elements = []
                 for json_element in resource.get_resource()[resource_name]:
                     if not _exact_resource(json_element, id):
+                        continue
+                    if not _matching_resource(json_element, name):
                         continue
                     elements.append(eclass(json_element, self.rest_client))
                 return elements


### PR DESCRIPTION
Adds `name` to `BuildService.get_toolkits` just as name is supported in existing rest calls that return a collection.

Use the `BuildService` method to filter the toolkits, where possible, including using `get_toolkit` when requesting to delete by name.