### PR TITLE
Fix topology name and namespace when one of them is an SPL reserved word

### DIFF
--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/spl/spl.py
@@ -604,20 +604,26 @@ _OperatorType.Sink.spl_template = 'PythonFunctionSink'
 _OperatorType.Filter.spl_template = 'PythonFunctionFilter'
 _OperatorType.Primitive.spl_template = 'PythonPrimitive'
 
-_SPL_KEYWORDS = {'graph', 'stream', 'public', 'composite', 'input', 'output', 'type', 'config', 'logic',
-                 'window', 'param', 'onTuple', 'onPunct', 'onProcess', 'state', 'stateful', 'mutable', 'static',
-                 'if', 'for', 'while', 'break', 'continue', 'return', 'attribute', 'function', 'operator', 'expression',
-                 'true', 'false', 'null',
-                 'boolean', 'enum',
-                 'int8', 'int16', 'int32', 'int64',
-                 'uint8', 'uint16', 'uint32', 'uint64',
-                 'float32', 'float64',
-                 'decimal32', 'decimal64', 'decimal128',
-                 'complex32', 'complex64',
-                 'timestamp', 'blob',
-                 'rstring', 'ustring', 'xml',
-                 'list', 'map', 'set', 'optional', 'tuple'
-                }
+_SPL_KEYWORDS = {'as', 'attribute', 
+                 'blob', 'boolean', 'break',
+                 'complex32', 'complex64', 'composite', 'config', 'continue',
+                 'decimal128', 'decimal32', 'decimal64', 'do',
+                 'else', 'enum', 'expression',
+                 'false', 'float32', 'float64', 'for', 'function',
+                 'graph',
+                 'if', 'in', 'input', 'int', 'int16', 'int32', 'int64', 'int8',
+                 'list', 'logic',
+                 'map', 'mutable',
+                 'namespace', 'null',
+                 'onProcess', 'onPunct', 'onTuple', 'operator', 'optional', 'output',
+                 'param', 'public',
+                 'return', 'rstring',
+                 'set', 'state', 'stateful', 'static', 'stream', 'streams',
+                 'timestamp', 'true', 'tuple', 'type',
+                 'uint16', 'uint32', 'uint64', 'uint8', 'use', 'ustring',
+                 'void',
+                 'while', 'window',
+                 'xml'}
 
 def _is_identifier(id):
     return re.match('^[a-zA-Z_][a-zA-Z_0-9]*$', id) and id not in _SPL_KEYWORDS

--- a/test/python/topology/test2_names.py
+++ b/test/python/topology/test2_names.py
@@ -41,6 +41,35 @@ class TestNames(unittest.TestCase):
      tester.contents(hw, ["Hello", "Tester"])
      tester.test(self.test_ctxtype, self.test_config)
 
+  def test_SPLReservedNames(self):
+     """ Test names and namespaces that are reserved words in SPL
+     """
+     n = 'graph'
+     ns = 'stream'
+     topo = Topology(name=n, namespace=ns)
+
+     self.assertEqual('__spl_RxjjoYWRhqU', topo.name)
+     self.assertEqual('__spl_yuDU45HWfFk', topo.namespace)
+     hw = topo.source(["Hello", "Tester"])
+     tester = Tester(topo)
+     tester.contents(hw, ["Hello", "Tester"])
+     tester.test(self.test_ctxtype, self.test_config)
+
+  def test_EmptyNamspaceTokens(self):
+     """ Test namespaces tokens that are empty after cleanup of non-word characters
+     """
+     n = 'MyNname'
+     ns = '## .streams5 . '
+     topo = Topology(name=n, namespace=ns)
+
+     self.assertEqual(n, topo.name)
+     self.assertEqual('streams5', topo.namespace)
+#     self.assertEqual('__spl_yuDU45HWfFk', topo.namespace)
+     hw = topo.source(["Hello", "Tester"])
+     tester = Tester(topo)
+     tester.contents(hw, ["Hello", "Tester"])
+     tester.test(self.test_ctxtype, self.test_config)
+
   def test_LongTopoNames(self):
      """ Test long topo names
      """

--- a/test/python/topology/test2_names.py
+++ b/test/python/topology/test2_names.py
@@ -64,7 +64,6 @@ class TestNames(unittest.TestCase):
 
      self.assertEqual(n, topo.name)
      self.assertEqual('streams5', topo.namespace)
-#     self.assertEqual('__spl_yuDU45HWfFk', topo.namespace)
      hw = topo.source(["Hello", "Tester"])
      tester = Tester(topo)
      tester.contents(hw, ["Hello", "Tester"])


### PR DESCRIPTION
resolves #2474
The resolution is, that tokens in the namespace, which are SPL keywords, are replaced by `__spl_` + _some hash_. Name and namespace are manipulated anyway, for example, non-word characters are removed, and empty tokens _should_ be dropped. _"Should be"_, because it did not work.
```
def _fix_namespace(ns):
    ns = str(ns)
    sns = ns.split('.')
    if len(sns) == 1:
        return re.sub(r'\W+', '', ns, flags=re.UNICODE)
    for i in range(0,len(sns)):
        sns[i] = re.sub(r'\W+', '', sns[i], flags=re.UNICODE)

    for i in range(len(sns), 0):     ## <<< range(len(x), 0) does NO iteration. If it did, next line raised IndexOutOfBounds
        if len(sns[i]) == 0:
            sns.pop(i)

    return '.'.join(sns)
```
The Java code generation has a test for vaild identifiers regular expression, but does not test for reserved words. As the function is used at many places, I decided, to not touch it.