### PR TITLE
query of base images added to BuildService

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/build.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/build.py
@@ -183,7 +183,7 @@ class BuildService(_AbstractStreamsConnection):
         """Returns the build pools via the new resource type 'buildPools' from Edge enabled build services.
 
         Returns:
-            :py:obj:`list` of :py:class:`~.rest_primitives._BuildPool`: A list of _BuildPool instances or ``None`` if no Build pools are not available.
+            :py:obj:`list` of :py:class:`~.rest_primitives._BuildPool`: A list of _BuildPool instances or ``None`` if build pools are not available.
         """
         buildpools = self._get_elements('buildPools', _BuildPool, name=name)
         if buildpools is None:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/build.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/build.py
@@ -45,7 +45,7 @@ from streamsx import st
 from .rest import _AbstractStreamsConnection
 from .rest_primitives import (Domain, Instance, Installation, RestResource, Toolkit, _StreamsRestClient, StreamingAnalyticsService, _streams_delegator,
     _exact_resource, _IAMStreamsRestClient, _IAMConstants, _get_username,
-    _ICPDExternalAuthHandler, _handle_http_errors, _JWTAuthHandler)
+    _ICPDExternalAuthHandler, _handle_http_errors, _JWTAuthHandler, _BuildPool, BaseImage)
 
 logger = logging.getLogger('streamsx.build')
 
@@ -179,6 +179,45 @@ class BuildService(_AbstractStreamsConnection):
                         return new_toolkits[0]    
                     return None
 
+    def _get_buildPools(self, name=None):
+        """Returns the build pools via the new resource type 'buildPools' from Edge enabled build services.
+
+        Returns:
+            :py:obj:`list` of :py:class:`~.rest_primitives._BuildPool`: A list of _BuildPool instances or ``None`` if no Build pools are not available.
+        """
+        buildpools = self._get_elements('buildPools', _BuildPool, name=name)
+        if buildpools is None:
+            # workaround as long as 'buildPools' resource is not available
+            #print("'buildPools' resource is not available. Query via connection-info")
+            buildpools_url = self.rest_client.session.auth._cfg['connection_info'].get('serviceBuildPoolsEndpoint')
+            if not buildpools_url:
+                # We do NOT get the deprecated BuildPool REST resource here as
+                # it will not be a build pool of 'image' type
+                return None
+            buildpools_json = self.rest_client.make_request(buildpools_url)['buildPools']
+            buildpools = [_BuildPool(json_rep, self.rest_client) for json_rep in buildpools_json]
+
+        return buildpools
+    
+    def get_base_images(self):
+        """Retrieves a list of all installed base images for Edge applications.
+
+        Returns:
+            :py:obj:`list` of :py:class:`~.rest_primitives.BaseImage`: List of all base images, ``None`` if there are no base images
+
+        """
+        buildpools = self._get_buildPools()
+        if not buildpools:
+            # None or empty list
+            return None
+        images = []
+        for pool in buildpools:
+            if hasattr(pool, 'baseimages'):
+                images.extend([BaseImage(json_rep, self.rest_client) for json_rep in self.rest_client.make_request(pool.baseimages)['images']])
+        if images:
+            return images
+        return None
+    
     @staticmethod
     def of_endpoint(endpoint=None, service_name=None, username=None, password=None, verify=None):
         """

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/rest_primitives.py
@@ -3128,3 +3128,63 @@ class Toolkit(_ResourceElement):
             version = dependency_element.find('{http://www.ibm.com/xmlns/prod/streams/spl/common}version').text
             deps.append(Toolkit.Dependency(name, version))
         return deps
+
+
+class _BuildPool(_ResourceElement):
+    """A build pool.
+    
+    Attributes:
+        baseimages(str): optional URL to query the base images
+        buildInactivityTimeout(int): 15,
+        buildProcessingTimeout": 15,
+        buildProcessingTimeoutMaximum": 15,
+        buildProductVersion": "",
+        buildingCount": 0,
+        name(str): The name of the build pool
+        resourceType(str): Identifies the REST resource type, which is *buildPool*
+        resourceWaitTimeout(int):
+        restid(str): The pool identifier
+        sizeMaximum(int):
+        sizeMinimum(int):
+        status(str): 
+        type(str): The type of the build pool. The type can be *application*, or *image*.
+        waitingCount(int)
+
+    Example:
+        >>> from streamsx.build import BuildService
+        >>> build_service = BuildService.of_endpoint()
+        >>> buildpools = build_service._get_builPools()
+        >>> print (buildpools[0].resourceType)
+        buildPool
+
+        .. versionadded:: 1.15
+    """
+    def __init__(self, json_rep, rest_client):
+        super(_BuildPool, self).__init__(json_rep, rest_client)
+
+class BaseImage(_ResourceElement):
+    """A base image used for an Edge image build using the EDGE context type.
+    
+    Attributes:
+        buildPool(str): REST URL of the build pool that contains the image
+        id(str): identifier in the form of registry/prefix/imagename:tag
+        name(str): the image name
+        prefix(str): the "image prefix
+        registry(str): the registry where the image is stored
+        resourceType(str): the REST resource type, which is *image*
+        restid(str): "image-registry.openshift-image-registry.svc:5000/edge-cpd-demo/streams-base-edge-application-el7:5.3.0.0",
+        tag(str): the image tag
+    
+    Example:
+        >>> from streamsx.build import BuildService
+        >>> build_service = BuildService.of_endpoint()
+        >>> baseimages = build_service.get_base_images()
+        >>> print(type(baseimages[0]))
+        <class 'streamsx.rest_primitives.BaseImage'>
+        >>> print (baseimages[0].resourceType)
+        image
+
+        .. versionadded:: 1.15
+    """
+    def __init__(self, json_rep, rest_client):
+        super(BaseImage, self).__init__(json_rep, rest_client)

--- a/java/src/com/ibm/streamsx/rest/build/StreamsRestActions.java
+++ b/java/src/com/ibm/streamsx/rest/build/StreamsRestActions.java
@@ -4,14 +4,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-
 import java.util.List;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AUTH;
-import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.client.fluent.Response;
 import org.apache.http.entity.ContentType;
@@ -19,7 +17,6 @@ import org.apache.http.util.EntityUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-
 import com.ibm.streamsx.rest.RESTException;
 import com.ibm.streamsx.rest.internal.DirectoryZipInputStream;
 


### PR DESCRIPTION
```
from streamsx.build import BuildService

bs = BuildService.of_endpoint(verify=False)
baseImages = bs.get_base_images()
print('# images = ' + str(len(baseImages)))
for i in baseImages:
    print(type(i))
    print(i.id)
    print(i.registry)
```
