### PR TITLE
add streamsx.ec.get_submission_time_value function

### DIFF
--- a/com.ibm.streamsx.topology/CHANGELOG.md
+++ b/com.ibm.streamsx.topology/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changes
 ==========
 
+## main/latest
+* [#2488](https://github.com/IBMStreams/streamsx.topology/issues/2488) execution context: Make submission time parameters available without serializing the parameter callable
+
 ## v1.15.3
 
 * [#2490](https://github.com/IBMStreams/streamsx.topology/issues/2490) Resolve issue with streamsx-streamtool caused by changes in v1.15.1

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -101,7 +101,7 @@ being invoked in a Streams application.
 
 """
 
-__all__ = ['is_active', 'shutdown', 'domain_id', 'instance_id', 'job_id', 'pe_id', 'is_standalone', 'get_application_directory', 'get_application_configuration', 'channel', 'local_channel', 'max_channels', 'local_max_channels', 'MetricKind', 'CustomMetric']
+__all__ = ['is_active', 'shutdown', 'domain_id', 'instance_id', 'job_id', 'pe_id', 'is_standalone', 'get_application_directory', 'get_application_configuration', 'get_submission_time_value', 'channel', 'local_channel', 'max_channels', 'local_max_channels', 'MetricKind', 'CustomMetric']
 
 import enum
 import pickle
@@ -136,7 +136,7 @@ def _is_supported():
     return _State._state is not None and _State._state._supported
 
 def is_active():
-    """Tests is code is active within a IBM Streams execution context.
+    """Tests if code is active within a IBM Streams execution context.
  
     Returns a true value when called from within a
     IBM Streams distributed job or standalone execution.
@@ -166,6 +166,40 @@ _SHUTDOWN = threading.Event()
 
 def _prepare_shutdown():
     _SHUTDOWN.set()
+
+def get_submission_time_value(name, type_=None):
+    """Gets the value of a submission time parameter.
+    
+    .. note::
+        Submission parameters must be created with :py:meth:`streamsx.topology.topology.Topology.create_submission_parameter`
+        at topology declaration time before they can be accessed with this function.
+    
+    .. note::
+        Submission time parameters, which are defined within other toolkits that are used by this topology 
+        or created with :py:class:`streamsx.spl.op.Expression` in this topology are not accessible with this function.
+        
+    Arguments:
+        name(str): The name of the submission time parameter
+        type_: Type of parameter value. Supported values are ``str``, ``int``, ``float`` and ``bool``.
+            ``None`` assumes that the type of the parameter is ``str`` and needs no conversion. The type must be
+            the same as used in :py:meth:`streamsx.topology.topology.Topology.create_submission_parameter`
+            or as deduced from the parameters default value.
+    Returns:
+        The value of the submission time parameter. The return type is either ``str`` or the given ``type_``. 
+    Raises:
+        ValueError: The submission time parameter with the given name does not exist.
+
+    .. versionadded:: 1.16
+    """
+    _check()
+    if name not in _SUBMIT_PARAMS:
+        raise ValueError("Submission parameter {} not defined. Added to the topology with 'create_submission_parameter(name, type_)'?".format(name))
+    v = _SUBMIT_PARAMS[name]
+    if type_ is None:
+        return v
+    if type_ is bool:
+        return not v == 'false'
+    return type_(v)
 
 def shutdown():
     """Return the processing element (PE) shutdown event.

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/ec.py
@@ -189,7 +189,7 @@ def get_submission_time_value(name, type_=None):
     Raises:
         ValueError: The submission time parameter with the given name does not exist.
 
-    .. versionadded:: 1.16
+    .. versionadded:: 1.15
     """
     _check()
     if name not in _SUBMIT_PARAMS:

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/topology.py
@@ -954,6 +954,7 @@ class Topology(object):
             type_: Type of parameter value when default is not set. Supported values are `str`, `int`, `float` and `bool`.
 
         .. versionadded:: 1.9
+        .. seealso:: :py:meth:`streamsx.ec.get_submission_time_value`
         """
         
         if name in self._submission_parameters:

--- a/python/sphinx/source/restrictions.rst
+++ b/python/sphinx/source/restrictions.rst
@@ -24,3 +24,5 @@ Restrictions and known bugs
 * Python Composites (derived from :py:class:`streamsx.topology.composite.Composite`) can have only one input port.
 * No support to process window markers or final marker (end of stream) in Python Callables like in SPL operators
 * No hook for drain processing in consistent region for Python Callables
+* Submission time parameters, which are defined in SPL composites of other toolkits, or created by using
+  `streamsx.spl.op.Expression` in the topology, cannot be accessed at runtime with `streamsx.ec.get_submission_time_value(name)`.

--- a/test/python/topology/test2_submission_params.py
+++ b/test/python/topology/test2_submission_params.py
@@ -17,6 +17,8 @@ from streamsx.topology.context import ConfigParams
 import streamsx.spl.op as op
 
 
+#def add_submsission_param
+
 class AddIt(object):
     def __init__(self, sp):
         self.sp = sp
@@ -26,6 +28,41 @@ class AddIt(object):
         pass
     def __call__(self, t):
         return str(t) + '-' + self.spv
+
+from streamsx.ec import get_submission_time_value
+
+# A wrapper that imports streamsx.ec so that the function can be used in a lambda expression at runtime
+# use in a lambda expression in a filter
+def wrap_get_int_submission_val(name):
+#    from streamsx.ec import get_submission_time_value
+    return get_submission_time_value(name, int)
+
+# use as function callable in a filter
+def is_dividable_by_modulo_submission_param(tuple):
+    #from streamsx.ec import get_submission_time_value
+    # assuming the tuple is an int python object
+    return tuple % get_submission_time_value(name='modulo', type_=int) == 0
+
+# use as function callable in a map
+def greet(tuple):
+    #from streamsx.ec import get_submission_time_value
+    # assume tuple is a string
+    return tuple.format(get_submission_time_value('p1'))
+
+# use as callable class in a filter
+# test if a number can be or cannot be divided by a modulo.
+# Which test is performed, is controlled by a submission time parameter
+class DivideTester(object):
+    def __init__(self, subm_param_name, modulo):
+        self.spn = subm_param_name
+        self.modulo = modulo
+    def __enter__(self):
+        self.spv = get_submission_time_value(self.spn, bool)
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+    def __call__(self, t):
+        is_even = t % self.modulo == 0
+        return is_even == self.spv
 
 class TestSubmissionParams(unittest.TestCase):
     """ Test submission params (standalone).
@@ -158,6 +195,65 @@ class TestSubmissionParams(unittest.TestCase):
         tester = Tester(topo)
         tester.contents(s,[0,15,30,45,60]*3, ordered=False)
         tester.test(self.test_ctxtype, self.test_config)
+
+    def test_int_parallel_with_ec(self):
+        topo = Topology()
+        sp_w1 = topo.create_submission_parameter('w1', type_=int)
+        sp_w2 = topo.create_submission_parameter('modulo', type_=int)
+        
+        s = topo.source(range(67)).set_parallel(sp_w1)
+        s = s.filter(lambda v : v % wrap_get_int_submission_val('w1') == 0)
+        s = s.filter(lambda v : v % get_submission_time_value('w1', int) == 0)
+        s = s.end_parallel()
+        s = s.parallel(width=sp_w2)
+        s = s.filter(is_dividable_by_modulo_submission_param)
+        s = s.end_parallel()
+
+        jc = JobConfig()
+        jc.submission_parameters['w1'] = 3
+        jc.submission_parameters['modulo'] = 5
+        jc.add(self.test_config)
+     
+        tester = Tester(topo)
+        tester.contents(s,[0,15,30,45,60]*3, ordered=False)
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_no_type_with_ec(self):
+
+        topo = Topology()
+        topo.create_submission_parameter('p1')
+        
+        s = topo.source(['Hello {}!'])
+        s = s.map(greet)
+
+        jc = JobConfig()
+        jc.submission_parameters['p1'] = 'Rolef'
+        jc.add(self.test_config)
+     
+        tester = Tester(topo)
+        tester.contents(s,['Hello Rolef!'])
+        tester.test(self.test_ctxtype, self.test_config)
+
+    def test_bool_default_with_ec(self):
+
+        topo = Topology()
+        topo.create_submission_parameter('pFalse', False, bool)
+        topo.create_submission_parameter('pTrue', False, bool)
+        
+        s = topo.source([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])
+        # passes through all numbers that cannot be divided by 2, when pFalse is false
+        o = s.filter(DivideTester('pFalse', 2))
+        # passes through all numbers that can be divided by 3, when pTrue is true
+        s = o.filter(DivideTester('pTrue', 3))
+        jc = JobConfig()
+        #jc.submission_parameters['pFalse'] = False # leave the default
+        jc.submission_parameters['pTrue'] = True
+        jc.add(self.test_config)
+     
+        tester = Tester(topo)
+        tester.contents(s,[3, 9, 15]) # all odd multiples of 3
+        tester.test(self.test_ctxtype, self.test_config)
+
 
 class TestDistributedSubmissionParams(TestSubmissionParams):
     """ Test submission params (distributed).

--- a/test/python/topology/test2_submission_params.py
+++ b/test/python/topology/test2_submission_params.py
@@ -17,8 +17,6 @@ from streamsx.topology.context import ConfigParams
 import streamsx.spl.op as op
 
 
-#def add_submsission_param
-
 class AddIt(object):
     def __init__(self, sp):
         self.sp = sp


### PR DESCRIPTION
resolves #2488 

This PR adds the new function `get_submission_time_value(name, type_)` to the `streamsx.ec` module, which allows to use submission time values
- in _function_ callables 
- without the necessity to pass submission time parameter callables around other callables.

This PR is a candidate for a new mod release (1.16)