### PR TITLE
Move operator specific logic into operator.

### DIFF
--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -48,10 +48,20 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
          SPL::AutoPortMutex am(mutex_, *this);
 #endif
          try {
+             SplpyGIL lock;
 
 @include "../pyspltuple2value.cgt"
 
-             passed = streamsx::topology::Splpy::pyTupleFilter(funcop_->callable(), value);
+             PyObject *ret = pySplProcessTuple(function, splVal);
+
+             if (ret == 0) {
+                 throw SplpyExceptionInfo::pythonError("filter");
+             }
+
+             passed = PyObject_IsTrue(pyReturnVar);
+
+             Py_DECREF(ret);
+
          } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
              SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
              return;

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -52,13 +52,13 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 
 @include "../pyspltuple2value.cgt"
 
-             PyObject *ret = pySplProcessTuple(function, splVal);
+             PyObject *ret = pySplProcessTuple(function, value);
 
-             if (ret == 0) {
+             if (ret == NULL) {
                  throw SplpyExceptionInfo::pythonError("filter");
              }
 
-             passed = PyObject_IsTrue(pyReturnVar);
+             passed = PyObject_IsTrue(ret);
 
              Py_DECREF(ret);
 

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Filter/Filter_cpp.cgt
@@ -52,7 +52,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 
 @include "../pyspltuple2value.cgt"
 
-             PyObject *ret = pySplProcessTuple(function, value);
+             PyObject *ret = pySplProcessTuple(funcop_->callable(), value);
 
              if (ret == NULL) {
                  throw SplpyExceptionInfo::pythonError("filter");

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/ForEach/ForEach_cpp.cgt
@@ -47,9 +47,18 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 #endif
 
     try {
+      SplpyGIL lock;
+
 @include "../pyspltuple2value.cgt"
 
-        streamsx::topology::Splpy::pyTupleForEach(funcop_->callable(), value);
+      PyObject *ret = pySplProcessTuple(funcop_->callable(), value);
+
+      if (ret == NULL) {
+        throw SplpyExceptionInfo::pythonError("for_each");
+      }
+
+      Py_DECREF(ret);
+
     } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
        SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
     }

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/HashAdder/HashAdder_cpp.cgt
@@ -50,9 +50,17 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 #endif
 
         try {
+          SplpyGIL lock;
 @include "../pyspltuple2value.cgt"
 
-            _hash = streamsx::topology::Splpy::pyTupleHash(funcop_->callable(), value);
+          PyObject *ret = pySplProcessTuple(funcop_->callable(), value);
+
+          if (ret == NULL) {
+              throw SplpyExceptionInfo::pythonError("hash");
+          }
+
+          pySplValueFromPyObject(_hash, ret);
+          Py_DECREF(ret);
 
         } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
             SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Split/Split_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Split/Split_cpp.cgt
@@ -53,7 +53,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 
 @include "../pyspltuple2value.cgt"
 
-           PyObject *ret = pySplProcessTuple(function, value);
+           PyObject *ret = pySplProcessTuple(funcop_->callable(), value);
 
            if (ret == 0) {
                throw SplpyExceptionInfo::pythonError("split");

--- a/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Split/Split_cpp.cgt
+++ b/com.ibm.streamsx.topology/com.ibm.streamsx.topology.functional.python/Split/Split_cpp.cgt
@@ -49,10 +49,20 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
          SPL::AutoPortMutex am(mutex_, *this);
 #endif
          try {
+           SplpyGIL lock;
 
 @include "../pyspltuple2value.cgt"
 
-             split = streamsx::topology::Splpy::pyTupleSplit(funcop_->callable(), value);
+           PyObject *ret = pySplProcessTuple(function, value);
+
+           if (ret == 0) {
+               throw SplpyExceptionInfo::pythonError("split");
+           }
+
+           pySplValueFromPyObject(split, ret);
+
+           Py_DECREF(ret);
+
          } catch (const streamsx::topology::SplpyExceptionInfo& excInfo) {
              SPLPY_OP_HANDLE_EXCEPTION_INFO_GIL(excInfo);
              return;

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -41,25 +41,6 @@ namespace streamsx {
       public:
 
     /*
-     * Call the function passing an SPL attribute
-     * converted to a Python object and discard the return 
-     * Implementation for function ForEach operator.
-     */
-    template <class T>
-    static void pyTupleForEach(PyObject * function, T & splVal) {
-      SplpyGIL lock;
-
-      // invoke python nested function that calls the application function
-      PyObject * pyReturnVar = pySplProcessTuple(function, splVal);
-
-      if(pyReturnVar == 0){
-        throw SplpyExceptionInfo::pythonError("for_each");
-      }
-
-      Py_DECREF(pyReturnVar);
-    }
-    
-    /*
     * Call a function passing the SPL attribute value of type T
     * and return the function return as a boolean
     * Implementation for function Filter operator.

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -106,27 +106,6 @@ namespace streamsx {
     }
 
 
-    // Python hash of an SPL value
-    // Python hashes are signed integer values
-    template <class T>
-    static SPL::int64 pyTupleHash(PyObject * function, T & splVal) {
-
-      SplpyGIL lock;
-
-      PyObject * pyReturnVar = pySplProcessTuple(function, splVal);
-
-      if (pyReturnVar == 0){
-        throw SplpyExceptionInfo::pythonError("hash");
-      }
-
-      // construct integer from return value
-      SPL::int64 hash;
-      pySplValueFromPyObject(hash, pyReturnVar);
-      Py_DECREF(pyReturnVar);
-      return hash;
-   }
-
-
     /**
      *  Return a Python tuple containing the attribute
      *  names for a port in order.

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -40,25 +40,6 @@ namespace streamsx {
 
       public:
 
-    template <class T>
-    static SPL::int64 pyTupleSplit(PyObject * function, T & splVal) {
-
-      SplpyGIL lock;
-
-      // invoke python nested function that calls the application function
-      PyObject * pyReturnVar = pySplProcessTuple(function, splVal);
-
-      if(pyReturnVar == 0){
-         throw SplpyExceptionInfo::pythonError("split");
-      }
-
-      SPL::int64 split;
-      pySplValueFromPyObject(split, pyReturnVar);
-
-      Py_DECREF(pyReturnVar);
-      return split;
-    }
-
     /*
     * Call a function passing the SPL attribute value of type T
     * and fill in the SPL attribute of type R with its result.

--- a/com.ibm.streamsx.topology/opt/python/include/splpy.h
+++ b/com.ibm.streamsx.topology/opt/python/include/splpy.h
@@ -40,29 +40,6 @@ namespace streamsx {
 
       public:
 
-    /*
-    * Call a function passing the SPL attribute value of type T
-    * and return the function return as a boolean
-    * Implementation for function Filter operator.
-    */
-    template <class T>
-    static int pyTupleFilter(PyObject * function, T & splVal) {
-
-      SplpyGIL lock;
-
-      // invoke python nested function that calls the application function
-      PyObject * pyReturnVar = pySplProcessTuple(function, splVal);
-
-      if(pyReturnVar == 0){
-         throw SplpyExceptionInfo::pythonError("filter");
-      }
-
-      int ret = PyObject_IsTrue(pyReturnVar);
-
-      Py_DECREF(pyReturnVar);
-      return ret;
-    }
-
     template <class T>
     static SPL::int64 pyTupleSplit(PyObject * function, T & splVal) {
 


### PR DESCRIPTION
Moves the operator specific tuple processing into each operator and thus avoids an extra level of C++ templating.