### PR TITLE
Java: unnecessary imports removed

### DIFF
--- a/java/src/com/ibm/streamsx/rest/build/StreamsBuildService.java
+++ b/java/src/com/ibm/streamsx/rest/build/StreamsBuildService.java
@@ -17,10 +17,7 @@ import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 
-import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
 import com.ibm.streamsx.rest.RESTException;

--- a/java/src/com/ibm/streamsx/rest/build/Toolkit.java
+++ b/java/src/com/ibm/streamsx/rest/build/Toolkit.java
@@ -1,20 +1,16 @@
 package com.ibm.streamsx.rest.build;
 
-import static java.util.Objects.requireNonNull;
-
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.io.IOException;
-import java.io.File;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -176,7 +172,7 @@ public class Toolkit extends Element {
    * @throws Exception
    */
   public List<Dependency> getDependencies() throws Exception {
-    List<Dependency> dependencies = new ArrayList();
+    List<Dependency> dependencies = new ArrayList<>();
 
     String index = getIndex();
 

--- a/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/DistributedStreamsRestContext.java
+++ b/java/src/com/ibm/streamsx/topology/internal/context/streamsrest/DistributedStreamsRestContext.java
@@ -11,8 +11,6 @@ import static com.ibm.streamsx.topology.internal.gson.GsonUtilities.object;
 
 import java.io.File;
 import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Map.Entry;
 import java.util.function.Function;
 


### PR DESCRIPTION
Unnecessary imports create useless warnings in the Java IDE.