### PR TITLE
Obtain version in release file name from info.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -254,11 +254,11 @@
        <ant dir="python" target="pythondoc"/>
   </target>
   
-  <target name="create_release_bundle">
+  <target name="create_release_bundle" depends="get_name">
       <tstamp/>
       <property name="release.dir" location="${release.base}" />
       <mkdir dir="${release.dir}" />
-      <property name="releasefilename" value="${release.dir}/streamsx.topology-v1.15-${DSTAMP}-${TSTAMP}.tgz"/>
+      <property name="releasefilename" value="${release.dir}/streamsx.topology-${tkinfo.identity.version}-${DSTAMP}-${TSTAMP}.tgz"/>
       <tar compression="gzip" longfile="gnu" destfile="${releasefilename}">
          <tarfileset dir="${basedir}" filemode="755" >
            <include name="**/pyversion*.sh"/>
@@ -276,6 +276,9 @@
       <checksum algorithm="sha1" file="${releasefilename}"/>
   </target>
 
-
-
+  <target name="get_name">
+    <xmlproperty file="${tk}/info.xml" prefix="tkinfo" keepRoot="no"/>
+    <echo message="Toolkit Name: ${tkinfo.identity.name}"/>
+    <echo message="Toolkit Version: ${tkinfo.identity.version}"/>
+  </target>
 </project>


### PR DESCRIPTION
With this change the release file version is obtained from info.xml (but the full version including alpha 1.15.0.alpha)
There is no longer a need to change the build.xml all the way.
If you like this, you can pull it.
We could also include the short git has into the release file name? 