### PR TITLE
Documentation: Fix typo in example code with ConsistentRegionConfig

### DIFF
--- a/com.ibm.streamsx.topology/CHANGELOG.md
+++ b/com.ibm.streamsx.topology/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changes
 ==========
 
+## branch latest
+* [#2639](https://github.com/IBMStreams/streamsx.topology/issues/2639) Documentation: Typo in ConsistentRegionConfig example
+
 ## v2.0.0
 * [#2627](https://github.com/IBMStreams/streamsx.topology/issues/2627) `streamsx-streamtool lstoolkits` should show the toolkit-ID
 * [#2609](https://github.com/IBMStreams/streamsx.topology/issues/2609) CPD3.5: "invalid platform token" error

--- a/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/state.py
+++ b/com.ibm.streamsx.topology/opt/python/packages/streamsx/topology/state.py
@@ -98,13 +98,15 @@ class ConsistentRegionConfig(object):
 
     Example::
 
+        from streamsx.topology.state import ConsistentRegionConfig
         # set source to be the start of an operator driven consistent region
-        # with a drain timeout of five seconds and a reset timeout of twenty seconds.
-        source.set_consistent(ConsistentRegionConfig.operatorDriven(drain_timeout=5, reset_timeout=20))
+        # with a drain timeout of sixty seconds and a reset timeout of twenty seconds.
+        source.set_consistent(ConsistentRegionConfig.operator_driven(drain_timeout=60, reset_timeout=20))
 
     .. seealso:: :py:meth:`~streamsx.topology.topology.Stream.set_consistent`
 
     .. versionadded:: 1.11
+
     """
     
     _DEFAULT_DRAIN=180
@@ -114,6 +116,7 @@ class ConsistentRegionConfig(object):
     class Trigger(Enum):
         """
         Defines how the drain-checkpoint cycle of a consistent region is triggered.
+
         .. versionadded:: 1.11
         """
         OPERATOR_DRIVEN = 1


### PR DESCRIPTION
operator**D**riven replaced by `operator_driven`

resolves #2639