### PR TITLE
derive ant property "streamsx.topology.version" from info.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -254,11 +254,11 @@
        <ant dir="python" target="pythondoc"/>
   </target>
   
-  <target name="create_release_bundle" depends="get_name">
+  <target name="create_release_bundle">
       <tstamp/>
       <property name="release.dir" location="${release.base}" />
       <mkdir dir="${release.dir}" />
-      <property name="releasefilename" value="${release.dir}/streamsx.topology-${tkinfo.identity.version}-${DSTAMP}-${TSTAMP}.tgz"/>
+      <property name="releasefilename" value="${release.dir}/streamsx.topology-v${streamsx.topology.version}-${DSTAMP}-${TSTAMP}.tgz"/>
       <tar compression="gzip" longfile="gnu" destfile="${releasefilename}">
          <tarfileset dir="${basedir}" filemode="755" >
            <include name="**/pyversion*.sh"/>
@@ -277,14 +277,8 @@
   </target>
 
   <target name="get_name">
-    <xmlproperty file="${tk}/info.xml" prefix="tkinfo" keepRoot="no"/>
-    <script language="javascript">
-      a = project.getProperty('tkinfo.identity.version').split('.')
-      // to overwrite existing xyz property use
-      // project.setProperty('xyz' ...);
-      project.setProperty('tkinfo.identity.version', 'v' + a[0] + '.' + a[1]);
-    </script>
-    <echo message="Toolkit Name: ${tkinfo.identity.name}"/>
-    <echo message="Toolkit Version: ${tkinfo.identity.version}"/>
+    <echo message="Toolkit name: ${tkinfo.identity.name}"/>
+    <echo message="Toolkit full version: ${tkinfo.identity.version}"/>
+    <echo message="Toolkit version: ${streamsx.topology.version}"/>
   </target>
 </project>

--- a/common-build.xml
+++ b/common-build.xml
@@ -5,8 +5,6 @@
         Common definitions for streamsx.topology
     </description>
 
-  <property name="streamsx.topology.version" value="1.10"/>
-
   <dirname property="streamsx.topology" file="${ant.file.streamsx.topology.common}"/>
 
   <property environment="env"/>
@@ -17,7 +15,14 @@
   <property name="tk.opt" location="${tk}/opt"/>
   <property name="tk.lib" location="${tk}/lib"/>
   <property name="tk.doc" location="${tk}/doc"/>
-   
+
+  <!-- derive property streamsx.topology.version from info.xml of the toolkit -->
+  <xmlproperty file="${tk}/info.xml" prefix="tkinfo" keepRoot="no"/>
+  <script language="javascript">
+    a = project.getProperty('tkinfo.identity.version').split('.')
+    project.setProperty('streamsx.topology.version', a[0] + '.' + a[1]);
+  </script>
+
   <!-- Default to the junit in $HOME/.ant/lib -->
   <!-- Can be overridden with the -Djunit.jar=some_path when building -->
   <fileset  id="junit.path" dir="${user.home}/.ant/lib" includes="junit-*.jar" erroronmissingdir="no"/>


### PR DESCRIPTION
resolves #2466 .

`${streamsx.topology.version}` goes into the footer of javadoc.

This PR contains also a change for the release file name. Its name is now generated from `${streamsx.topology.version}` instead of `${tkinfo.identity.version}`. The target `get_name` is reduced to a pure echo target. No other target depends on `get_name`.